### PR TITLE
fix: web3dart only used in tests

### DIFF
--- a/packages/bc_ur_dart/pubspec.yaml
+++ b/packages/bc_ur_dart/pubspec.yaml
@@ -13,9 +13,9 @@ dependencies:
   crypto: ^3.0.3
   crypto_wallet_util: ^1.1.10
   uuid: ^4.4.0
-  web3dart: ^2.7.3
   xrandom: ^0.7.2
 
 dev_dependencies:
+  web3dart: ^2.7.3
   lints: ^3.0.0
   test: ^1.24.0


### PR DESCRIPTION
## Description
The dependency `web3dart` is only used in test for the `bc_ur_dart` package. 
Removing this fixes version incompatibility with other packages using `bc_ur_dart`

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
Running the provided tests
