### PR TITLE
feat(web3-provider): restore the WebView bridge layer in source

### DIFF
--- a/packages/flutter_web3_webview/provider/RECOVERY.md
+++ b/packages/flutter_web3_webview/provider/RECOVERY.md
@@ -2,15 +2,19 @@
 
 The current `lib/js/provider.min.js` was generated from a previously-modified
 fork of `trust-web3-provider`. Those source modifications were lost, so this
-document tracks what we have inferred from the minified bundle and what still
-needs to be ported back into `provider/packages/` before the esbuild bundle
-becomes equivalent to the ship-asset.
+document tracks what was inferred from the minified bundle and what has /
+has not been ported back into `provider/packages/`.
 
-The Phase 2 build infrastructure (`bundle/index.ts` + `bundle/build.mjs`)
-already produces a working IIFE, but the output is missing the Flutter
-bridge layer described below. Until that layer is restored, the build is
-**not** yet a drop-in replacement and the legacy `provider.min.js` is the
-asset of record.
+> **Status update (Phase 3 in progress):** the Flutter bridge layer described
+> below has now been restored in source (`packages/core/adapter/FlutterBridge.ts`
+> plus the per-package overrides). `bun run build:flutter` produces a bundle
+> that contains every legacy surface token (`FxWalletHandler`,
+> `emitChainChanged`, `solana_account`, `solana_signTransaction`,
+> `solana_signMessage`, `Not init finished`, the `wallet-standard:register-wallet`
+> events, …). The asset of record is still the legacy `provider.min.js`
+> until **Phase 5** signs off the regenerated bundle against a real DApp
+> regression set. Run `bun run build:flutter` locally to refresh
+> `lib/js/provider.min.js` when you are ready to swap.
 
 ## What's in the legacy bundle but not in upstream source
 
@@ -47,60 +51,97 @@ that we have not yet traced. The Dart dispatcher
 `solana_account`, `solana_signTransaction`, `solana_signMessage`, so the
 gap is largely informational.
 
-## Phase 3 work to make the new bundle equivalent
+## Phase 3 — restored bridge
 
-The minimal changes required on top of the vendored source:
+The bridge layer has been ported back into the vendored source:
 
-1. **EthereumProvider.internalRequest** — override to forward the args
-   directly to the WebView bridge:
-   ```ts
-   internalRequest<T>(args: IRequestArguments): Promise<T> {
-     return (window as Window & {
-       flutter_inappwebview: {
-         callHandler: (handler: string, ...args: unknown[]) => Promise<unknown>;
-       };
-     }).flutter_inappwebview.callHandler('FxWalletHandler', args) as Promise<T>;
-   }
-   ```
-   The upstream `MobileAdapter` keeps doing the EIP-1193 → mobile method
-   rewrites; the bridge just transports the rewritten request.
+1. **`packages/core/adapter/FlutterBridge.ts`** — single shared helper that
+   guards `window.flutter_inappwebview` (throwing `Not init finished.` to
+   match the legacy error message) and invokes
+   `callHandler('FxWalletHandler', payload)`. Re-exported from
+   `packages/core/index.ts` as `callFlutterHandler` so neither chain
+   package has to re-declare the global.
+2. **`packages/ethereum/EthereumProvider.ts`**
+   * `internalRequest(args)` now forwards `args` through the bridge
+     verbatim. `MobileAdapter` still performs the EIP-1193 → mobile
+     method rewrites first, so the Dart dispatcher sees `requestAccounts`,
+     `signTransaction`, `signPersonalMessage`, `signTypedMessage`,
+     `ecRecover`, `watchAsset`, `wallet_addEthereumChain`,
+     `wallet_switchEthereumChain`, etc.
+   * `emitChainChanged(chainId)` and `emitAccountsChanged(accounts)` are
+     exposed publicly so the Dart side can fire EIP-1193 events after
+     `wallet_switchEthereumChain` or an account switch (matching the
+     `window.ethereum.emitChainChanged(...)` injection in
+     `lib/src/utils/request_dispatcher.dart`).
+3. **`packages/solana/SolanaProvider.ts`**
+   * `isConnected` boolean field added so DApps can sniff the connection
+     state directly (matching the legacy bundle).
+   * `connect()` now bridges to `{ method: 'solana_account' }`, sets
+     `publicKey` / `isConnected`, and emits `connect`.
+   * `disconnect()` clears `publicKey` / `isConnected` and emits
+     `disconnect`.
+   * `signMessage(message)` bridges to
+     `{ method: 'solana_signMessage', params: { raw: hex } }`.
+   * `signTransaction(tx)` serialises the transaction message (handling
+     both legacy `Transaction` and `VersionedTransaction`) and bridges to
+     `{ method: 'solana_signTransaction', params: { raw, message } }`,
+     then attaches the returned signature via `mapSignedTransaction`.
+   * `emitAccountChanged()` exposed for the wallet-standard adapter and
+     DApp listeners.
+   * `internalRequest(args)` forwards generic Solana requests through the
+     bridge unchanged so any future method that doesn't have a bespoke
+     wrapper still works.
 
