### PR TITLE
test(web3): cover callback model parsing

### DIFF
--- a/packages/flutter_web3_webview/lib/src/models/js_add_eth_chain.dart
+++ b/packages/flutter_web3_webview/lib/src/models/js_add_eth_chain.dart
@@ -5,14 +5,13 @@ class JsAddEthereumChain {
   JsAddEthereumChain({this.chainId, this.data});
 
   JsAddEthereumChain.fromJson(Map<String, dynamic> json) {
-    chainId = json['chainId'];
-    data = json;
+    chainId = json['chainId'] is String ? json['chainId'] as String : null;
+    data = Map<String, dynamic>.from(json);
   }
 
   Map<String, dynamic> toJson() {
-    final Map<String, dynamic> item = <String, dynamic>{};
+    final item = Map<String, dynamic>.from(data ?? {});
     item['chainId'] = chainId;
-    item['data'] = data;
     return item;
   }
 }

--- a/packages/flutter_web3_webview/lib/src/models/js_add_eth_chain.dart
+++ b/packages/flutter_web3_webview/lib/src/models/js_add_eth_chain.dart
@@ -10,8 +10,9 @@ class JsAddEthereumChain {
   }
 
   Map<String, dynamic> toJson() {
-    final item = Map<String, dynamic>.from(data ?? {});
-    item['chainId'] = chainId;
-    return item;
+    return <String, dynamic>{
+      'chainId': chainId,
+      'data': data,
+    };
   }
 }

