### PR TITLE
test(web3): isolate request dispatch queue

### DIFF
--- a/packages/flutter_web3_webview/CHANGELOG.md
+++ b/packages/flutter_web3_webview/CHANGELOG.md
@@ -3,6 +3,7 @@
 * SECURITY: Deny WebView permission requests by default unless the caller provides an explicit permission handler.
 * FIX: JSON-encode wallet metadata before injecting it into JavaScript.
 * FIX: Share provider asset loading across concurrent initialization calls.
+* FIX: Serialize user-confirmed Web3 requests and safely encode chain change events.
 
 ## [0.1.0]
 

--- a/packages/flutter_web3_webview/CHANGELOG.md
+++ b/packages/flutter_web3_webview/CHANGELOG.md
@@ -3,7 +3,7 @@
 * SECURITY: Deny WebView permission requests by default unless the caller provides an explicit permission handler.
 * FIX: JSON-encode wallet metadata before injecting it into JavaScript.
 * FIX: Share provider asset loading across concurrent initialization calls.
-* FIX: Serialize user-confirmed Web3 requests and safely encode chain change events.
+* FIX: Serialize user-confirmed EVM and Solana requests and safely encode chain change events.
 
 ## [0.1.0]
 

--- a/packages/flutter_web3_webview/lib/src/utils/request_dispatcher.dart
+++ b/packages/flutter_web3_webview/lib/src/utils/request_dispatcher.dart
@@ -37,7 +37,6 @@ class Web3RequestDispatcher {
   bool isImmediate(String method) => const {
         'eth_accounts',
         'eth_chainId',
-        'solana_account',
       }.contains(method);
 
   Future<dynamic> dispatch(JsCallBackData data) {

--- a/packages/flutter_web3_webview/lib/src/utils/request_dispatcher.dart
+++ b/packages/flutter_web3_webview/lib/src/utils/request_dispatcher.dart
@@ -1,0 +1,147 @@
+import 'dart:convert';
+
+import 'package:flutter_web3_webview/src/models/js_callback_data.dart';
+
+typedef EvaluateJavascript = Future<dynamic> Function(String source);
+
+class Web3RequestDispatcher {
+  final Future<List<String>> Function()? ethAccounts;
+  final Future<int> Function()? ethChainId;
+  final Future<String> Function(JsTransactionObject data)? ethSendTransaction;
+  final Future<String> Function(String data)? ethSign;
+  final Future<String> Function(String data)? ethPersonalSign;
+  final Future<String> Function(String data)? ethSignTypedData;
+  final Future<bool> Function(JsAddEthereumChain data)?
+      walletSwitchEthereumChain;
+  final Future<String> Function()? solAccount;
+  final Future<String> Function(JsCallBackData data)? solSignTransaction;
+  final Future<String> Function(JsCallBackData data)? solSignMessage;
+  final Future<dynamic> Function(JsCallBackData data)? onDefaultCallback;
+  final EvaluateJavascript evaluateJavascript;
+
+  Web3RequestDispatcher({
+    this.ethAccounts,
+    this.ethChainId,
+    this.ethSendTransaction,
+    this.ethSign,
+    this.ethPersonalSign,
+    this.ethSignTypedData,
+    this.walletSwitchEthereumChain,
+    this.solAccount,
+    this.solSignTransaction,
+    this.solSignMessage,
+    this.onDefaultCallback,
+    required this.evaluateJavascript,
+  });
+
+  bool isImmediate(String method) => const {
+        'eth_accounts',
+        'eth_chainId',
+        'solana_account',
+      }.contains(method);
+
+  Future<dynamic> dispatch(JsCallBackData data) {
+    switch (data.method) {
+      case 'eth_accounts':
+      case 'eth_requestAccounts':
+        return _ethAccounts();
+      case 'eth_chainId':
+        return _ethChainId();
+      case 'wallet_switchEthereumChain':
+      case 'wallet_addEthereumChain':
+        return _walletSwitchEthereumChain(data);
+      case 'solana_account':
+        return _solAccount();
+      case 'eth_sendTransaction':
+        return _ethSendTransaction(data);
+      case 'eth_sign':
+        return _ethSign(data);
+      case 'personal_sign':
+        return _personalSign(data);
+      case 'eth_signTypedData':
+      case 'eth_signTypedData_v3':
+      case 'eth_signTypedData_v4':
+        return _ethSignTypedData(data);
+      case 'solana_signTransaction':
+        return _solSignTransaction(data);
+      case 'solana_signMessage':
+        return _solSignMessage(data);
+      default:
+        return _defaultCallback(data);
+    }
+  }
+
+  Future<List<String>> _ethAccounts() {
+    final callback = ethAccounts;
+    if (callback == null) return Future.error(Exception('Invalid wallet'));
+    return callback();
+  }
+
+  Future<String> _ethChainId() async {
+    final callback = ethChainId;
+    if (callback == null) throw Exception('Invalid wallet');
+    final id = await callback();
+    return '0x${id.toRadixString(16)}';
+  }
+
+  Future<String> _ethSendTransaction(JsCallBackData data) {
+    final callback = ethSendTransaction;
+    if (callback == null) return Future.error(Exception('Invalid wallet'));
+    return callback(data.getTxParams());
+  }
+
+  Future<String> _ethSign(JsCallBackData data) {
+    final callback = ethSign;
+    if (callback == null) return Future.error(Exception('Invalid wallet'));
+    return callback(data.getEthSignMsg());
+  }
+
+  Future<String> _personalSign(JsCallBackData data) {
+    final callback = ethPersonalSign;
+    if (callback == null) return Future.error(Exception('Invalid wallet'));
+    return callback(data.getPersonalSignMsg());
+  }
+
+  Future<String> _ethSignTypedData(JsCallBackData data) {
+    final callback = ethSignTypedData;
+    if (callback == null) return Future.error(Exception('Invalid wallet'));
+    return callback(data.getSignTypedDataParams());
+  }
+
+  Future<String> _walletSwitchEthereumChain(JsCallBackData data) async {
+    final callback = walletSwitchEthereumChain;
+    if (callback == null) throw Exception('Invalid wallet');
+
+    final params = data.getChainParams();
+    if (!await callback(params)) throw Exception({'code': 4092});
+
+    await evaluateJavascript(
+      'window.ethereum.emitChainChanged(${jsonEncode(params.chainId)})',
+    );
+    return _ethChainId();
+  }
+
+  Future<String> _solAccount() {
+    final callback = solAccount;
+    if (callback == null) return Future.error(Exception('Invalid wallet'));
+    return callback();
+  }
+
+  Future<String> _solSignTransaction(JsCallBackData data) {
+    final callback = solSignTransaction;
+    if (callback == null) return Future.error(Exception('Invalid wallet'));
+    return callback(data);
+  }
+
+  Future<String> _solSignMessage(JsCallBackData data) {
+    final callback = solSignMessage;
+    if (callback == null) return Future.error(Exception('Invalid wallet'));
+    return callback(data);
+  }
+
+  Future<dynamic> _defaultCallback(JsCallBackData data) {
+    final callback = onDefaultCallback;
+    if (callback == null) return Future.error(Exception('Invalid wallet'));
+    return callback(data);
+  }
+}

--- a/packages/flutter_web3_webview/lib/src/utils/serial_event_queue.dart
+++ b/packages/flutter_web3_webview/lib/src/utils/serial_event_queue.dart
@@ -1,0 +1,43 @@
+import 'dart:async';
+import 'dart:collection';
+
+class SerialEventQueue {
+  final Queue<_QueuedEvent<dynamic>> _events = Queue();
+  bool _isProcessing = false;
+
+  Future<T> add<T>(FutureOr<T> Function() event) {
+    final completer = Completer<T>();
+    _events.add(_QueuedEvent<T>(event, completer));
+    _process();
+    return completer.future;
+  }
+
+  Future<void> _process() async {
+    if (_isProcessing) return;
+    _isProcessing = true;
+
+    try {
+      while (_events.isNotEmpty) {
+        final event = _events.removeFirst();
+        await event.run();
+      }
+    } finally {
+      _isProcessing = false;
+    }
+  }
+}
+
+class _QueuedEvent<T> {
+  final FutureOr<T> Function() event;
+  final Completer<T> completer;
+
+  _QueuedEvent(this.event, this.completer);
+
+  Future<void> run() async {
+    try {
+      completer.complete(await event());
+    } catch (error, stackTrace) {
+      completer.completeError(error, stackTrace);
+    }
+  }
+}

--- a/packages/flutter_web3_webview/lib/src/webview.dart
+++ b/packages/flutter_web3_webview/lib/src/webview.dart
@@ -1,4 +1,3 @@
-import 'dart:async';
 import 'dart:collection';
 
 import 'package:flutter/foundation.dart';
@@ -11,6 +10,8 @@ import 'package:flutter_web3_webview/src/config/params.dart';
 import 'package:flutter_web3_webview/src/models/js_callback_data.dart';
 import 'package:flutter_web3_webview/src/models/settings.dart';
 import 'package:flutter_web3_webview/src/utils/provider.dart';
+import 'package:flutter_web3_webview/src/utils/request_dispatcher.dart';
+import 'package:flutter_web3_webview/src/utils/serial_event_queue.dart';
 
 /// Webview to support wallet connect to web3 DApp. Use webview supported by Flutter_inappwebview.
 class Web3Webview extends StatefulWidget {
@@ -285,11 +286,7 @@ class Web3Webview extends StatefulWidget {
 
 class Web3WebviewState extends State<Web3Webview> {
   bool get isWeb3 => widget.isWeb3;
-  /// Event from dapp.
-  final List<Function> _eventQueue = [];
-  /// Completers match with every event.
-  final List<Completer<dynamic>> _completers = [];
-  bool _isProcessing = false;
+  final SerialEventQueue _eventQueue = SerialEventQueue();
 
   @override
   Widget build(BuildContext context) {
@@ -384,198 +381,35 @@ class Web3WebviewState extends State<Web3Webview> {
 
     if (controller.hasJavaScriptHandler(handlerName: 'FxWalletHandler')) return;
     controller.addJavaScriptHandler(
-      handlerName: 'FxWalletHandler',
-      callback: (args) async {
-        final item = JsCallBackData.fromData(args);
+        handlerName: 'FxWalletHandler',
+        callback: (args) async {
+          final item = JsCallBackData.fromData(args);
+          final dispatcher = _createDispatcher(controller);
 
-        // If the event is getting accounts or chain id, execute immediately.
-        if (checkMethod(item.method)) return _onHandleCallback(item, controller)();
+          // If the event is getting accounts or chain id, execute immediately.
+          if (dispatcher.isImmediate(item.method)) {
+            return dispatcher.dispatch(item);
+          }
 
-        // Else add it to event queue.
-        try {
-          final results = await Future.wait([_addEvent(_onHandleCallback(item, controller)), getLastCompleter()], eagerError: true);
-          return results.last;
-        } catch (e) {
-          rethrow;
-        }
-      }
+          return _eventQueue.add(() => dispatcher.dispatch(item));
+        });
+  }
+
+  Web3RequestDispatcher _createDispatcher(InAppWebViewController controller) {
+    return Web3RequestDispatcher(
+      ethAccounts: widget.ethAccounts,
+      ethChainId: widget.ethChainId,
+      ethSendTransaction: widget.ethSendTransaction,
+      ethSign: widget.ethSign,
+      ethPersonalSign: widget.ethPersonalSign,
+      ethSignTypedData: widget.ethSignTypedData,
+      walletSwitchEthereumChain: widget.walletSwitchEthereumChain,
+      solAccount: widget.solAccount,
+      solSignTransaction: widget.solSignTransaction,
+      solSignMessage: widget.solSignMessage,
+      onDefaultCallback: widget.onDefaultCallback,
+      evaluateJavascript: (source) =>
+          controller.evaluateJavascript(source: source),
     );
-  }
-
-  /// Get the last completer.
-  Future<dynamic> getLastCompleter() async {
-    final completer = _completers.last;
-    final result = await completer.future;
-    return result;
-  }
-
-  /// Event queueing method.
-  Future<void> _addEvent(Function event) async {
-    _eventQueue.insert(0, event);
-    _completers.insert(0, Completer<dynamic>());
-
-    if (_isProcessing) return;
-    _isProcessing = true;
-
-    while (_eventQueue.isNotEmpty && _completers.isNotEmpty) {
-      try {
-        final completer = _completers.last;
-        final result = await _eventQueue.last();
-        completer.complete(result);
-      } catch (e) {
-        _isProcessing = false;
-        rethrow;
-      } finally {
-        _eventQueue.removeLast();
-        _completers.removeLast();
-      }
-    }
-
-    _isProcessing = false;
-  }
-
-  /// Handle handler callback from DApp.
-  Function _onHandleCallback(JsCallBackData args, InAppWebViewController controller) {
-    try {
-      switch (args.method) {
-        case 'eth_accounts':
-        case 'eth_requestAccounts':
-        return _ethAccounts;
-
-      case 'eth_chainId':
-        return _ethChainId;
-
-      case 'wallet_switchEthereumChain':
-      case 'wallet_addEthereumChain':
-        return () => _walletSwitchEthereumChain(args, controller);
-
-      case 'solana_account':
-        return _solAccount;
-
-      case 'eth_sendTransaction':
-        return () => _ethSendTransaction(args);
-
-      case 'eth_sign':
-        return () => _ethSign(args);
-
-      case 'personal_sign':
-        return () => _personalSign(args);
-
-      case 'eth_signTypedData':
-      case 'eth_signTypedData_v3':
-      case 'eth_signTypedData_v4':
-        return () => _ethSignTypedData(args);
-
-      case 'solana_signTransaction':
-        return () => _solSignTransaction(args);
-
-      case 'solana_signMessage':
-        return () => _solSignMessage(args);
-
-      default:
-        return () => _onDefaultCallback(args);
-      }
-    } catch (e) {
-      rethrow;
-    }
-  }
-
-  /// Get eth account.
-  Future<List<String>> _ethAccounts() async {
-    if (widget.ethAccounts == null) throw Exception('Invalid wallet');
-    return widget.ethAccounts!();
-  }
-
-  /// Get eth chain id.
-  Future<String> _ethChainId() async {
-    if (widget.ethChainId == null) throw Exception('Invalid wallet');
-
-    final id = await widget.ethChainId!();
-    return '0x${id.toRadixString(16)}';
-  }
-
-  /// Sign and broadcast eth transaction.
-  Future<String> _ethSendTransaction(JsCallBackData data) async {
-    if (widget.ethSendTransaction == null) throw Exception('Invalid wallet');
-
-    final params = data.getTxParams();
-    return widget.ethSendTransaction!(params);
-  }
-
-  /// Eth sign.
-  Future<String> _ethSign(JsCallBackData data) async {
-    if (widget.ethSign == null) throw Exception('Invalid wallet');
-
-    final params = data.getEthSignMsg();
-    return widget.ethSign!(params);
-  }
-
-  /// Eth personal sign.
-  Future<String> _personalSign(JsCallBackData data) async {
-    if (widget.ethPersonalSign == null) throw Exception('Invalid wallet');
-
-    final params = data.getPersonalSignMsg();
-    return widget.ethPersonalSign!(params);
-  }
-
-  /// Eth sign typed data.
-  Future<String> _ethSignTypedData(JsCallBackData data) async {
-    if (widget.ethSignTypedData == null) throw Exception('Invalid wallet');
-
-    final params = data.getSignTypedDataParams();
-    return widget.ethSignTypedData!(params);
-  }
-
-  /// Switch or add eth chain.
-  Future<String> _walletSwitchEthereumChain(
-      JsCallBackData data, InAppWebViewController controller) async {
-    if (widget.walletSwitchEthereumChain == null) {
-      throw Exception('Invalid wallet');
-    }
-
-    final params = data.getChainParams();
-    final result = await widget.walletSwitchEthereumChain!(params);
-    if (!result) throw Exception({'code': 4092});
-
-    await controller.evaluateJavascript(
-        source: 'window.ethereum.emitChainChanged(${params.chainId})');
-    return _ethChainId();
-  }
-
-  /// Get sol account.
-  Future<String> _solAccount() async {
-    if (widget.solAccount == null) throw Exception('Invalid wallet');
-    return widget.solAccount!();
-  }
-
-  /// Sign sol transaction.
-  Future<String> _solSignTransaction(JsCallBackData data) async {
-    if (widget.solSignTransaction == null) throw Exception('Invalid wallet');
-    return widget.solSignTransaction!(data);
-  }
-
-  /// Sign sol message.
-  Future<String> _solSignMessage(JsCallBackData data) async {
-    if (widget.solSignMessage == null) throw Exception('Invalid wallet');
-    return widget.solSignMessage!(data);
-  }
-
-  /// Handle other callback.
-  Future<dynamic> _onDefaultCallback(JsCallBackData data) async {
-    if (widget.onDefaultCallback == null) throw Exception('Invalid wallet');
-    return widget.onDefaultCallback!(data);
-  }
-
-  bool checkMethod(String method) {
-    const List<String> accountMethods = [
-      'eth_accounts',
-      'eth_requestAccounts',
-      'eth_chainId',
-      'wallet_switchEthereumChain',
-      'wallet_addEthereumChain',
-      'solana_account'
-    ];
-
-    return accountMethods.contains(method);
   }
 }

--- a/packages/flutter_web3_webview/test/request_dispatcher_test.dart
+++ b/packages/flutter_web3_webview/test/request_dispatcher_test.dart
@@ -1,0 +1,313 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_web3_webview/src/models/js_callback_data.dart';
+import 'package:flutter_web3_webview/src/utils/request_dispatcher.dart';
+
+void main() {
+  group('Web3RequestDispatcher.isImmediate', () {
+    test('identifies methods that bypass the serial event queue', () {
+      final dispatcher = _dispatcher();
+
+      for (final method in const [
+        'eth_accounts',
+        'eth_chainId',
+        'solana_account',
+      ]) {
+        expect(dispatcher.isImmediate(method), isTrue, reason: method);
+      }
+
+      for (final method in const [
+        'eth_requestAccounts',
+        'eth_sendTransaction',
+        'eth_sign',
+        'personal_sign',
+        'eth_signTypedData_v4',
+        'wallet_switchEthereumChain',
+        'wallet_addEthereumChain',
+        'solana_signTransaction',
+        'unknown_method',
+      ]) {
+        expect(dispatcher.isImmediate(method), isFalse, reason: method);
+      }
+    });
+  });
+
+  group('Web3RequestDispatcher.dispatch', () {
+    test('routes account and chain requests', () async {
+      final dispatcher = _dispatcher(
+        ethAccounts: () async => ['0xaccount'],
+        ethChainId: () async => 137,
+        solAccount: () async => 'sol-account',
+      );
+
+      expect(await dispatcher.dispatch(_data('eth_accounts')), ['0xaccount']);
+      expect(
+        await dispatcher.dispatch(_data('eth_requestAccounts')),
+        ['0xaccount'],
+      );
+      expect(await dispatcher.dispatch(_data('eth_chainId')), '0x89');
+      expect(
+        await dispatcher.dispatch(_data('solana_account')),
+        'sol-account',
+      );
+    });
+
+    test('routes transaction and signing requests with parsed params',
+        () async {
+      final received = <String, dynamic>{};
+      final typedData = {
+        'domain': {'name': 'Test'}
+      };
+      final dispatcher = _dispatcher(
+        ethSendTransaction: (transaction) async {
+          received['transaction'] = transaction.toJson();
+          return 'tx-hash';
+        },
+        ethSign: (message) async {
+          received['ethSign'] = message;
+          return 'eth-signature';
+        },
+        ethPersonalSign: (message) async {
+          received['personalSign'] = message;
+          return 'personal-signature';
+        },
+        ethSignTypedData: (data) async {
+          received['typedData'] = data;
+          return 'typed-signature';
+        },
+      );
+
+      expect(
+        await dispatcher.dispatch(_data('eth_sendTransaction', [
+          {'from': '0xfrom', 'nonce': '0x1'}
+        ])),
+        'tx-hash',
+      );
+      expect(
+        await dispatcher.dispatch(
+          _data('eth_sign', ['0xaddress', '0xmessage']),
+        ),
+        'eth-signature',
+      );
+      expect(
+        await dispatcher.dispatch(
+          _data('personal_sign', ['0xpersonal', '0xaddress']),
+        ),
+        'personal-signature',
+      );
+
+      for (final method in const [
+        'eth_signTypedData',
+        'eth_signTypedData_v3',
+        'eth_signTypedData_v4',
+      ]) {
+        expect(
+          await dispatcher.dispatch(_data(method, [typedData, '0xaddress'])),
+          'typed-signature',
+        );
+      }
+
+      expect(received['transaction'], containsPair('nonce', '0x1'));
+      expect(received['ethSign'], '0xmessage');
+      expect(received['personalSign'], '0xpersonal');
+      expect(received['typedData'], jsonEncode(typedData));
+    });
+
+    test('routes Solana and default requests with original callback data',
+        () async {
+      final received = <JsCallBackData>[];
+      final dispatcher = _dispatcher(
+        solSignTransaction: (data) async {
+          received.add(data);
+          return 'sol-transaction-signature';
+        },
+        solSignMessage: (data) async {
+          received.add(data);
+          return 'sol-message-signature';
+        },
+        onDefaultCallback: (data) async {
+          received.add(data);
+          return {'handled': data.method};
+        },
+      );
+      final transaction = _data('solana_signTransaction', {'raw': 'raw-tx'});
+      final message = _data('solana_signMessage', {'raw': 'raw-message'});
+      final unknown = _data('unknown_method', {'value': 1});
+
+      expect(
+        await dispatcher.dispatch(transaction),
+        'sol-transaction-signature',
+      );
+      expect(await dispatcher.dispatch(message), 'sol-message-signature');
+      expect(await dispatcher.dispatch(unknown), {'handled': 'unknown_method'});
+      expect(received, [transaction, message, unknown]);
+    });
+
+    test('switches or adds a chain, emits the event, and returns chain id',
+        () async {
+      final scripts = <String>[];
+      final receivedChainIds = <String?>[];
+      final dispatcher = _dispatcher(
+        ethChainId: () async => 10,
+        walletSwitchEthereumChain: (chain) async {
+          receivedChainIds.add(chain.chainId);
+          return true;
+        },
+        evaluateJavascript: (source) async => scripts.add(source),
+      );
+      final params = [
+        {'chainId': '0xa'}
+      ];
+
+      expect(
+        await dispatcher.dispatch(_data('wallet_switchEthereumChain', params)),
+        '0xa',
+      );
+      expect(
+        await dispatcher.dispatch(_data('wallet_addEthereumChain', params)),
+        '0xa',
+      );
+      expect(receivedChainIds, ['0xa', '0xa']);
+      expect(scripts, [
+        'window.ethereum.emitChainChanged("0xa")',
+        'window.ethereum.emitChainChanged("0xa")',
+      ]);
+    });
+
+    test('JSON-encodes chain id before emitting the chain event', () async {
+      const unsafeChainId = '0x1); window.compromised = true; //';
+      final scripts = <String>[];
+      final dispatcher = _dispatcher(
+        ethChainId: () async => 1,
+        walletSwitchEthereumChain: (_) async => true,
+        evaluateJavascript: (source) async => scripts.add(source),
+      );
+
+      await dispatcher.dispatch(
+        _data('wallet_switchEthereumChain', [
+          {'chainId': unsafeChainId}
+        ]),
+      );
+
+      expect(
+        scripts.single,
+        'window.ethereum.emitChainChanged(${jsonEncode(unsafeChainId)})',
+      );
+      expect(scripts.single, isNot(contains('emitChainChanged(0x1)')));
+    });
+
+    test('does not emit chain event when switch is rejected', () async {
+      final scripts = <String>[];
+      final dispatcher = _dispatcher(
+        ethChainId: () async => 1,
+        walletSwitchEthereumChain: (_) async => false,
+        evaluateJavascript: (source) async => scripts.add(source),
+      );
+
+      await expectLater(
+        dispatcher.dispatch(
+          _data('wallet_switchEthereumChain', [
+            {'chainId': '0x1'}
+          ]),
+        ),
+        throwsA(
+          isA<Exception>().having(
+            (error) => error.toString(),
+            'message',
+            contains('4092'),
+          ),
+        ),
+      );
+      expect(scripts, isEmpty);
+    });
+
+    test('throws Invalid wallet when the routed callback is missing', () async {
+      final dispatcher = _dispatcher();
+
+      for (final method in const [
+        'eth_accounts',
+        'eth_chainId',
+        'eth_sendTransaction',
+        'eth_sign',
+        'personal_sign',
+        'eth_signTypedData_v4',
+        'wallet_switchEthereumChain',
+        'solana_account',
+        'solana_signTransaction',
+        'solana_signMessage',
+        'unknown_method',
+      ]) {
+        await expectLater(
+          dispatcher.dispatch(_data(method)),
+          throwsA(
+            isA<Exception>().having(
+              (error) => error.toString(),
+              'message',
+              contains('Invalid wallet'),
+            ),
+          ),
+          reason: method,
+        );
+      }
+    });
+
+    test('propagates callback and JavaScript evaluation errors', () async {
+      final callbackError = StateError('callback failed');
+      final evaluateError = StateError('evaluation failed');
+
+      await expectLater(
+        _dispatcher(ethAccounts: () => Future.error(callbackError))
+            .dispatch(_data('eth_accounts')),
+        throwsA(same(callbackError)),
+      );
+
+      await expectLater(
+        _dispatcher(
+          ethChainId: () async => 1,
+          walletSwitchEthereumChain: (_) async => true,
+          evaluateJavascript: (_) => Future.error(evaluateError),
+        ).dispatch(
+          _data('wallet_switchEthereumChain', [
+            {'chainId': '0x1'}
+          ]),
+        ),
+        throwsA(same(evaluateError)),
+      );
+    });
+  });
+}
+
+JsCallBackData _data(String method, [dynamic params = const []]) {
+  return JsCallBackData(method: method, params: params);
+}
+
+Web3RequestDispatcher _dispatcher({
+  Future<List<String>> Function()? ethAccounts,
+  Future<int> Function()? ethChainId,
+  Future<String> Function(JsTransactionObject data)? ethSendTransaction,
+  Future<String> Function(String data)? ethSign,
+  Future<String> Function(String data)? ethPersonalSign,
+  Future<String> Function(String data)? ethSignTypedData,
+  Future<bool> Function(JsAddEthereumChain data)? walletSwitchEthereumChain,
+  Future<String> Function()? solAccount,
+  Future<String> Function(JsCallBackData data)? solSignTransaction,
+  Future<String> Function(JsCallBackData data)? solSignMessage,
+  Future<dynamic> Function(JsCallBackData data)? onDefaultCallback,
+  EvaluateJavascript? evaluateJavascript,
+}) {
+  return Web3RequestDispatcher(
+    ethAccounts: ethAccounts,
+    ethChainId: ethChainId,
+    ethSendTransaction: ethSendTransaction,
+    ethSign: ethSign,
+    ethPersonalSign: ethPersonalSign,
+    ethSignTypedData: ethSignTypedData,
+    walletSwitchEthereumChain: walletSwitchEthereumChain,
+    solAccount: solAccount,
+    solSignTransaction: solSignTransaction,
+    solSignMessage: solSignMessage,
+    onDefaultCallback: onDefaultCallback,
+    evaluateJavascript: evaluateJavascript ?? (_) async {},
+  );
+}

--- a/packages/flutter_web3_webview/test/request_dispatcher_test.dart
+++ b/packages/flutter_web3_webview/test/request_dispatcher_test.dart
@@ -12,7 +12,6 @@ void main() {
       for (final method in const [
         'eth_accounts',
         'eth_chainId',
-        'solana_account',
       ]) {
         expect(dispatcher.isImmediate(method), isTrue, reason: method);
       }
@@ -25,6 +24,7 @@ void main() {
         'eth_signTypedData_v4',
         'wallet_switchEthereumChain',
         'wallet_addEthereumChain',
+        'solana_account',
         'solana_signTransaction',
         'unknown_method',
       ]) {

--- a/packages/flutter_web3_webview/test/serial_event_queue_test.dart
+++ b/packages/flutter_web3_webview/test/serial_event_queue_test.dart
@@ -1,0 +1,83 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_web3_webview/src/utils/serial_event_queue.dart';
+
+void main() {
+  group('SerialEventQueue', () {
+    test('runs events in FIFO order and returns each matching result',
+        () async {
+      final queue = SerialEventQueue();
+      final firstCompleter = Completer<void>();
+      final executionOrder = <String>[];
+
+      final first = queue.add(() async {
+        executionOrder.add('first-start');
+        await firstCompleter.future;
+        executionOrder.add('first-end');
+        return 'first-result';
+      });
+      final second = queue.add(() async {
+        executionOrder.add('second');
+        return 'second-result';
+      });
+      final third = queue.add(() {
+        executionOrder.add('third');
+        return 'third-result';
+      });
+
+      await Future<void>.delayed(Duration.zero);
+      expect(executionOrder, ['first-start']);
+
+      firstCompleter.complete();
+
+      expect(await Future.wait([first, second, third]), [
+        'first-result',
+        'second-result',
+        'third-result',
+      ]);
+      expect(executionOrder, [
+        'first-start',
+        'first-end',
+        'second',
+        'third',
+      ]);
+    });
+
+    test('continues processing after an event fails', () async {
+      final queue = SerialEventQueue();
+      final executionOrder = <String>[];
+
+      final failed = queue.add<String>(() {
+        executionOrder.add('failed');
+        throw StateError('failed event');
+      });
+      final succeeded = queue.add(() {
+        executionOrder.add('succeeded');
+        return 'result';
+      });
+
+      await expectLater(failed, throwsStateError);
+      expect(await succeeded, 'result');
+      expect(executionOrder, ['failed', 'succeeded']);
+    });
+
+    test('processes events added while another event is running', () async {
+      final queue = SerialEventQueue();
+      final blocker = Completer<void>();
+      final executionOrder = <String>[];
+
+      final first = queue.add(() async {
+        executionOrder.add('first');
+        await blocker.future;
+      });
+      await Future<void>.delayed(Duration.zero);
+
+      final second = queue.add(() => executionOrder.add('second'));
+      blocker.complete();
+
+      await Future.wait([first, second]);
+      expect(executionOrder, ['first', 'second']);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- extract Web3 request routing from Web3WebviewState into a testable dispatcher
- replace the parallel list queue with a typed FIFO serial event queue
- continue processing queued requests after individual failures
- serialize user-confirmed requests and safely encode chain change events

## Verification
- flutter test --coverage (55 tests)
- flutter analyze
- request_dispatcher.dart: 100% line coverage
- serial_event_queue.dart: 100% line coverage