-2. **SolanaProvider Flutter bridge** — replace the three call sites
-   (`connect`, `signMessage`, `signTransaction`) so they call
-   `callHandler('FxWalletHandler', { method: 'solana_*', params: ... })`
-   with the `raw` / `raw + message` parameter shapes documented above.
-   Match the upstream method bodies for everything else.
+### Surface verification (regenerated bundle vs legacy)
 
-3. **Match the Dart dispatcher** — confirm every method the Dart side
-   (`request_dispatcher.dart`) routes for has a matching bridge call in
-   the JS source so nothing falls through to `_defaultCallback`.
+| Token | Legacy | New |
+|-------|-------:|----:|
+| `window.fxwallet` | ✓ | ✓ |
+| `FxWalletHandler` | 5 | 1 (minifier dedupes) |
+| `isFxWallet` | 8 | 8 |
+| `'fxwallet:'` (wallet-standard namespace) | ✓ | ✓ |
+| `wallet-standard:register-wallet` | ✓ | 3 |
+| `emitChainChanged` | 2 | 1 |
+| `emitAccountsChanged` | — | 1 (new) |
+| `solana_account` | 1 | 1 |
+| `solana_signTransaction` | 1 | 1 |
+| `solana_signMessage` | 1 | 1 |
+| `Not init finished` guard | 5 | 1 (minifier dedupes) |
 
-4. **Verify behaviour against a real DApp** — load both bundles in a
-   WebView side-by-side, intercept the `callHandler` arguments for the
-   core flows (connect / personal_sign / signTypedData / sendTransaction /
-   switchChain / Solana sign), and confirm the payloads match byte-for-byte.
+`registerWallet` itself does not appear by name in the regenerated bundle
+because esbuild's minifier renamed the local symbol — the dispatched
+event names (`wallet-standard:register-wallet`, `wallet-standard:app-ready`)
+are present and that is the contract DApps observe.
 
-After Phase 3 lands, the build script (`bun run build:flutter`) should
-produce a bundle that can replace the legacy asset without breaking any
-DApp the wallet supports today.
+## Phase 5 — outstanding regression verification
 
-## Surface inventory
+Before the regenerated bundle replaces `lib/js/provider.min.js`:
 
-Tokens currently present in the legacy bundle but absent from the
-freshly-built bundle (`bun run build:flutter` against the current source):
+1. Run the wallet against a representative DApp set (Uniswap V3, OpenSea,
+   Aave on EVM; Jupiter, Drift on Solana) using **both** bundles.
+2. Intercept every `window.flutter_inappwebview.callHandler('FxWalletHandler',
+   …)` invocation and confirm the new bundle emits payloads byte-for-byte
+   identical to the legacy bundle for: `eth_accounts`, `eth_chainId`,
+   `eth_requestAccounts`, `personal_sign`, `eth_signTypedData_v4`,
+   `eth_sendTransaction`, `wallet_switchEthereumChain`,
+   `wallet_addEthereumChain`, `solana_account`, `solana_signMessage`,
+   `solana_signTransaction`.
+3. Bundle size: regenerated ≈ 2.95 MB vs legacy ≈ 1.46 MB. The growth is
+   driven by the newer Solana / wallet-standard dependency tree esbuild
+   pulls in. Confirm WebView cold-start latency is acceptable before
+   shipping.
 
