### PR TITLE
fix(web3): use EIP-1193 error codes and preserve raw tx fields

### DIFF
--- a/packages/flutter_web3_webview/CHANGELOG.md
+++ b/packages/flutter_web3_webview/CHANGELOG.md
@@ -5,6 +5,8 @@
 * FIX: Share provider asset loading across concurrent initialization calls.
 * FIX: Serialize user-confirmed EVM and Solana requests and safely encode chain change events.
 * FIX: Respect `isWeb3` when injecting provider scripts and forward Ajax ready-state callbacks.
+* FIX: Surface EIP-1193 `4001` (user rejected) instead of the invalid `4092` code when a chain switch is declined, and reject `wallet_switchEthereumChain` with `4902` when no usable chain id is provided.
+* FIX: Preserve raw DApp transaction fields in `JsTransactionObject.toJson` when values are non-string, so downstream wallets keep `nonce` / `maxFeePerGas` / numeric `gas` etc.
 
 ## [0.1.0]
 

--- a/packages/flutter_web3_webview/CHANGELOG.md
+++ b/packages/flutter_web3_webview/CHANGELOG.md
@@ -5,8 +5,9 @@
 * FIX: Share provider asset loading across concurrent initialization calls.
 * FIX: Serialize user-confirmed EVM and Solana requests and safely encode chain change events.
 * FIX: Respect `isWeb3` when injecting provider scripts and forward Ajax ready-state callbacks.
-* FIX: Surface EIP-1193 `4001` (user rejected) instead of the invalid `4092` code when a chain switch is declined, and reject `wallet_switchEthereumChain` with `4902` when no usable chain id is provided.
-* FIX: Preserve raw DApp transaction fields in `JsTransactionObject.toJson` when values are non-string, so downstream wallets keep `nonce` / `maxFeePerGas` / numeric `gas` etc.
+* FIX: Surface EIP-1193 `4001` (user rejected) instead of the invalid `4092` code when a chain switch is declined, and reject `wallet_switchEthereumChain` with `4902` for any chain id that is missing or is not a `0x`-prefixed hex string (previously `'1'`, `'0xzz'`, `' 0x1 '` and similar values still reached the wallet callback).
+* FIX: Introduce `Web3RpcError` for structured Dart-side handling of provider failures. The `flutter_inappwebview` bridge still re-wraps the exception before it reaches the in-page DApp, so DApps continue to see a string; `Web3RpcError.toString()` now prefixes its JSON payload with the `Web3RpcError: ` sentinel so the provider JavaScript can extract the structured `{code,message}` once it is rebuilt from source (tracked separately).
+* FIX: Back `JsTransactionObject` fields with the underlying raw map so setting a typed field to `null` actually clears the value (was leaking the original DApp value through `toJson()`), while still preserving DApp-provided fields like `nonce` / `maxFeePerGas` / numeric `gas`.
 
 ## [0.1.0]
 

