### PR TITLE
Bugfix: update the crypto_wallet_util dependency package of bc_ur_dart

### DIFF
--- a/packages/bc_ur_dart/CHANGELOG.md
+++ b/packages/bc_ur_dart/CHANGELOG.md
@@ -66,3 +66,7 @@
 
 - Fix: Fixed address and signHashType parse error of GsplItem.
 - Fix: Refactor some code about gspl
+
+## 0.1.18
+
+- Update: Update crypto_wallet_util pubspec version.

--- a/packages/bc_ur_dart/pubspec.yaml
+++ b/packages/bc_ur_dart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: bc_ur_dart
 description: A dart plugin for Uniform Resources(URs) decode/encode. URs are URI-encoded CBOR structures developed by Blockchain Commons.
-version: 0.1.17
+version: 0.1.18
 homepage: https://github.com/fxwalletOfficial/fx-wallet-packages/tree/main/packages/bc_ur_dart
 
 environment:

--- a/packages/bc_ur_dart/pubspec.yaml
+++ b/packages/bc_ur_dart/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   cbor: ^6.3.3
   convert: ^3.1.1
   crypto: ^3.0.3
-  crypto_wallet_util: ^1.1.7
+  crypto_wallet_util: ^1.1.8
   uuid: ^4.4.0
   web3dart: ^2.7.3
   xrandom: ^0.7.2

--- a/packages/crypto_wallet_util/CHANGELOG.md
+++ b/packages/crypto_wallet_util/CHANGELOG.md
@@ -165,7 +165,7 @@
 
 - fix psbt signer error.
 
-## [1.1.8] - 2025-01-XX
+## [1.1.8] - 2025-07-28
 ### Update
 
 - Add gspl signer.

--- a/packages/crypto_wallet_util/lib/src/wallets/bch.dart
+++ b/packages/crypto_wallet_util/lib/src/wallets/bch.dart
@@ -56,7 +56,6 @@ class BchCoin extends WalletType {
 
   @override
   String sign(String message) {
-    print('gspl bch sign message: $message');
     final ecPrivateKey = ECPrivate.fromBytes(privateKey);
     return ecPrivateKey.signInput(message.toUint8List(), sigHash: sighashType).toHex();
   }

--- a/packages/crypto_wallet_util/lib/src/wallets/ltc.dart
+++ b/packages/crypto_wallet_util/lib/src/wallets/ltc.dart
@@ -31,7 +31,7 @@ class LtcCoin extends WalletType {
 
   @override
   Future<Uint8List> mnemonicToPrivateKey(String mnemonic) async {
-    return HDWallet.bip32DerivePath(mnemonic, setting!.bip44Path);
+    return HDWallet.bip32DerivePath(mnemonic, setting.bip44Path);
   }
 
   @override

--- a/packages/crypto_wallet_util/test/doge_test.dart
+++ b/packages/crypto_wallet_util/test/doge_test.dart
@@ -1,9 +1,5 @@
-import 'dart:convert';
-import 'dart:io';
-
-import 'package:test/test.dart';
-
 import 'package:crypto_wallet_util/crypto_utils.dart';
+import 'package:test/test.dart';
 
 void main() async {
   const String mnemonic =


### PR DESCRIPTION
## Changes Made
This merge request update the crypto_wallet_util dependency package version of bc_ur_dart from 1.1.7 to 1.1.8 to be compatible with the new type definition of some data structure in crypto_wallet_util package. 