-| Token | Legacy occurrences | New occurrences |
-|-------|-------------------:|----------------:|
-| `FxWalletHandler` | 5 | 0 |
-| `registerWallet` | 10 | 0 |
-| `emitChainChanged` | 2 | 0 |
-| `solana_signTransaction` | 1 | 0 |
-| `solana_signMessage` | 1 | 0 |
-| `solana_account` | 1 | 0 |
+## Known gaps (deferred)
 
-`registerWallet = 0` deserves a closer look — the wallet-standard
-`registerWallet` import in `solana/adapter/register.ts` should survive
-tree-shaking because `SolanaProvider`'s constructor calls
-`initialize(this)`, which in turn calls `registerWallet`. Confirm the
-chain is intact in the new bundle (it might just be inlined under a
-minified name).
+The legacy bundle also added the following niceties that are **not yet**
+ported back because they aren't required for the wire protocol:
+
+* `EthereumProvider.setAddress` lower-cases the address, sets
+  `provider.ready`, and walks `window.frames[*].ethereum` to mirror the
+  state into iframes branded with `isFxWallet`. The vendored source still
+  has the upstream stub that just stores the private `#address`.
+* `EthereumProvider.isConnected()` always-returns-true legacy stub.
+* `EthereumProvider.setConfig(config)` aggregate setter.
+
+These can be ported in a follow-up once a DApp is observed to depend on
+them.

--- a/packages/flutter_web3_webview/provider/packages/core/adapter/FlutterBridge.ts
+++ b/packages/flutter_web3_webview/provider/packages/core/adapter/FlutterBridge.ts
@@ -1,0 +1,63 @@
+/**
+ * Transport that hands provider requests to the Flutter side of the WebView.
+ *
+ * `flutter_web3_webview` registers a JavaScript handler named
+ * `FxWalletHandler` (see `lib/src/webview.dart`) that delegates incoming
+ * messages to `Web3RequestDispatcher`. Every provider request therefore
+ * flows through `window.flutter_inappwebview.callHandler('FxWalletHandler',
+ * payload)`; the Dart side resolves the returned `Promise` with the
+ * dispatcher result or rejects it with an `Exception` string.
+ *
+ * The helper lives in `core` because both `ethereum` and `solana` need it
+ * and re-implementing the guard / type declaration in each package would
+ * drift over time.
+ */
+
+export const FLUTTER_HANDLER_NAME = 'FxWalletHandler' as const;
+
+export interface FlutterCallHandler {
+  callHandler(handlerName: string, ...args: unknown[]): Promise<unknown>;
+}
+
+export interface FlutterWebViewWindow {
+  flutter_inappwebview?: FlutterCallHandler;
+}
+
+/**
+ * Read `window.flutter_inappwebview` defensively. The provider bundle is
+ * also bundled into unit tests that don't have a host WebView, so the
+ * caller is expected to handle the `undefined` case rather than us
+ * throwing eagerly at module load time.
+ */
+function getBridge(): FlutterCallHandler {
+  const host = (
+    typeof window !== 'undefined' ? (window as FlutterWebViewWindow) : null
+  );
+  const bridge = host?.flutter_inappwebview;
+  if (!bridge) {
+    // Match the wording the legacy bundle used so DApp-side error
+    // matchers continue to work.
+    throw new Error('Not init finished.');
+  }
+  return bridge;
+}
+
+export interface IFlutterBridgeArgs {
+  method: string;
+  params?: unknown;
+}
+
+/**
+ * Send `payload` to the wallet via the WebView bridge and return the
+ * Dart-side response. Generic `T` is the expected response shape — the
+ * helper does not enforce it at runtime, mirroring the upstream
+ * `internalRequest` contract.
+ */
+export function callFlutterHandler<T = unknown>(
+  payload: IFlutterBridgeArgs,
+): Promise<T> {
+  return getBridge().callHandler(
+    FLUTTER_HANDLER_NAME,
+    payload,
+  ) as Promise<T>;
+}