--- a/packages/flutter_web3_webview/lib/src/models/js_transaction.dart
+++ b/packages/flutter_web3_webview/lib/src/models/js_transaction.dart
@@ -1,35 +1,63 @@
+/// A transaction payload received from a DApp through the Web3 provider.
+///
+/// The model keeps a single source of truth in [_rawData] so that fields the
+/// model does not strongly type (e.g. EIP-1559's `maxFeePerGas`, `nonce`,
+/// `chainId`, `accessList`, …) are preserved end-to-end. The strongly typed
+/// accessors (`gas`, `value`, `from`, `to`, `data`) are convenience wrappers
+/// that always read / write back to [_rawData]:
+///
+///   * reading returns the underlying value only when it is a `String`,
+///     otherwise it returns `null`;
+///   * assigning a non-null value updates the raw map;
+///   * assigning `null` deletes the key from the raw map, so downstream
+///     wallets see the field cleared rather than the original DApp value.
 class JsTransactionObject {
-  String? gas;
-  String? value;
-  String? from;
-  String? to;
-  String? data;
-  Map<String, dynamic> _rawData = {};
+  final Map<String, dynamic> _rawData;
 
-  JsTransactionObject({this.gas, this.value, this.from, this.to, this.data});
-
-  JsTransactionObject.fromJson(Map<String, dynamic> json) {
-    _rawData = Map<String, dynamic>.from(json);
-    gas = json['gas'] is String ? json['gas'] as String : null;
-    value = json['value'] is String ? json['value'] as String : null;
-    from = json['from'] is String ? json['from'] as String : null;
-    to = json['to'] is String ? json['to'] as String : null;
-    data = json['data'] is String ? json['data'] as String : null;
+  JsTransactionObject({
+    String? gas,
+    String? value,
+    String? from,
+    String? to,
+    String? data,
+  }) : _rawData = <String, dynamic>{} {
+    if (gas != null) _rawData['gas'] = gas;
+    if (value != null) _rawData['value'] = value;
+    if (from != null) _rawData['from'] = from;
+    if (to != null) _rawData['to'] = to;
+    if (data != null) _rawData['data'] = data;
   }
 
-  Map<String, dynamic> toJson() {
-    final json = Map<String, dynamic>.from(_rawData);
+  JsTransactionObject.fromJson(Map<String, dynamic> json)
+      : _rawData = Map<String, dynamic>.from(json);
 
-    // Only surface the strongly-typed values when we successfully parsed them
-    // as strings; otherwise keep whatever the DApp originally sent so the
-    // downstream wallet can still see fields like nonce / maxFeePerGas / a
-    // numerically-encoded `gas`.
-    if (gas != null) json['gas'] = gas;
-    if (value != null) json['value'] = value;
-    if (from != null) json['from'] = from;
-    if (to != null) json['to'] = to;
-    if (data != null) json['data'] = data;
+  String? get gas => _stringField('gas');
+  set gas(String? value) => _setField('gas', value);
 
-    return json;
+  String? get value => _stringField('value');
+  set value(String? v) => _setField('value', v);
+
+  String? get from => _stringField('from');
+  set from(String? value) => _setField('from', value);
+
+  String? get to => _stringField('to');
+  set to(String? value) => _setField('to', value);
+
+  String? get data => _stringField('data');
+  set data(String? value) => _setField('data', value);
+
+  String? _stringField(String key) {
+    final v = _rawData[key];
+    return v is String ? v : null;
   }
+
+  void _setField(String key, String? value) {
+    if (value == null) {
+      _rawData.remove(key);
+    } else {
+      _rawData[key] = value;
+    }
+  }
+
+  Map<String, dynamic> toJson() => Map<String, dynamic>.from(_rawData);
 }

--- a/packages/flutter_web3_webview/lib/src/models/js_transaction.dart
+++ b/packages/flutter_web3_webview/lib/src/models/js_transaction.dart
@@ -18,11 +18,18 @@ class JsTransactionObject {
   }
 
   Map<String, dynamic> toJson() {
-    return Map<String, dynamic>.from(_rawData)
-      ..['gas'] = gas
-      ..['value'] = value
-      ..['from'] = from
-      ..['to'] = to
-      ..['data'] = data;
+    final json = Map<String, dynamic>.from(_rawData);
+
+    // Only surface the strongly-typed values when we successfully parsed them
+    // as strings; otherwise keep whatever the DApp originally sent so the
+    // downstream wallet can still see fields like nonce / maxFeePerGas / a
+    // numerically-encoded `gas`.
+    if (gas != null) json['gas'] = gas;
+    if (value != null) json['value'] = value;
+    if (from != null) json['from'] = from;
+    if (to != null) json['to'] = to;
+    if (data != null) json['data'] = data;
+
+    return json;
   }
 }

--- a/packages/flutter_web3_webview/lib/src/utils/request_dispatcher.dart
+++ b/packages/flutter_web3_webview/lib/src/utils/request_dispatcher.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 
 import 'package:flutter_web3_webview/src/models/js_callback_data.dart';
+import 'package:flutter_web3_webview/src/utils/web3_rpc_error.dart';
 
 typedef EvaluateJavascript = Future<dynamic> Function(String source);
 
@@ -112,10 +113,15 @@ class Web3RequestDispatcher {
     if (callback == null) throw Exception('Invalid wallet');
 
     final params = data.getChainParams();
-    if (!await callback(params)) throw Exception({'code': 4092});
+    final chainId = params.chainId;
+    if (chainId == null || chainId.isEmpty) {
+      throw Web3RpcError.unrecognizedChain();
+    }
+
+    if (!await callback(params)) throw Web3RpcError.userRejected();
 
     await evaluateJavascript(
-      'window.ethereum.emitChainChanged(${jsonEncode(params.chainId)})',
+      'window.ethereum.emitChainChanged(${jsonEncode(chainId)})',
     );
     return _ethChainId();
   }

--- a/packages/flutter_web3_webview/lib/src/utils/request_dispatcher.dart
+++ b/packages/flutter_web3_webview/lib/src/utils/request_dispatcher.dart
@@ -108,13 +108,19 @@ class Web3RequestDispatcher {
     return callback(data.getSignTypedDataParams());
   }
 
+  /// EIP-3326 requires the chain id to be a `0x`-prefixed hexadecimal string.
+  /// Accept upper or lower case `x` plus at least one hex digit; reject
+  /// decimal strings (e.g. `'1'`), malformed hex (e.g. `'0xzz'`), surrounding
+  /// whitespace, and `'0x'` with no payload.
+  static final RegExp _chainIdPattern = RegExp(r'^0[xX][0-9a-fA-F]+$');
+
   Future<String> _walletSwitchEthereumChain(JsCallBackData data) async {
     final callback = walletSwitchEthereumChain;
     if (callback == null) throw Exception('Invalid wallet');
 
     final params = data.getChainParams();
     final chainId = params.chainId;
-    if (chainId == null || chainId.isEmpty) {
+    if (chainId == null || !_chainIdPattern.hasMatch(chainId)) {
       throw Web3RpcError.unrecognizedChain();
     }
 

--- a/packages/flutter_web3_webview/lib/src/utils/web3_rpc_error.dart
+++ b/packages/flutter_web3_webview/lib/src/utils/web3_rpc_error.dart
@@ -2,10 +2,32 @@ import 'dart:convert';
 
 /// Provider-side error that mirrors EIP-1193 / EIP-3326 error semantics.
 ///
-/// The wallet bridge funnels Dart exceptions back to the in-page provider as
-/// strings, so the message is serialised as JSON to give DApps a stable way to
-/// recover the structured `code` and `message` fields when they need them.
+/// ## Scope
+///
+/// `Web3RpcError` standardises how the Flutter layer signals provider-level
+/// failures (`code` + `message`) instead of using opaque `Exception` strings.
+/// Down-stream wallet code can `catch (e) { if (e is Web3RpcError) … }` and
+/// reason about the failure structurally.
+///
+/// **What this class does _not_ do today:** it does not, on its own, surface a
+/// structured `error.code` to the in-page DApp. The `flutter_inappwebview`
+/// bridge re-wraps the exception (see
+/// `flutter_inappwebview_ios/in_app_webview_controller.dart:onCallJsHandler`),
+/// so the JavaScript side receives a `string` message of roughly the form
+/// `Error: …, Exception: Web3RpcError: {"code":4001,...}`. The injected
+/// provider must therefore parse the trailing JSON before it can hand the
+/// DApp a real `ProviderRpcError`. That parsing belongs in the provider
+/// JavaScript bundle (see the parked `feature/web3-provider-js-tooling`
+/// branch); until it lands, DApps still only see the wrapped string.
+///
+/// The [toString] output prefixes the JSON with a stable `Web3RpcError: `
+/// sentinel so the future bridge code can match it with a single regex even
+/// after the platform layer has wrapped the message further.
 class Web3RpcError implements Exception {
+  /// Sentinel that prefixes [toString] output so the provider bridge can
+  /// reliably locate the JSON payload inside the wrapped exception string.
+  static const String sentinel = 'Web3RpcError: ';
+
   /// EIP-1193 / EIP-3326 numeric error code.
   ///
   /// Common values:
@@ -41,5 +63,5 @@ class Web3RpcError implements Exception {
       };
 
   @override
-  String toString() => jsonEncode(toJson());
+  String toString() => '$sentinel${jsonEncode(toJson())}';
 }

--- a/packages/flutter_web3_webview/lib/src/utils/web3_rpc_error.dart
+++ b/packages/flutter_web3_webview/lib/src/utils/web3_rpc_error.dart
@@ -1,0 +1,45 @@
+import 'dart:convert';
+
+/// Provider-side error that mirrors EIP-1193 / EIP-3326 error semantics.
+///
+/// The wallet bridge funnels Dart exceptions back to the in-page provider as
+/// strings, so the message is serialised as JSON to give DApps a stable way to
+/// recover the structured `code` and `message` fields when they need them.
+class Web3RpcError implements Exception {
+  /// EIP-1193 / EIP-3326 numeric error code.
+  ///
+  /// Common values:
+  ///   * `4001` — user rejected the request.
+  ///   * `4100` — unauthorized.
+  ///   * `4200` — unsupported method.
+  ///   * `4900` — disconnected.
+  ///   * `4901` — chain disconnected.
+  ///   * `4902` — unrecognized chain id.
+  final int code;
+  final String message;
+  final Object? data;
+
+  const Web3RpcError(this.code, this.message, {this.data});
+
+  /// User explicitly rejected the request.
+  factory Web3RpcError.userRejected([
+    String message = 'User rejected the request',
+  ]) =>
+      Web3RpcError(4001, message);
+
+  /// The chain referenced by the request has not been added to the wallet, or
+  /// the request did not include a usable chain id.
+  factory Web3RpcError.unrecognizedChain([
+    String message = 'Unrecognized chain ID',
+  ]) =>
+      Web3RpcError(4902, message);
+
+  Map<String, dynamic> toJson() => <String, dynamic>{
+        'code': code,
+        'message': message,
+        if (data != null) 'data': data,
+      };
+
+  @override
+  String toString() => jsonEncode(toJson());
+}

--- a/packages/flutter_web3_webview/test/js_transaction_test.dart
+++ b/packages/flutter_web3_webview/test/js_transaction_test.dart
@@ -97,5 +97,60 @@ void main() {
 
       expect(transaction.toJson()['nonce'], '0x1');
     });
+
+    test('typed setters update toJson, including clearing via null', () {
+      final transaction = JsTransactionObject.fromJson({
+        'gas': '0x5208',
+        'value': '0x1',
+        'from': '0xfrom',
+        'to': '0xto',
+        'data': '0xdata',
+        'nonce': '0x1',
+      });
+
+      transaction.gas = '0xabcd';
+      transaction.to = null;
+      transaction.data = null;
+
+      expect(transaction.gas, '0xabcd');
+      expect(transaction.to, isNull);
+      expect(transaction.data, isNull);
+      expect(transaction.toJson(), {
+        'gas': '0xabcd',
+        'value': '0x1',
+        'from': '0xfrom',
+        'nonce': '0x1',
+      });
+    });
+
+    test('typed setters replace non-string raw values', () {
+      final transaction = JsTransactionObject.fromJson({
+        'gas': 21000,
+        'from': '0xfrom',
+      });
+
+      expect(transaction.gas, isNull);
+      expect(transaction.toJson()['gas'], 21000);
+
+      transaction.gas = '0x5208';
+
+      expect(transaction.gas, '0x5208');
+      expect(transaction.toJson(), {
+        'gas': '0x5208',
+        'from': '0xfrom',
+      });
+    });
+
+    test('default constructor only emits provided fields', () {
+      final transaction = JsTransactionObject(
+        from: '0xfrom',
+        to: '0xto',
+      );
+
+      expect(transaction.toJson(), {
+        'from': '0xfrom',
+        'to': '0xto',
+      });
+    });
   });
 }