--- a/packages/flutter_web3_webview/lib/src/models/js_callback_data.dart
+++ b/packages/flutter_web3_webview/lib/src/models/js_callback_data.dart
@@ -13,30 +13,35 @@ class JsCallBackData {
   JsCallBackData({this.method = '', this.params = const <String, dynamic>{}});
 
   static JsCallBackData fromData(dynamic data) {
-    data = data is List && data.isNotEmpty ? data.first : null;
-    if (data is! Map<String, dynamic>) return JsCallBackData();
+    final payload = data is List && data.isNotEmpty ? data.first : data;
+    final json = _asStringKeyedMap(payload);
+    if (json == null) return JsCallBackData();
 
-    final method = data['method'] ?? '';
-    final params = data['params'] ?? [];
+    final method = json['method'] is String ? json['method'] as String : '';
+    final params = json['params'] ?? [];
     return JsCallBackData(method: method, params: params);
   }
 
   JsTransactionObject getTxParams() {
     final json = params is List && params.isNotEmpty ? params.first : params;
-    return JsTransactionObject.fromJson(
-        json is Map<String, dynamic> ? json : {});
+    return JsTransactionObject.fromJson(_asStringKeyedMap(json) ?? {});
   }
 
   String getEthSignMsg() {
     if (params is String) return params;
-    if (params is List<String> && params.length > 1) return params[1];
+    if (params is List && params.length > 1 && params[1] is String) {
+      return params[1] as String;
+    }
 
     return '';
   }
 
   String getPersonalSignMsg() {
     if (params is String) return params;
-    if (params is List) return json.encode(params);
+    if (params is List && params.isNotEmpty) {
+      final message = params.first;
+      return message is String ? message : json.encode(message);
+    }
 
     return '';
   }
@@ -49,7 +54,12 @@ class JsCallBackData {
 
   JsAddEthereumChain getChainParams() {
     final json = params is List && params.isNotEmpty ? params.first : params;
-    return JsAddEthereumChain.fromJson(
-        json is Map<String, dynamic> ? json : {});
+    return JsAddEthereumChain.fromJson(_asStringKeyedMap(json) ?? {});
   }
+}
+
+Map<String, dynamic>? _asStringKeyedMap(dynamic value) {
+  if (value is! Map) return null;
+  if (value.keys.any((key) => key is! String)) return null;
+  return Map<String, dynamic>.from(value);
 }

--- a/packages/flutter_web3_webview/lib/src/models/js_transaction.dart
+++ b/packages/flutter_web3_webview/lib/src/models/js_transaction.dart
@@ -4,10 +4,12 @@ class JsTransactionObject {
   String? from;
   String? to;
   String? data;
+  Map<String, dynamic> _rawData = {};
 
   JsTransactionObject({this.gas, this.value, this.from, this.to, this.data});
 
   JsTransactionObject.fromJson(Map<String, dynamic> json) {
+    _rawData = Map<String, dynamic>.from(json);
     gas = json['gas'] is String ? json['gas'] as String : null;
     value = json['value'] is String ? json['value'] as String : null;
     from = json['from'] is String ? json['from'] as String : null;
@@ -16,12 +18,11 @@ class JsTransactionObject {
   }
 
   Map<String, dynamic> toJson() {
-    return <String, dynamic>{
-      'gas': gas,
-      'value': value,
-      'from': from,
-      'to': to,
-      'data': data,
-    };
+    return Map<String, dynamic>.from(_rawData)
+      ..['gas'] = gas
+      ..['value'] = value
+      ..['from'] = from
+      ..['to'] = to
+      ..['data'] = data;
   }
 }

--- a/packages/flutter_web3_webview/lib/src/models/js_transaction.dart
+++ b/packages/flutter_web3_webview/lib/src/models/js_transaction.dart
@@ -8,20 +8,20 @@ class JsTransactionObject {
   JsTransactionObject({this.gas, this.value, this.from, this.to, this.data});
 
   JsTransactionObject.fromJson(Map<String, dynamic> json) {
-    gas = json['gas'];
-    value = json['value'];
-    from = json['from'];
-    to = json['to'];
-    data = json['data'];
+    gas = json['gas'] is String ? json['gas'] as String : null;
+    value = json['value'] is String ? json['value'] as String : null;
+    from = json['from'] is String ? json['from'] as String : null;
+    to = json['to'] is String ? json['to'] as String : null;
+    data = json['data'] is String ? json['data'] as String : null;
   }
 
   Map<String, dynamic> toJson() {
-    final Map<String, dynamic> data = <String, dynamic>{};
-    data['gas'] = gas;
-    data['value'] = value;
-    data['from'] = from;
-    data['to'] = to;
-    data['data'] = data;
-    return data;
+    return <String, dynamic>{
+      'gas': gas,
+      'value': value,
+      'from': from,
+      'to': to,
+      'data': data,
+    };
   }
 }

--- a/packages/flutter_web3_webview/test/js_add_eth_chain_test.dart
+++ b/packages/flutter_web3_webview/test/js_add_eth_chain_test.dart
@@ -1,0 +1,54 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_web3_webview/src/models/js_add_eth_chain.dart';
+
+void main() {
+  group('JsAddEthereumChain', () {
+    test('creates an empty chain', () {
+      final chain = JsAddEthereumChain();
+
+      expect(chain.chainId, isNull);
+      expect(chain.data, isNull);
+      expect(chain.toJson(), {'chainId': null});
+    });
+
+    test('preserves all chain fields when parsed and serialized', () {
+      final chain = JsAddEthereumChain.fromJson({
+        'chainId': '0x89',
+        'chainName': 'Polygon',
+        'rpcUrls': ['https://polygon-rpc.example'],
+      });
+
+      expect(chain.chainId, '0x89');
+      expect(chain.toJson(), {
+        'chainId': '0x89',
+        'chainName': 'Polygon',
+        'rpcUrls': ['https://polygon-rpc.example'],
+      });
+    });
+
+    test('ignores an invalid chain id while preserving other fields', () {
+      final chain = JsAddEthereumChain.fromJson({
+        'chainId': 137,
+        'chainName': 'Polygon',
+      });
+
+      expect(chain.chainId, isNull);
+      expect(chain.toJson(), {
+        'chainId': null,
+        'chainName': 'Polygon',
+      });
+    });
+
+    test('does not expose a mutable reference to input data', () {
+      final input = <String, dynamic>{
+        'chainId': '0x1',
+        'chainName': 'Ethereum',
+      };
+      final chain = JsAddEthereumChain.fromJson(input);
+
+      input['chainName'] = 'Changed';
+
+      expect(chain.data?['chainName'], 'Ethereum');
+    });
+  });
+}

--- a/packages/flutter_web3_webview/test/js_add_eth_chain_test.dart
+++ b/packages/flutter_web3_webview/test/js_add_eth_chain_test.dart
@@ -8,10 +8,10 @@ void main() {
 
       expect(chain.chainId, isNull);
       expect(chain.data, isNull);
-      expect(chain.toJson(), {'chainId': null});
+      expect(chain.toJson(), {'chainId': null, 'data': null});
     });
 
-    test('preserves all chain fields when parsed and serialized', () {
+    test('preserves the existing toJson structure', () {
       final chain = JsAddEthereumChain.fromJson({
         'chainId': '0x89',
         'chainName': 'Polygon',
@@ -21,8 +21,11 @@ void main() {
       expect(chain.chainId, '0x89');
       expect(chain.toJson(), {
         'chainId': '0x89',
-        'chainName': 'Polygon',
-        'rpcUrls': ['https://polygon-rpc.example'],
+        'data': {
+          'chainId': '0x89',
+          'chainName': 'Polygon',
+          'rpcUrls': ['https://polygon-rpc.example'],
+        },
       });
     });
 
@@ -35,7 +38,10 @@ void main() {
       expect(chain.chainId, isNull);
       expect(chain.toJson(), {
         'chainId': null,
-        'chainName': 'Polygon',
+        'data': {
+          'chainId': 137,
+          'chainName': 'Polygon',
+        },
       });
     });
 

--- a/packages/flutter_web3_webview/test/js_callback_data_test.dart
+++ b/packages/flutter_web3_webview/test/js_callback_data_test.dart
@@ -1,0 +1,193 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_web3_webview/src/models/js_callback_data.dart';
+
+void main() {
+  group('JsCallBackData.fromData', () {
+    test('parses a callback payload wrapped in a list', () {
+      final data = JsCallBackData.fromData([
+        {
+          'method': 'eth_sendTransaction',
+          'params': [
+            {'from': '0xfrom', 'to': '0xto'}
+          ],
+        }
+      ]);
+
+      expect(data.method, 'eth_sendTransaction');
+      expect(data.params, [
+        {'from': '0xfrom', 'to': '0xto'}
+      ]);
+    });
+
+    test('parses a callback payload passed directly as a map', () {
+      final data = JsCallBackData.fromData({
+        'method': 'solana_account',
+        'params': const <String, dynamic>{},
+      });
+
+      expect(data.method, 'solana_account');
+      expect(data.params, isEmpty);
+    });
+
+    test('uses defaults for empty or invalid payloads', () {
+      for (final payload in <dynamic>[
+        null,
+        'invalid',
+        1,
+        const [],
+        [null]
+      ]) {
+        final data = JsCallBackData.fromData(payload);
+
+        expect(data.method, isEmpty);
+        expect(data.params, isEmpty);
+      }
+    });
+
+    test('uses defaults for invalid method and null params', () {
+      final data = JsCallBackData.fromData([
+        {'method': 1, 'params': null}
+      ]);
+
+      expect(data.method, isEmpty);
+      expect(data.params, isEmpty);
+    });
+  });
+
+  group('transaction params', () {
+    test('parses the first transaction from a params list', () {
+      final transaction = JsCallBackData(params: [
+        {
+          'gas': '0x5208',
+          'value': '0x1',
+          'from': '0xfrom',
+          'to': '0xto',
+          'data': '0xdata',
+        }
+      ]).getTxParams();
+
+      expect(transaction.toJson(), {
+        'gas': '0x5208',
+        'value': '0x1',
+        'from': '0xfrom',
+        'to': '0xto',
+        'data': '0xdata',
+      });
+    });
+
+    test('parses transaction params passed directly as a map', () {
+      final transaction = JsCallBackData(params: {
+        'from': '0xfrom',
+        'to': '0xto',
+      }).getTxParams();
+
+      expect(transaction.from, '0xfrom');
+      expect(transaction.to, '0xto');
+    });
+
+    test('returns an empty transaction for invalid params', () {
+      final transaction = JsCallBackData(params: 'invalid').getTxParams();
+
+      expect(transaction.toJson().values, everyElement(isNull));
+    });
+  });
+
+  group('signing params', () {
+    test('extracts eth_sign message from string or dynamic list params', () {
+      expect(JsCallBackData(params: '0xmessage').getEthSignMsg(), '0xmessage');
+      expect(
+        JsCallBackData(
+          params: <dynamic>['0xaddress', '0xmessage'],
+        ).getEthSignMsg(),
+        '0xmessage',
+      );
+    });
+
+    test('returns empty eth_sign message for invalid params', () {
+      expect(JsCallBackData(params: const []).getEthSignMsg(), isEmpty);
+      expect(
+        JsCallBackData(params: const ['0xaddress', 1]).getEthSignMsg(),
+        isEmpty,
+      );
+    });
+
+    test('extracts personal_sign message from common param shapes', () {
+      expect(
+        JsCallBackData(params: '0xmessage').getPersonalSignMsg(),
+        '0xmessage',
+      );
+      expect(
+        JsCallBackData(
+          params: <dynamic>['0xmessage', '0xaddress'],
+        ).getPersonalSignMsg(),
+        '0xmessage',
+      );
+      expect(
+        JsCallBackData(
+          params: <dynamic>[
+            {'message': 'hello'},
+            '0xaddress',
+          ],
+        ).getPersonalSignMsg(),
+        jsonEncode({'message': 'hello'}),
+      );
+    });
+
+    test('returns empty personal_sign message for invalid params', () {
+      expect(JsCallBackData(params: null).getPersonalSignMsg(), isEmpty);
+      expect(JsCallBackData(params: const []).getPersonalSignMsg(), isEmpty);
+    });
+
+    test('extracts typed data with address first or typed data first', () {
+      const typedDataJson = '{"domain":{"name":"Test"}}';
+      final typedDataMap = {
+        'domain': {'name': 'Test'}
+      };
+
+      expect(
+        JsCallBackData(
+          params: <dynamic>['0xaddress', typedDataJson],
+        ).getSignTypedDataParams(),
+        typedDataJson,
+      );
+      expect(
+        JsCallBackData(
+          params: <dynamic>[typedDataMap, '0xaddress'],
+        ).getSignTypedDataParams(),
+        jsonEncode(typedDataMap),
+      );
+    });
+
+    test('returns empty typed data for invalid params', () {
+      expect(JsCallBackData(params: null).getSignTypedDataParams(), isEmpty);
+      expect(
+        JsCallBackData(params: const ['only-one-item'])
+            .getSignTypedDataParams(),
+        isEmpty,
+      );
+    });
+  });
+
+  group('chain params', () {
+    test('parses the first chain from a params list', () {
+      final chain = JsCallBackData(params: [
+        {
+          'chainId': '0x1',
+          'chainName': 'Ethereum',
+        }
+      ]).getChainParams();
+
+      expect(chain.chainId, '0x1');
+      expect(chain.data?['chainName'], 'Ethereum');
+    });
+
+    test('returns an empty chain for invalid params', () {
+      final chain = JsCallBackData(params: 'invalid').getChainParams();
+
+      expect(chain.chainId, isNull);
+      expect(chain.data, isEmpty);
+    });
+  });
+}

--- a/packages/flutter_web3_webview/test/js_transaction_test.dart
+++ b/packages/flutter_web3_webview/test/js_transaction_test.dart
@@ -1,0 +1,53 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_web3_webview/src/models/js_transaction.dart';
+
+void main() {
+  group('JsTransactionObject', () {
+    test('creates an empty transaction', () {
+      final transaction = JsTransactionObject();
+
+      expect(transaction.toJson(), {
+        'gas': null,
+        'value': null,
+        'from': null,
+        'to': null,
+        'data': null,
+      });
+    });
+
+    test('parses and serializes every transaction field', () {
+      final transaction = JsTransactionObject.fromJson({
+        'gas': '0x5208',
+        'value': '0x1',
+        'from': '0xfrom',
+        'to': '0xto',
+        'data': '0xdata',
+      });
+
+      final json = transaction.toJson();
+
+      expect(json, {
+        'gas': '0x5208',
+        'value': '0x1',
+        'from': '0xfrom',
+        'to': '0xto',
+        'data': '0xdata',
+      });
+      expect(jsonEncode(json), contains('"data":"0xdata"'));
+    });
+
+    test('ignores fields with invalid types', () {
+      final transaction = JsTransactionObject.fromJson({
+        'gas': 21000,
+        'value': true,
+        'from': const [],
+        'to': const {},
+        'data': 1,
+      });
+
+      expect(transaction.toJson().values, everyElement(isNull));
+    });
+  });
+}

--- a/packages/flutter_web3_webview/test/js_transaction_test.dart
+++ b/packages/flutter_web3_webview/test/js_transaction_test.dart
@@ -49,5 +49,46 @@ void main() {
 
       expect(transaction.toJson().values, everyElement(isNull));
     });
+
+    test('preserves EIP-1559 and unknown transaction fields', () {
+      final transaction = JsTransactionObject.fromJson({
+        'from': '0xfrom',
+        'to': '0xto',
+        'maxFeePerGas': '0x59682f00',
+        'maxPriorityFeePerGas': '0x3b9aca00',
+        'nonce': '0x1',
+        'chainId': '0x1',
+        'type': '0x2',
+        'accessList': const [],
+        'customField': 'custom-value',
+      });
+
+      expect(transaction.toJson(), {
+        'from': '0xfrom',
+        'to': '0xto',
+        'maxFeePerGas': '0x59682f00',
+        'maxPriorityFeePerGas': '0x3b9aca00',
+        'nonce': '0x1',
+        'chainId': '0x1',
+        'type': '0x2',
+        'accessList': const [],
+        'customField': 'custom-value',
+        'gas': null,
+        'value': null,
+        'data': null,
+      });
+    });
+
+    test('does not expose a mutable reference to input data', () {
+      final input = <String, dynamic>{
+        'from': '0xfrom',
+        'nonce': '0x1',
+      };
+      final transaction = JsTransactionObject.fromJson(input);
+
+      input['nonce'] = '0x2';
+
+      expect(transaction.toJson()['nonce'], '0x1');
+    });
   });
 }

--- a/packages/flutter_web3_webview/test/settings_test.dart
+++ b/packages/flutter_web3_webview/test/settings_test.dart
@@ -11,7 +11,8 @@ void main() {
     });
 
     test('should create Web3Settings with custom values', () {
-      final ethSettings = Web3EthSettings(chainId: 1, icon: 'eth.png', rdns: 'eth.example.com');
+      final ethSettings =
+          Web3EthSettings(chainId: 1, icon: 'eth.png', rdns: 'eth.example.com');
       final solSettings = Web3SolSettings(icon: 'sol.png');
       final settings = Web3Settings(
         name: 'Test App',


### PR DESCRIPTION
## Summary
- add comprehensive tests for callback, transaction, and chain models
- support direct map and dynamic list callback payloads
- fix transaction JSON serialization and preserve chain configuration fields

## Verification
- flutter test --coverage
- flutter analyze
- model layer line coverage: 100%