--- a/packages/flutter_web3_webview/provider/packages/core/index.ts
+++ b/packages/flutter_web3_webview/provider/packages/core/index.ts
@@ -62,3 +62,10 @@ export class Web3Provider {
 }
 
 export * from './Provider';
+export {
+  FLUTTER_HANDLER_NAME,
+  callFlutterHandler,
+  type FlutterCallHandler,
+  type FlutterWebViewWindow,
+  type IFlutterBridgeArgs,
+} from './adapter/FlutterBridge';

--- a/packages/flutter_web3_webview/provider/packages/ethereum/EthereumProvider.ts
+++ b/packages/flutter_web3_webview/provider/packages/ethereum/EthereumProvider.ts
@@ -2,7 +2,7 @@ import type IEthereumProvider from './types/EthereumProvider';
 
 import type { IPermissionRes, IRequestArguments } from './types';
 
-import { BaseProvider } from '@fxwallet/web3-provider-core';
+import { BaseProvider, callFlutterHandler } from '@fxwallet/web3-provider-core';
 import type { IEthereumProviderConfig } from './types/EthereumProvider';
 import { RPCError } from './exceptions/RPCError';
 import { MobileAdapter } from './MobileAdapter';
@@ -80,6 +80,31 @@ export class EthereumProvider
    */
   private connect() {
     this.emit('connect', { chainId: this.#chainId });
+  }
+
+  /**
+   * Forward a wallet-initiated chain switch to subscribed DApps.
+   *
+   * `lib/src/utils/request_dispatcher.dart` calls
+   * `window.ethereum.emitChainChanged(chainId)` from
+   * `_walletSwitchEthereumChain` so DApps that listen via EIP-1193's
+   * `chainChanged` event (or the legacy `networkChanged` alias still used
+   * by older libraries) refresh their state immediately. The Dart side
+   * passes a `0x`-prefixed hex chain id, matching the EIP-1193 contract.
+   */
+  public emitChainChanged(chainId: string) {
+    this.#chainId = chainId;
+    this.emit('chainChanged', chainId);
+    this.emit('networkChanged', chainId);
+  }
+
+  /**
+   * Emit the EIP-1193 `accountsChanged` event for the currently selected
+   * accounts. Exposed publicly so the Flutter side can notify DApps when
+   * the user switches wallets without reloading the page.
+   */
+  public emitAccountsChanged(accounts: string[]) {
+    this.emit('accountsChanged', accounts);
   }
 
   /**
@@ -180,8 +205,17 @@ export class EthereumProvider
     return this._send(methodOrPayload as IRequestArguments);
   }
 
+  /**
+   * Hand the (already EIP-1193 → mobile-rewritten) request to the Flutter
+   * side of the WebView. The upstream `MobileAdapter` has either mapped the
+   * DApp method to its mobile equivalent (`eth_requestAccounts` →
+   * `requestAccounts`, `eth_sendTransaction` → `signTransaction`, etc.) or
+   * fallen through to the JSON-RPC server; everything else flows through
+   * here unchanged. The Dart `Web3RequestDispatcher` switches on the
+   * method name we forward.
+   */
   internalRequest<T>(args: IRequestArguments): Promise<T> {
-    return super.request<T>(args);
+    return callFlutterHandler<T>(args);
   }
 
   /**

--- a/packages/flutter_web3_webview/provider/packages/solana/SolanaProvider.ts
+++ b/packages/flutter_web3_webview/provider/packages/solana/SolanaProvider.ts
@@ -3,6 +3,7 @@ import 'rpc-websockets/dist/lib/client';
 import {
   BaseProvider,
   IRequestArguments,
+  callFlutterHandler,
 } from '@fxwallet/web3-provider-core';
 import type ISolanaProvider from './types/SolanaProvider';
 import type { ISolanaProviderConfig } from './types/SolanaProvider';
@@ -35,6 +36,8 @@ export class SolanaProvider extends BaseProvider implements ISolanaProvider {
   connection!: Connection;
 
   publicKey!: PublicKey | null;
+
+  isConnected: boolean = false;
 
   isFxWallet: boolean = true;
 
@@ -97,25 +100,46 @@ export class SolanaProvider extends BaseProvider implements ISolanaProvider {
     return new FxWallet(this);
   }
 
+  /**
+   * Resolve the active wallet account via the Flutter bridge.
+   *
+   * The Dart `Web3RequestDispatcher` handles the `solana_account` method
+   * by returning the base58 public-key string of the currently selected
+   * wallet (see `lib/src/utils/request_dispatcher.dart`). We wrap it back
+   * into a `PublicKey`, flag `isConnected`, and emit the EIP-1193-style
+   * `connect` event so the wallet-standard adapter and listening DApps
+   * pick up the state change.
+   */
   async connect(
-    options?: { onlyIfTrusted?: boolean | undefined } | undefined,
+    _options?: { onlyIfTrusted?: boolean | undefined } | undefined,
   ): Promise<{ publicKey: PublicKey }> {
-    const res = await this.#privateRequest<{ publicKey: PublicKey }>({
-      method: 'connect',
-      params: { options },
+    const address = await callFlutterHandler<string>({
+      method: 'solana_account',
     });
 
-    this.publicKey = res.publicKey;
+    this.publicKey = new PublicKey(address);
+    this.isConnected = true;
+    this.emit('connect');
 
-    return res;
+    return { publicKey: this.publicKey };
   }
 
   disconnect(): Promise<void> {
     return new Promise((resolve) => {
       this.publicKey = null;
+      this.isConnected = false;
       this.emit('disconnect');
       resolve();
     });
+  }
+
+  /**
+   * Notify listeners that the active Solana account changed. The Flutter
+   * side calls this from `provider.dart` after the user switches wallets
+   * so DApps subscribed via the wallet standard refresh their state.
+   */
+  emitAccountChanged(): void {
+    this.emit('accountChanged', this.publicKey);
   }
 
   async signAndSendTransaction<T extends Transaction | VersionedTransaction>(
@@ -132,10 +156,30 @@ export class SolanaProvider extends BaseProvider implements ISolanaProvider {
     return { signature: signature };
   }
 
-  signTransaction<T extends Transaction | VersionedTransaction>(
+  /**
+   * Serialise the transaction's *message* (the signed-over bytes, not the
+   * full transaction) and ask the Flutter side to sign it. The wallet
+   * receives both a hex (`raw`) and base64 (`message`) encoding of the
+   * same bytes so it can pick whichever its native signer expects, and
+   * replies with the base58-encoded signature, which `mapSignedTransaction`
+   * attaches back to the original transaction object.
+   */
+  async signTransaction<T extends Transaction | VersionedTransaction>(
     tx: T,
   ): Promise<T> {
-    return this.#privateRequest({ method: 'signTransaction', params: tx });
+    const message = isVersionedTransaction(tx)
+      ? Buffer.from(tx.message.serialize())
+      : tx.serializeMessage();
+
+    const signature = await callFlutterHandler<string>({
+      method: 'solana_signTransaction',
+      params: {
+        raw: message.toString('hex'),
+        message: message.toString('base64'),
+      },
+    });
+
+    return this.mapSignedTransaction(tx, signature);
   }
 
   signAllTransactions<T extends Transaction | VersionedTransaction>(
@@ -183,14 +227,11 @@ export class SolanaProvider extends BaseProvider implements ISolanaProvider {
   async signMessage(
     message: Uint8Array,
   ): Promise<{ signature: Uint8Array; publicKey: string | undefined }> {
-    const data = SolanaProvider.bufferToHex(message);
+    const hex = SolanaProvider.bufferToHex(message);
 
-    const res = await this.#privateRequest<string>({
-      method: 'signMessage',
-      params: {
-        data,
-        originalMethod: 'signMessage'
-      },
+    const res = await callFlutterHandler<string>({
+      method: 'solana_signMessage',
+      params: { raw: hex },
     });
 
     return {
@@ -237,11 +278,13 @@ export class SolanaProvider extends BaseProvider implements ISolanaProvider {
   }
 
   /**
-   * Call request handler directly
-   * @param args
-   * @returns
+   * Generic Solana bridge for callers that aren't covered by the bespoke
+   * `connect` / `signMessage` / `signTransaction` overrides above. The
+   * Dart side dispatches on the un-prefixed method name when it falls
+   * through to `onDefaultCallback`, so we keep `args` intact rather than
+   * synthesising a `solana_` prefix here.
    */
   internalRequest<T>(args: IRequestArguments): Promise<T> {
-    return super.request<T>(args);
+    return callFlutterHandler<T>(args);
   }
 }


### PR DESCRIPTION
## Summary

Phase 3 of the provider import — re-add the Flutter bridge layer that the lost fork had layered on top of `trust-web3-provider`. After this lands, `bun run build:flutter` produces a bundle whose surface matches the shipped `lib/js/provider.min.js` (the legacy fork's wire shape), so swapping the asset becomes a small, low-risk follow-up step instead of a re-implementation.

The asset itself is **unchanged** in this PR — Phase 5 (real-DApp regression) signs off the swap. DApp behaviour is identical to `main`.

## What's new

- `packages/core/adapter/FlutterBridge.ts` — shared `callFlutterHandler({ method, params })` helper that guards `window.flutter_inappwebview` and invokes `callHandler('FxWalletHandler', payload)`. Throws the legacy `Not init finished.` message so DApp-side error matchers stay valid.
- `packages/ethereum/EthereumProvider.ts`
  - `internalRequest` now forwards args directly through the bridge (the upstream adapter abstraction is bypassed; `MobileAdapter` still does the EIP-1193 → mobile method renames first).
  - `emitChainChanged(chainId)` and `emitAccountsChanged(accounts)` exposed publicly so `lib/src/utils/request_dispatcher.dart` can fire the EIP-1193 events after `wallet_switchEthereumChain` / account switches.
- `packages/solana/SolanaProvider.ts`
  - `isConnected` field + `emitAccountChanged()` method.
  - `connect()` bridges to `{ method: 'solana_account' }` and emits `connect` after constructing the `PublicKey`.
  - `disconnect()` clears state and emits `disconnect`.
  - `signMessage(message)` bridges to `{ method: 'solana_signMessage', params: { raw: hex } }`.
  - `signTransaction(tx)` serialises the transaction *message* (legacy `Transaction` + `VersionedTransaction`) and bridges to `{ method: 'solana_signTransaction', params: { raw, message } }`, then re-attaches the signature via `mapSignedTransaction`.
  - `internalRequest(args)` forwards generic Solana calls through the bridge unchanged so any future un-bridged method still routes correctly.

`provider/RECOVERY.md` is updated with a status section, a regenerated-vs-legacy surface inventory table, and the list of known cosmetic gaps still deferred (`setAddress` iframe sync, the always-true `isConnected()` stub, `setConfig`).

## What's *not* in this PR

- The regenerated `lib/js/provider.min.js`. The asset is still the legacy bundle until **Phase 5** verifies the new build against a representative DApp set (Uniswap V3 / OpenSea / Aave on EVM, Jupiter / Drift on Solana). When swapped, the bundle will grow from ~1.46 MB to ~2.95 MB (newer Solana stack), which is worth a deliberate check before shipping.

## Test plan

- [x] `bun run build:packages` — core / ethereum / solana all build clean.
- [x] `bun run build:flutter` — produces a 2.95 MB bundle that now contains every legacy surface token (`FxWalletHandler`, `emitChainChanged`, `emitAccountsChanged`, `solana_account`, `solana_signTransaction`, `solana_signMessage`, the `wallet-standard:register-wallet` events, the `Not init finished` guard). See the `Surface verification` table in `RECOVERY.md`.
- [x] `node scripts/brand-rename.mjs --check` — still passes (0 files would change), no brand drift.
- [x] Dart tests untouched because the asset is still the legacy bundle; the existing `flutter test` suite (69/69) keeps passing.
- [ ] Phase 5 — load both bundles in a real WebView and confirm byte-for-byte equivalent `callHandler` payloads for the core flows.