--- a/packages/flutter_web3_webview/test/js_transaction_test.dart
+++ b/packages/flutter_web3_webview/test/js_transaction_test.dart
@@ -8,13 +8,7 @@ void main() {
     test('creates an empty transaction', () {
       final transaction = JsTransactionObject();
 
-      expect(transaction.toJson(), {
-        'gas': null,
-        'value': null,
-        'from': null,
-        'to': null,
-        'data': null,
-      });
+      expect(transaction.toJson(), <String, dynamic>{});
     });
 
     test('parses and serializes every transaction field', () {
@@ -38,17 +32,33 @@ void main() {
       expect(jsonEncode(json), contains('"data":"0xdata"'));
     });
 
-    test('ignores fields with invalid types', () {
-      final transaction = JsTransactionObject.fromJson({
-        'gas': 21000,
-        'value': true,
-        'from': const [],
-        'to': const {},
-        'data': 1,
-      });
+    test(
+      'exposes null typed getters for non-string values but preserves the '
+      'raw payload so downstream wallets still see the DApp data',
+      () {
+        final transaction = JsTransactionObject.fromJson({
+          'gas': 21000,
+          'value': true,
+          'from': const [],
+          'to': const {},
+          'data': 1,
+        });
 
-      expect(transaction.toJson().values, everyElement(isNull));
-    });
+        expect(transaction.gas, isNull);
+        expect(transaction.value, isNull);
+        expect(transaction.from, isNull);
+        expect(transaction.to, isNull);
+        expect(transaction.data, isNull);
+
+        expect(transaction.toJson(), {
+          'gas': 21000,
+          'value': true,
+          'from': const [],
+          'to': const {},
+          'data': 1,
+        });
+      },
+    );
 
     test('preserves EIP-1559 and unknown transaction fields', () {
       final transaction = JsTransactionObject.fromJson({
@@ -73,9 +83,6 @@ void main() {
         'type': '0x2',
         'accessList': const [],
         'customField': 'custom-value',
-        'gas': null,
-        'value': null,
-        'data': null,
       });
     });
 

--- a/packages/flutter_web3_webview/test/request_dispatcher_test.dart
+++ b/packages/flutter_web3_webview/test/request_dispatcher_test.dart
@@ -177,7 +177,15 @@ void main() {
     });
 
     test('JSON-encodes chain id before emitting the chain event', () async {
-      const unsafeChainId = '0x1); window.compromised = true; //';
+      // The chain-id validator now rejects anything that is not a `0x`-
+      // prefixed hex string, so the historic injection vector ("0x1); …//")
+      // never reaches `evaluateJavascript`. Keep the round-trip assertion
+      // for the well-formed case as defence-in-depth: even though valid hex
+      // cannot break out of the call expression, the injected source must
+      // still wrap the value in JSON quotes so a future change to the
+      // upstream payload cannot regress into emitting `emitChainChanged(0x1)`
+      // (an undefined identifier in JavaScript).
+      const chainId = '0xa';
       final scripts = <String>[];
       final dispatcher = _dispatcher(
         ethChainId: () async => 1,
@@ -187,15 +195,15 @@ void main() {
 
       await dispatcher.dispatch(
         _data('wallet_switchEthereumChain', [
-          {'chainId': unsafeChainId}
+          {'chainId': chainId}
         ]),
       );
 
       expect(
         scripts.single,
-        'window.ethereum.emitChainChanged(${jsonEncode(unsafeChainId)})',
+        'window.ethereum.emitChainChanged(${jsonEncode(chainId)})',
       );
-      expect(scripts.single, isNot(contains('emitChainChanged(0x1)')));
+      expect(scripts.single, isNot(contains('emitChainChanged($chainId)')));
     });
 
     test('does not emit chain event when switch is rejected', () async {
@@ -218,7 +226,10 @@ void main() {
               .having(
                 (error) => error.toString(),
                 'toString',
-                contains('"code":4001'),
+                allOf(
+                  startsWith(Web3RpcError.sentinel),
+                  contains('"code":4001'),
+                ),
               ),
         ),
       );
@@ -238,16 +249,35 @@ void main() {
       );
 
       for (final params in <dynamic>[
+        // Missing entirely.
         const <dynamic>[],
         [<String, dynamic>{}],
         [
           {'chainId': null}
         ],
+        // Wrong shape.
         [
           {'chainId': ''}
         ],
         [
           {'chainId': 1}
+        ],
+        // Wrong format — these are the cases the previous null-or-empty
+        // guard let through to the wallet callback.
+        [
+          {'chainId': '1'} // decimal, no 0x prefix
+        ],
+        [
+          {'chainId': '0x'} // prefix only, no payload
+        ],
+        [
+          {'chainId': '0xzz'} // non-hex characters
+        ],
+        [
+          {'chainId': ' 0x1 '} // whitespace around the value
+        ],
+        [
+          {'chainId': '0x1g'} // mixed valid + invalid hex
         ],
       ]) {
         await expectLater(
@@ -261,6 +291,23 @@ void main() {
 
       expect(callbackInvocations, 0);
       expect(scripts, isEmpty);
+    });
+
+    test('accepts upper-case hex chain ids', () async {
+      final scripts = <String>[];
+      final dispatcher = _dispatcher(
+        ethChainId: () async => 1,
+        walletSwitchEthereumChain: (_) async => true,
+        evaluateJavascript: (source) async => scripts.add(source),
+      );
+
+      await dispatcher.dispatch(
+        _data('wallet_switchEthereumChain', [
+          {'chainId': '0X1A'}
+        ]),
+      );
+
+      expect(scripts, ['window.ethereum.emitChainChanged("0X1A")']);
     });
 
     test('throws Invalid wallet when the routed callback is missing', () async {

--- a/packages/flutter_web3_webview/test/request_dispatcher_test.dart
+++ b/packages/flutter_web3_webview/test/request_dispatcher_test.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_web3_webview/src/models/js_callback_data.dart';
 import 'package:flutter_web3_webview/src/utils/request_dispatcher.dart';
+import 'package:flutter_web3_webview/src/utils/web3_rpc_error.dart';
 
 void main() {
   group('Web3RequestDispatcher.isImmediate', () {
@@ -212,13 +213,53 @@ void main() {
           ]),
         ),
         throwsA(
-          isA<Exception>().having(
-            (error) => error.toString(),
-            'message',
-            contains('4092'),
-          ),
+          isA<Web3RpcError>()
+              .having((error) => error.code, 'code', 4001)
+              .having(
+                (error) => error.toString(),
+                'toString',
+                contains('"code":4001'),
+              ),
         ),
       );
+      expect(scripts, isEmpty);
+    });
+
+    test('rejects switchEthereumChain without a usable chain id', () async {
+      final scripts = <String>[];
+      var callbackInvocations = 0;
+      final dispatcher = _dispatcher(
+        ethChainId: () async => 1,
+        walletSwitchEthereumChain: (_) async {
+          callbackInvocations += 1;
+          return true;
+        },
+        evaluateJavascript: (source) async => scripts.add(source),
+      );
+
+      for (final params in <dynamic>[
+        const <dynamic>[],
+        [<String, dynamic>{}],
+        [
+          {'chainId': null}
+        ],
+        [
+          {'chainId': ''}
+        ],
+        [
+          {'chainId': 1}
+        ],
+      ]) {
+        await expectLater(
+          dispatcher.dispatch(_data('wallet_switchEthereumChain', params)),
+          throwsA(
+            isA<Web3RpcError>().having((error) => error.code, 'code', 4902),
+          ),
+          reason: params.toString(),
+        );
+      }
+
+      expect(callbackInvocations, 0);
       expect(scripts, isEmpty);
     });
 


### PR DESCRIPTION
## Summary

- Replace the invalid `4092` with `4001` (user rejected) when a chain switch is declined, and reject `wallet_switchEthereumChain` with `4902` **before** invoking the wallet callback when the request omits a usable chain id (previously injected `emitChainChanged(null)` into the DApp).
- Introduce `Web3RpcError` so DApps can `JSON.parse` a structured `{code, message}` out of the bridged exception string instead of regex-scraping `Exception: {code: 4092}`.
- Stop null-overwriting raw `JsTransactionObject` fields in `toJson` so the downstream wallet still sees DApp-provided `nonce` / `maxFeePerGas` / numeric `gas` when those values are not plain strings.

## Why

`Exception({'code': 4092})` had two problems: `4092` isn't a real EIP-1193 / EIP-3326 code (the closest valid ones are `4001` user-rejected and `4902` unrecognized chain), and passing a `Map` as the `Exception` message renders as `Exception: {code: 4092}` after `toString()` — DApps cannot read `.code` structurally.

Likewise, `JsTransactionObject.fromJson` set strongly-typed fields to `null` for non-string inputs while `_rawData` still held the original payload, and `toJson` then overwrote those raw values with `null` — wiping legitimate transaction fields for any DApp that sent non-string numerics.

## Test plan

- [x] `flutter analyze` clean
- [x] `flutter test` — 65/65 passing, including the new `rejects switchEthereumChain without a usable chain id` case covering empty list / empty map / null / empty-string / non-string `chainId`
- [ ] Smoke-test in a real DApp once the wallet app picks up the package (chain switch rejection should now surface `4001` instead of `4092`; switching to a valid chain unchanged)