### PR TITLE
feat(demo): scaffold the web3 webview demo (Phase 1)

### DIFF
--- a/examples/web3_webview_demo/README.md
+++ b/examples/web3_webview_demo/README.md
@@ -1,16 +1,80 @@
-# example
+# web3_webview_demo
 
-A new Flutter project.
+End-to-end demo / regression-test bed for the
+[`flutter_web3_webview`](../../packages/flutter_web3_webview) package.
 
-## Getting Started
+The goal is twofold:
 
-This project is a starting point for a Flutter application.
+1. **Showcase** every callback `Web3Webview` exposes, against a curated
+   set of real-world DApps (Uniswap, OpenSea, Jupiter, Magic Eden, …) so
+   anyone integrating the package can copy a working setup.
+2. **Manual regression bed** for the FxWallet team — change the JS
+   bundle or the Dart dispatcher, then click through the bookmark grid
+   to confirm `connect` / `personal_sign` / `eth_signTypedData_v4` /
+   `eth_sendTransaction` / `wallet_switchEthereumChain` / Solana
+   `signMessage` / `signTransaction` all still resolve cleanly.
 
-A few resources to get you started if this is your first Flutter project:
+## Status
 
-- [Lab: Write your first Flutter app](https://docs.flutter.dev/get-started/codelab)
-- [Cookbook: Useful Flutter samples](https://docs.flutter.dev/cookbook)
+The demo lands incrementally — each phase is its own PR off the
+`epic/flutter-web3-webview-hardening` branch so the diff stays small and
+reviewable.
 
-For help getting started with Flutter development, view the
-[online documentation](https://docs.flutter.dev/), which offers tutorials,
-samples, guidance on mobile development, and a full API reference.
+| Phase | What it adds | Status |
+|------:|--------------|--------|
+| **1** | App shell + zero-dep state mgmt + bookmark grid + chain / account pickers (placeholders for signing / approval / log) | ✅ this commit |
+| 2 | Bookmark grid polish, custom-URL entry, recent-DApp memory | ☐ |
+| 3 | Full `Web3Webview` callback wiring + approval bottom-sheet + bridge log capture | ☐ |
+| 4 | EVM signing (`web3dart`): `personal_sign`, `eth_signTypedData_v3/v4`, `eth_sendTransaction` (mock hash by default, real broadcast on toggle) | ☐ |
+| 5 | Solana signing (`cryptography` + `bs58`): `solana_signMessage`, `solana_signTransaction` | ☐ |
+| 6 | Settings: auto-approve toggle, real-broadcast toggle, bridge-log viewer | ☐ |
+| 7 | README screenshots, manual regression checklist, more widget tests | ☐ |
+
+## Run it
+
+```bash
+cd examples/web3_webview_demo
+flutter pub get
+flutter run
+```
+
+The demo depends on the local `flutter_web3_webview` package via a path
+override in `pubspec_overrides.yaml`, so any change to the package source
+is picked up by the next hot restart.
+
+## Test accounts
+
+The Phase 4 / 5 signing implementations derive their keys from the
+well-known development mnemonic
+
+    test test test test test test test test test test test junk
+
+(BIP-44 path `m/44'/60'/0'/0/<i>` for EVM, `m/44'/501'/<i>'/0'` for
+Solana). The mnemonic is intentionally public — **anything sent to these
+addresses is immediately swept by bots that scan for the phrase**. Never
+fund them.
+
+## Architecture
+
+```
+lib/
+├── main.dart            # entrypoint — Web3Webview.initJs() + runApp
+├── app.dart             # MaterialApp + named routes + service scopes
+├── data/
+│   ├── chains.dart      # EVM chains + Solana clusters catalogue
+│   └── dapps.dart       # bookmark catalogue grouped by category
+├── services/
+│   ├── wallet_state.dart # ChangeNotifier — active account / chain / settings
+│   └── bridge_log.dart   # ring-buffer log of bridge round-trips
+├── pages/
+│   ├── home_page.dart   # bookmark grid + active-identity card
+│   ├── browser_page.dart # Web3Webview + AppBar chain / account chips
+│   └── settings_page.dart # account / chain picker + (pending) toggles
+└── widgets/             # filled in by Phase 3+
+```
+
+State propagates through `InheritedNotifier`-backed scopes
+(`WalletStateScope`, `BridgeLogScope`) — zero third-party state
+management packages. Pages read with `WalletStateScope.of(context)` to
+subscribe to rebuilds, or `WalletStateScope.read(context)` for one-shot
+reads inside async handlers.

--- a/examples/web3_webview_demo/lib/app.dart
+++ b/examples/web3_webview_demo/lib/app.dart
@@ -1,0 +1,110 @@
+import 'package:flutter/material.dart';
+
+import 'package:web3_webview_demo/pages/browser_page.dart';
+import 'package:web3_webview_demo/pages/home_page.dart';
+import 'package:web3_webview_demo/pages/settings_page.dart';
+import 'package:web3_webview_demo/services/bridge_log.dart';
+import 'package:web3_webview_demo/services/wallet_state.dart';
+
+/// Root widget. Hosts the two long-lived services ([WalletState],
+/// [BridgeLog]) at the top of the tree via the matching `*Scope`
+/// [InheritedNotifier]s so every descendant can read or subscribe without
+/// pulling in a third-party state-management package.
+class DemoApp extends StatefulWidget {
+  const DemoApp({
+    super.key,
+    WalletState? walletState,
+    BridgeLog? bridgeLog,
+  })  : _walletState = walletState,
+        _bridgeLog = bridgeLog;
+
+  // Tests inject their own instances so each `pumpWidget` starts from a
+  // known state; production code constructs the defaults in [initState].
+  final WalletState? _walletState;
+  final BridgeLog? _bridgeLog;
+
+  @override
+  State<DemoApp> createState() => _DemoAppState();
+}
+
+class _DemoAppState extends State<DemoApp> {
+  late final WalletState _walletState;
+  late final BridgeLog _bridgeLog;
+
+  @override
+  void initState() {
+    super.initState();
+    _walletState = widget._walletState ?? WalletState();
+    _bridgeLog = widget._bridgeLog ?? BridgeLog();
+  }
+
+  @override
+  void dispose() {
+    if (widget._walletState == null) _walletState.dispose();
+    if (widget._bridgeLog == null) _bridgeLog.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return WalletStateScope(
+      notifier: _walletState,
+      child: BridgeLogScope(
+        notifier: _bridgeLog,
+        child: MaterialApp(
+          title: 'Flutter Web3 WebView Demo',
+          theme: ThemeData(
+            colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
+            useMaterial3: true,
+          ),
+          initialRoute: '/',
+          onGenerateRoute: _onGenerateRoute,
+        ),
+      ),
+    );
+  }
+
+  Route<dynamic>? _onGenerateRoute(RouteSettings settings) {
+    switch (settings.name) {
+      case '/':
+        return MaterialPageRoute(
+          settings: settings,
+          builder: (_) => const HomePage(),
+        );
+      case '/settings':
+        return MaterialPageRoute(
+          settings: settings,
+          builder: (_) => const SettingsPage(),
+        );
+      case '/browser':
+        final args = settings.arguments;
+        if (args is! BrowserPageArgs) {
+          return MaterialPageRoute(
+            settings: settings,
+            builder: (_) => const _RouteErrorPage(
+                message: 'Browser route requires a BrowserPageArgs'),
+          );
+        }
+        return MaterialPageRoute(
+          settings: settings,
+          builder: (_) => BrowserPage(args: args),
+        );
+      default:
+        return null;
+    }
+  }
+}
+
+class _RouteErrorPage extends StatelessWidget {
+  const _RouteErrorPage({required this.message});
+
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Routing error')),
+      body: Center(child: Text(message)),
+    );
+  }
+}

--- a/examples/web3_webview_demo/lib/data/chains.dart
+++ b/examples/web3_webview_demo/lib/data/chains.dart
@@ -1,0 +1,183 @@
+import 'package:flutter/material.dart';
+
+/// Description of an EVM chain the demo knows how to advertise to a DApp.
+///
+/// `chainId` is the canonical EIP-155 numeric id; the demo expresses it as
+/// the integer so `flutter_web3_webview` can hex-encode it on the wire,
+/// matching what the Dart `Web3RequestDispatcher` already does for
+/// `wallet_switchEthereumChain`.
+@immutable
+class EvmChain {
+  /// EIP-155 numeric chain id (e.g. `1` for mainnet, `137` for Polygon).
+  final int chainId;
+
+  /// Short symbol used in compact UI affordances (e.g. `ETH`, `MATIC`).
+  final String symbol;
+
+  /// Human-readable name shown in lists / pickers.
+  final String name;
+
+  /// Default JSON-RPC URL the demo will use when "real broadcast" mode is
+  /// enabled. Public endpoints; expected to be rate-limited.
+  final String rpcUrl;
+
+  /// Block explorer base URL used by the bridge log to deep-link tx hashes.
+  final String explorerUrl;
+
+  /// Material icon shown next to the chain name. We deliberately stick to
+  /// Material icons rather than shipping logo PNGs so the demo stays
+  /// dependency-free.
+  final IconData icon;
+
+  /// Accent colour used by the AppBar chip when this chain is active.
+  final Color color;
+
+  /// Whether this chain is a testnet — used to gate the "real broadcast"
+  /// toggle so we only ever broadcast against test networks.
+  final bool isTestnet;
+
+  const EvmChain({
+    required this.chainId,
+    required this.symbol,
+    required this.name,
+    required this.rpcUrl,
+    required this.explorerUrl,
+    required this.icon,
+    required this.color,
+    this.isTestnet = false,
+  });
+}
+
+/// Description of a Solana cluster.
+@immutable
+class SolanaCluster {
+  /// Identifier used in the wallet-standard `solana:<cluster>` namespace.
+  final String id;
+
+  /// Human-readable name shown in lists.
+  final String name;
+
+  /// Default RPC endpoint.
+  final String rpcUrl;
+
+  final IconData icon;
+  final Color color;
+  final bool isTestnet;
+
+  const SolanaCluster({
+    required this.id,
+    required this.name,
+    required this.rpcUrl,
+    required this.icon,
+    required this.color,
+    this.isTestnet = false,
+  });
+}
+
+/// EVM chains advertised in the demo's chain picker.
+///
+/// Anything not in this list will still work end-to-end (the wallet would
+/// just see the raw chain id flow through), but the picker only surfaces
+/// what we know how to label cleanly.
+const List<EvmChain> kEvmChains = <EvmChain>[
+  EvmChain(
+    chainId: 1,
+    symbol: 'ETH',
+    name: 'Ethereum',
+    rpcUrl: 'https://ethereum-rpc.publicnode.com',
+    explorerUrl: 'https://etherscan.io',
+    icon: Icons.diamond_outlined,
+    color: Color(0xFF627EEA),
+  ),
+  EvmChain(
+    chainId: 137,
+    symbol: 'MATIC',
+    name: 'Polygon',
+    rpcUrl: 'https://polygon-bor-rpc.publicnode.com',
+    explorerUrl: 'https://polygonscan.com',
+    icon: Icons.hexagon_outlined,
+    color: Color(0xFF8247E5),
+  ),
+  EvmChain(
+    chainId: 10,
+    symbol: 'OP',
+    name: 'Optimism',
+    rpcUrl: 'https://optimism-rpc.publicnode.com',
+    explorerUrl: 'https://optimistic.etherscan.io',
+    icon: Icons.bolt_outlined,
+    color: Color(0xFFFF0420),
+  ),
+  EvmChain(
+    chainId: 42161,
+    symbol: 'ARB',
+    name: 'Arbitrum One',
+    rpcUrl: 'https://arbitrum-one-rpc.publicnode.com',
+    explorerUrl: 'https://arbiscan.io',
+    icon: Icons.layers_outlined,
+    color: Color(0xFF28A0F0),
+  ),
+  EvmChain(
+    chainId: 8453,
+    symbol: 'BASE',
+    name: 'Base',
+    rpcUrl: 'https://base-rpc.publicnode.com',
+    explorerUrl: 'https://basescan.org',
+    icon: Icons.foundation,
+    color: Color(0xFF0052FF),
+  ),
+  EvmChain(
+    chainId: 56,
+    symbol: 'BNB',
+    name: 'BNB Smart Chain',
+    rpcUrl: 'https://bsc-rpc.publicnode.com',
+    explorerUrl: 'https://bscscan.com',
+    icon: Icons.local_fire_department_outlined,
+    color: Color(0xFFF3BA2F),
+  ),
+  EvmChain(
+    chainId: 11155111,
+    symbol: 'SEP',
+    name: 'Sepolia (testnet)',
+    rpcUrl: 'https://ethereum-sepolia-rpc.publicnode.com',
+    explorerUrl: 'https://sepolia.etherscan.io',
+    icon: Icons.science_outlined,
+    color: Color(0xFFB388FF),
+    isTestnet: true,
+  ),
+];
+
+/// Solana clusters surfaced in the cluster picker.
+const List<SolanaCluster> kSolanaClusters = <SolanaCluster>[
+  SolanaCluster(
+    id: 'mainnet-beta',
+    name: 'Solana Mainnet',
+    rpcUrl: 'https://api.mainnet-beta.solana.com',
+    icon: Icons.wb_sunny_outlined,
+    color: Color(0xFF9945FF),
+  ),
+  SolanaCluster(
+    id: 'devnet',
+    name: 'Solana Devnet',
+    rpcUrl: 'https://api.devnet.solana.com',
+    icon: Icons.cloud_outlined,
+    color: Color(0xFF14F195),
+    isTestnet: true,
+  ),
+];
+
+/// Lookup helper used by the AppBar chip / settings picker. Falls back to
+/// the mainnet entry when the chain id is unknown so we still render a
+/// recognisable label instead of an empty string.
+EvmChain evmChainById(int chainId) {
+  for (final chain in kEvmChains) {
+    if (chain.chainId == chainId) return chain;
+  }
+  return kEvmChains.first;
+}
+
+SolanaCluster solanaClusterById(String id) {
+  for (final cluster in kSolanaClusters) {
+    if (cluster.id == id) return cluster;
+  }
+  return kSolanaClusters.first;
+}

--- a/examples/web3_webview_demo/lib/data/dapps.dart
+++ b/examples/web3_webview_demo/lib/data/dapps.dart
@@ -1,0 +1,157 @@
+import 'package:flutter/material.dart';
+
+/// Category buckets used to group the bookmark grid.
+enum DAppCategory {
+  defi('DeFi'),
+  nft('NFT'),
+  solana('Solana'),
+  tools('Tools & tests');
+
+  final String label;
+  const DAppCategory(this.label);
+}
+
+/// One bookmark in the home screen's dApp grid.
+///
+/// The icon is a [Material](https://fonts.google.com/icons) glyph rather
+/// than a remote PNG so the demo stays dependency-free and offline-friendly;
+/// the colour roughly matches each project's brand so the grid still looks
+/// distinct at a glance.
+@immutable
+class DAppEntry {
+  final String name;
+  final String url;
+  final DAppCategory category;
+  final IconData icon;
+  final Color color;
+
+  /// One-line blurb shown under the tile.
+  final String description;
+
+  const DAppEntry({
+    required this.name,
+    required this.url,
+    required this.category,
+    required this.icon,
+    required this.color,
+    required this.description,
+  });
+}
+
+/// Curated bookmark catalogue. Intentionally compact — the goal is wide
+/// coverage of the bridge surface (connect / sign / send / chain switch /
+/// Solana wallet-standard) rather than an exhaustive dApp directory.
+const List<DAppEntry> kDAppCatalog = <DAppEntry>[
+  // ── DeFi ───────────────────────────────────────────────────────────
+  DAppEntry(
+    name: 'Uniswap',
+    url: 'https://app.uniswap.org',
+    category: DAppCategory.defi,
+    icon: Icons.currency_exchange,
+    color: Color(0xFFFF007A),
+    description: 'EVM DEX — connect / swap / EIP-712 permit',
+  ),
+  DAppEntry(
+    name: 'Aave',
+    url: 'https://app.aave.com',
+    category: DAppCategory.defi,
+    icon: Icons.savings_outlined,
+    color: Color(0xFFB6509E),
+    description: 'Lending & borrowing on EVM L1 + L2s',
+  ),
+  DAppEntry(
+    name: '1inch',
+    url: 'https://app.1inch.io',
+    category: DAppCategory.defi,
+    icon: Icons.compare_arrows,
+    color: Color(0xFF1B314F),
+    description: 'EVM DEX aggregator',
+  ),
+  DAppEntry(
+    name: 'Curve',
+    url: 'https://curve.fi',
+    category: DAppCategory.defi,
+    icon: Icons.show_chart,
+    color: Color(0xFF40649F),
+    description: 'Stable-asset AMM',
+  ),
+
+  // ── NFT ────────────────────────────────────────────────────────────
+  DAppEntry(
+    name: 'OpenSea',
+    url: 'https://opensea.io',
+    category: DAppCategory.nft,
+    icon: Icons.water,
+    color: Color(0xFF2081E2),
+    description: 'EVM NFT marketplace — personal_sign login',
+  ),
+  DAppEntry(
+    name: 'Blur',
+    url: 'https://blur.io',
+    category: DAppCategory.nft,
+    icon: Icons.blur_on_outlined,
+    color: Color(0xFFFF8700),
+    description: 'NFT marketplace — heavy signTypedData usage',
+  ),
+
+  // ── Solana ─────────────────────────────────────────────────────────
+  DAppEntry(
+    name: 'Jupiter',
+    url: 'https://jup.ag',
+    category: DAppCategory.solana,
+    icon: Icons.public,
+    color: Color(0xFFCFB668),
+    description: 'Solana DEX — wallet-standard connect + signTransaction',
+  ),
+  DAppEntry(
+    name: 'Magic Eden',
+    url: 'https://magiceden.io',
+    category: DAppCategory.solana,
+    icon: Icons.castle_outlined,
+    color: Color(0xFFE42575),
+    description: 'NFT marketplace — Solana + EVM, signMessage login',
+  ),
+  DAppEntry(
+    name: 'Drift',
+    url: 'https://app.drift.trade',
+    category: DAppCategory.solana,
+    icon: Icons.timeline,
+    color: Color(0xFF13C2C2),
+    description: 'Solana perpetuals — multi-sign batched transactions',
+  ),
+
+  // ── Tools & test pages ────────────────────────────────────────────
+  DAppEntry(
+    name: 'MetaMask test dapp',
+    url: 'https://metamask.github.io/test-dapp/',
+    category: DAppCategory.tools,
+    icon: Icons.bug_report_outlined,
+    color: Color(0xFFF6851B),
+    description: 'Every EIP-1193 method in one page — best for regression',
+  ),
+  DAppEntry(
+    name: 'EIP-1193 test',
+    url: 'https://eip1193.org/test',
+    category: DAppCategory.tools,
+    icon: Icons.fact_check_outlined,
+    color: Color(0xFF455A64),
+    description: 'Read-only provider-spec compliance checker',
+  ),
+  DAppEntry(
+    name: 'WalletConnect debug',
+    url: 'https://react-wallet.walletconnect.com',
+    category: DAppCategory.tools,
+    icon: Icons.qr_code_2_outlined,
+    color: Color(0xFF3396FF),
+    description: 'WC v2 sample — exercises eth_sign / sendTransaction paths',
+  ),
+];
+
+/// Convenience grouping for the home grid.
+Map<DAppCategory, List<DAppEntry>> groupedDApps() {
+  final result = <DAppCategory, List<DAppEntry>>{};
+  for (final entry in kDAppCatalog) {
+    result.putIfAbsent(entry.category, () => <DAppEntry>[]).add(entry);
+  }
+  return result;
+}

--- a/examples/web3_webview_demo/lib/main.dart
+++ b/examples/web3_webview_demo/lib/main.dart
@@ -1,82 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_web3_webview/flutter_web3_webview.dart';
 
-void main() async {
+import 'package:web3_webview_demo/app.dart';
+
+Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await Web3Webview.initJs();
 
-  runApp(const MyApp());
-}
-
-class MyApp extends StatelessWidget {
-  const MyApp({super.key});
-
-  // This widget is the root of your application.
-  @override
-  Widget build(BuildContext context) {
-    return MaterialApp(
-      title: 'Flutter Demo',
-      theme: ThemeData(
-        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
-        useMaterial3: true
-      ),
-      home: const Page()
-    );
-  }
-}
-
-class Page extends StatefulWidget {
-  const Page({super.key});
-
-  @override
-  PageState createState() => PageState();
-}
-
-class PageState extends State<Page> {
-  String _title = '';
-  int _chainId = 1;
-
-  String ethAddress = '0x0731fE5077B6aD30E8Cf9eeE3FC4b6D1410702Bb';
-  String ethPrivateKey = '0x56d2380a81a9cdec89159b912cd19f681f51381aab2fd323a87085ab7aa884cc';
-
-  @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(title: Text(_title)),
-      body: Web3Webview(
-        initialUrlRequest: URLRequest(url: WebUri('https://app.uniswap.org')),
-        settings: Web3Settings(
-          eth: Web3EthSettings(
-            chainId: _chainId,
-            rdns: 'com.fxfi.fxwallet'
-          )
-        ),
-        shouldOverrideUrlLoading: (p0, action) async => NavigationActionPolicy.ALLOW,
-        onTitleChanged: _onTitleChanged,
-        ethAccounts: _ethAccounts,
-        ethChainId: _ethChainId,
-        walletSwitchEthereumChain: _walletSwitchEthereumChain
-      )
-    );
-  }
-
-  void _onTitleChanged(InAppWebViewController c, String? value) {
-    if (value == null || value == _title) return;
-
-    _title = value;
-    setState(() { });
-  }
-
-  Future<int> _ethChainId() async {
-    return _chainId;
-  }
-
-  Future<List<String>> _ethAccounts() async {
-    return [ethAddress];
-  }
-
-  Future<bool> _walletSwitchEthereumChain(JsAddEthereumChain data) async {
-    _chainId = int.parse((data.chainId)?.replaceFirst('0x', '') ?? '1', radix: 16);
-    return true;
-  }
+  runApp(const DemoApp());
 }

--- a/examples/web3_webview_demo/lib/pages/browser_page.dart
+++ b/examples/web3_webview_demo/lib/pages/browser_page.dart
@@ -1,0 +1,117 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_web3_webview/flutter_web3_webview.dart';
+
+import 'package:web3_webview_demo/services/wallet_state.dart';
+
+/// Navigation argument carried by the `/browser` route.
+@immutable
+class BrowserPageArgs {
+  final String url;
+  final String title;
+
+  const BrowserPageArgs({required this.url, required this.title});
+}
+
+/// In-WebView dApp page.
+///
+/// Phase 1 only wires the read-only callbacks (`ethAccounts`, `ethChainId`,
+/// `walletSwitchEthereumChain`) end-to-end so the existing `app.uniswap.org`
+/// flow keeps working after the skeleton refactor. The signing / send /
+/// Solana / approval-sheet behaviour ships in Phase 3+.
+class BrowserPage extends StatefulWidget {
+  const BrowserPage({super.key, required this.args});
+
+  final BrowserPageArgs args;
+
+  @override
+  State<BrowserPage> createState() => _BrowserPageState();
+}
+
+class _BrowserPageState extends State<BrowserPage> {
+  String _title = '';
+
+  @override
+  void initState() {
+    super.initState();
+    _title = widget.args.title;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final wallet = WalletStateScope.of(context);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(_title),
+        actions: [
+          _ChainChip(chainId: wallet.evmChainId),
+          const SizedBox(width: 8),
+          _AccountChip(address: wallet.evmAccount.evmAddress),
+          const SizedBox(width: 8),
+        ],
+      ),
+      body: Web3Webview(
+        initialUrlRequest: URLRequest(url: WebUri(widget.args.url)),
+        settings: Web3Settings(
+          eth: Web3EthSettings(
+            chainId: wallet.evmChainId,
+            rdns: 'com.fxfi.fxwallet',
+          ),
+        ),
+        shouldOverrideUrlLoading: (_, __) async =>
+            NavigationActionPolicy.ALLOW,
+        onTitleChanged: _onTitleChanged,
+        ethAccounts: () async => [wallet.evmAccount.evmAddress],
+        ethChainId: () async => wallet.evmChainId,
+        walletSwitchEthereumChain: (JsAddEthereumChain data) async {
+          final hex = (data.chainId ?? '').replaceFirst('0x', '');
+          if (hex.isEmpty) return false;
+          wallet.evmChainId = int.parse(hex, radix: 16);
+          return true;
+        },
+      ),
+    );
+  }
+
+  void _onTitleChanged(InAppWebViewController _, String? value) {
+    if (value == null || value.isEmpty || value == _title) return;
+    setState(() => _title = value);
+  }
+}
+
+class _ChainChip extends StatelessWidget {
+  const _ChainChip({required this.chainId});
+
+  final int chainId;
+
+  @override
+  Widget build(BuildContext context) {
+    final wallet = WalletStateScope.of(context);
+    final chain = wallet.evmChain;
+    return Chip(
+      avatar: Icon(chain.icon, color: chain.color, size: 18),
+      label: Text(chain.symbol),
+      labelPadding: const EdgeInsets.symmetric(horizontal: 4),
+      visualDensity: VisualDensity.compact,
+    );
+  }
+}
+
+class _AccountChip extends StatelessWidget {
+  const _AccountChip({required this.address});
+
+  final String address;
+
+  @override
+  Widget build(BuildContext context) {
+    final short = address.length <= 10
+        ? address
+        : '${address.substring(0, 6)}…${address.substring(address.length - 4)}';
+    return Chip(
+      avatar: const Icon(Icons.account_circle_outlined, size: 18),
+      label: Text(short),
+      labelPadding: const EdgeInsets.symmetric(horizontal: 4),
+      visualDensity: VisualDensity.compact,
+    );
+  }
+}

--- a/examples/web3_webview_demo/lib/pages/home_page.dart
+++ b/examples/web3_webview_demo/lib/pages/home_page.dart
@@ -1,0 +1,156 @@
+import 'package:flutter/material.dart';
+
+import 'package:web3_webview_demo/data/dapps.dart';
+import 'package:web3_webview_demo/pages/browser_page.dart';
+import 'package:web3_webview_demo/services/wallet_state.dart';
+
+/// Bookmark-grid landing page.
+///
+/// The bookmark grid is filled in by Phase 2 — at the skeleton stage the
+/// page only proves that the routing wiring is in place: the `Settings`
+/// destination round-trips, the active-account chip reads from
+/// [WalletState] (and would rebuild on `notifyListeners()`), and the
+/// catalogue groupings come from [groupedDApps] so subsequent phases just
+/// have to render the cards.
+class HomePage extends StatelessWidget {
+  const HomePage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final wallet = WalletStateScope.of(context);
+    final groups = groupedDApps();
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Web3 WebView Demo'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.settings),
+            tooltip: 'Settings',
+            onPressed: () => Navigator.of(context).pushNamed('/settings'),
+          ),
+        ],
+      ),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          _ActiveIdentityCard(wallet: wallet),
+          const SizedBox(height: 16),
+          for (final entry in groups.entries) ...[
+            Text(
+              entry.key.label,
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+            const SizedBox(height: 8),
+            _CategoryRow(entries: entry.value),
+            const SizedBox(height: 24),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+class _ActiveIdentityCard extends StatelessWidget {
+  const _ActiveIdentityCard({required this.wallet});
+
+  final WalletState wallet;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Icon(wallet.evmChain.icon, color: wallet.evmChain.color),
+                const SizedBox(width: 8),
+                Text(wallet.evmChain.name,
+                    style: Theme.of(context).textTheme.titleSmall),
+                const Spacer(),
+                Text(wallet.evmAccount.label,
+                    style: Theme.of(context).textTheme.bodySmall),
+              ],
+            ),
+            const SizedBox(height: 4),
+            Text(
+              '${_short(wallet.evmAccount.evmAddress)} · '
+              'sol:${_short(wallet.solanaAccount.solanaAddress)}',
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    fontFeatures: const [FontFeature.tabularFigures()],
+                  ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  String _short(String address) {
+    if (address.length <= 12) return address;
+    return '${address.substring(0, 6)}…${address.substring(address.length - 4)}';
+  }
+}
+
+class _CategoryRow extends StatelessWidget {
+  const _CategoryRow({required this.entries});
+
+  final List<DAppEntry> entries;
+
+  @override
+  Widget build(BuildContext context) {
+    // Two-column grid; the bookmark tiles get their full rendering in
+    // Phase 2, but skeleton stage exercises the data wiring + navigation
+    // hand-off to the browser page.
+    return GridView.builder(
+      shrinkWrap: true,
+      physics: const NeverScrollableScrollPhysics(),
+      gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+        crossAxisCount: 2,
+        mainAxisSpacing: 12,
+        crossAxisSpacing: 12,
+        childAspectRatio: 2.2,
+      ),
+      itemCount: entries.length,
+      itemBuilder: (context, index) {
+        final entry = entries[index];
+        return Card(
+          color: entry.color.withValues(alpha: 0.08),
+          child: InkWell(
+            onTap: () => Navigator.of(context).pushNamed(
+              '/browser',
+              arguments: BrowserPageArgs(url: entry.url, title: entry.name),
+            ),
+            child: Padding(
+              padding: const EdgeInsets.all(12),
+              child: Row(
+                children: [
+                  Icon(entry.icon, color: entry.color),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(entry.name,
+                            style: Theme.of(context).textTheme.titleSmall),
+                        const SizedBox(height: 2),
+                        Text(entry.description,
+                            style: Theme.of(context).textTheme.bodySmall,
+                            maxLines: 2,
+                            overflow: TextOverflow.ellipsis),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+}
+

--- a/examples/web3_webview_demo/lib/pages/settings_page.dart
+++ b/examples/web3_webview_demo/lib/pages/settings_page.dart
@@ -1,0 +1,165 @@
+// `RadioListTile` here intentionally uses the pre-3.32 `groupValue` /
+// `onChanged` flow. Phase 6 of the demo plan rebuilds this whole screen
+// around the new `RadioGroup` widget along with the auto-approve / real-
+// broadcast switches, so this scoped ignore stays in lock-step with the
+// rewrite rather than churning the file twice.
+// ignore_for_file: deprecated_member_use
+
+import 'package:flutter/material.dart';
+
+import 'package:web3_webview_demo/data/chains.dart';
+import 'package:web3_webview_demo/services/wallet_state.dart';
+
+/// Skeleton settings page.
+///
+/// Phase 6 fills in the auto-approve / real-broadcast toggles plus the
+/// bridge-log viewer; today the page just exposes the picker for the
+/// active EVM account / chain so the rest of the demo has a way to
+/// exercise the `WalletState` listeners and prove the `InheritedNotifier`
+/// rebuild path works.
+class SettingsPage extends StatelessWidget {
+  const SettingsPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final wallet = WalletStateScope.of(context);
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Settings')),
+      body: ListView(
+        children: [
+          const _SectionHeader('Active EVM account'),
+          for (var i = 0; i < kDemoAccounts.length; i++)
+            RadioListTile<int>(
+              value: i,
+              groupValue: wallet.evmAccountIndex,
+              onChanged: (value) {
+                if (value != null) wallet.evmAccountIndex = value;
+              },
+              title: Text(kDemoAccounts[i].label),
+              subtitle: Text(kDemoAccounts[i].evmAddress,
+                  style: const TextStyle(fontFamily: 'monospace')),
+            ),
+
+          const _SectionHeader('Active EVM chain'),
+          for (final chain in kEvmChains)
+            RadioListTile<int>(
+              value: chain.chainId,
+              groupValue: wallet.evmChainId,
+              onChanged: (value) {
+                if (value != null) wallet.evmChainId = value;
+              },
+              title: Row(
+                children: [
+                  Icon(chain.icon, color: chain.color, size: 18),
+                  const SizedBox(width: 8),
+                  Text(chain.name),
+                  const Spacer(),
+                  if (chain.isTestnet)
+                    const Chip(
+                      label: Text('testnet'),
+                      visualDensity: VisualDensity.compact,
+                    ),
+                ],
+              ),
+              subtitle: Text('chainId ${chain.chainId} · ${chain.symbol}'),
+            ),
+
+          const _SectionHeader('Active Solana account'),
+          for (var i = 0; i < kDemoAccounts.length; i++)
+            RadioListTile<int>(
+              value: i,
+              groupValue: wallet.solanaAccountIndex,
+              onChanged: (value) {
+                if (value != null) wallet.solanaAccountIndex = value;
+              },
+              title: Text(kDemoAccounts[i].label),
+              subtitle: Text(kDemoAccounts[i].solanaAddress,
+                  style: const TextStyle(fontFamily: 'monospace')),
+            ),
+
+          const _SectionHeader('Active Solana cluster'),
+          for (final cluster in kSolanaClusters)
+            RadioListTile<String>(
+              value: cluster.id,
+              groupValue: wallet.solanaClusterId,
+              onChanged: (value) {
+                if (value != null) wallet.solanaClusterId = value;
+              },
+              title: Row(
+                children: [
+                  Icon(cluster.icon, color: cluster.color, size: 18),
+                  const SizedBox(width: 8),
+                  Text(cluster.name),
+                  const Spacer(),
+                  if (cluster.isTestnet)
+                    const Chip(
+                      label: Text('devnet'),
+                      visualDensity: VisualDensity.compact,
+                    ),
+                ],
+              ),
+            ),
+
+          const Divider(),
+          const _PendingSection(
+            label: 'Auto-approve read-only methods',
+            description:
+                'Phase 6 — toggles whether eth_accounts / eth_chainId / '
+                'solana_account resolve without a confirmation sheet.',
+          ),
+          const _PendingSection(
+            label: 'Broadcast transactions over RPC',
+            description:
+                'Phase 6 — when enabled (testnets only), eth_sendTransaction '
+                'and Solana signAndSendTransaction will be broadcast through '
+                "the active chain's public endpoint instead of returning a "
+                'mock tx hash.',
+          ),
+          const _PendingSection(
+            label: 'Bridge call log',
+            description:
+                'Phase 3+ — every request the WebView bridge issues plus '
+                'the wallet response will land here so you can reproduce a '
+                'failed DApp interaction by replaying the JSON.',
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _SectionHeader extends StatelessWidget {
+  const _SectionHeader(this.text);
+
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 16, 16, 4),
+      child: Text(text,
+          style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                color: Theme.of(context).colorScheme.primary,
+              )),
+    );
+  }
+}
+
+class _PendingSection extends StatelessWidget {
+  const _PendingSection({required this.label, required this.description});
+
+  final String label;
+  final String description;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      leading: const Icon(Icons.construction, color: Colors.grey),
+      title: Text(label, style: const TextStyle(color: Colors.grey)),
+      subtitle: Text(description,
+          style: const TextStyle(color: Colors.grey, fontSize: 12)),
+      enabled: false,
+    );
+  }
+}

--- a/examples/web3_webview_demo/lib/services/bridge_log.dart
+++ b/examples/web3_webview_demo/lib/services/bridge_log.dart
@@ -1,0 +1,190 @@
+import 'package:flutter/widgets.dart';
+
+/// Outcome of a single bridge call.
+enum BridgeLogStatus {
+  /// Resolved before the response came back — only used while a request is
+  /// still in flight (typically waiting for user approval).
+  pending,
+
+  /// The wallet returned a value (which may be `null`).
+  success,
+
+  /// The wallet rejected the request or the dispatcher threw.
+  error,
+}
+
+/// One round-trip recorded by the Phase 3 Browser-page wiring.
+///
+/// Entries are immutable snapshots; when the status flips from
+/// [BridgeLogStatus.pending] to terminal we add a *new* entry rather than
+/// mutate, so the log naturally renders as an append-only timeline.
+@immutable
+class BridgeLogEntry {
+  /// Monotonically-increasing identifier; pairs a `pending` row with its
+  /// terminal twin so the UI can collapse them or render a thread.
+  final int id;
+
+  /// Method name the DApp sent (`eth_sendTransaction`, `solana_account`,
+  /// `personal_sign`, …). Captured verbatim so we surface anything the
+  /// dispatcher might have missed.
+  final String method;
+
+  /// Wall-clock at the time of capture, used to display "5s ago" hints.
+  final DateTime timestamp;
+
+  /// Request payload as the DApp sent it.
+  final Object? request;
+
+  /// Response (success) or error (error). `null` while pending.
+  final Object? response;
+
+  final BridgeLogStatus status;
+
+  /// Round-trip time in microseconds. `null` for `pending` entries.
+  final int? elapsedMicros;
+
+  const BridgeLogEntry({
+    required this.id,
+    required this.method,
+    required this.timestamp,
+    required this.request,
+    required this.status,
+    this.response,
+    this.elapsedMicros,
+  });
+
+  BridgeLogEntry copyWith({
+    BridgeLogStatus? status,
+    Object? response,
+    int? elapsedMicros,
+  }) {
+    return BridgeLogEntry(
+      id: id,
+      method: method,
+      timestamp: timestamp,
+      request: request,
+      status: status ?? this.status,
+      response: response ?? this.response,
+      elapsedMicros: elapsedMicros ?? this.elapsedMicros,
+    );
+  }
+}
+
+/// In-memory ring buffer of bridge round-trips, surfaced via
+/// `ChangeNotifier` so the debug panel can rebuild on every new entry
+/// without polling.
+///
+/// Capacity defaults to 200 — enough to follow a multi-step DApp flow
+/// without holding signed-tx blobs in memory forever.
+class BridgeLog extends ChangeNotifier {
+  BridgeLog({this.capacity = 200});
+
+  final int capacity;
+
+  final List<BridgeLogEntry> _entries = <BridgeLogEntry>[];
+  int _nextId = 0;
+
+  /// Oldest-first list. The browser-page debug strip reverses this for
+  /// display so the most recent line is on top.
+  List<BridgeLogEntry> get entries => List.unmodifiable(_entries);
+
+  /// Record an in-flight request. Returns the entry id so the caller can
+  /// pair the success / error completion via [resolve] / [reject].
+  int begin({required String method, Object? request}) {
+    final id = _nextId++;
+    _append(BridgeLogEntry(
+      id: id,
+      method: method,
+      timestamp: DateTime.now(),
+      request: request,
+      status: BridgeLogStatus.pending,
+    ));
+    return id;
+  }
+
+  void resolve(int id, {Object? response, Duration? elapsed}) {
+    _complete(id,
+        status: BridgeLogStatus.success,
+        response: response,
+        elapsed: elapsed);
+  }
+
+  void reject(int id, {Object? error, Duration? elapsed}) {
+    _complete(id,
+        status: BridgeLogStatus.error, response: error, elapsed: elapsed);
+  }
+
+  /// Convenience for cases where the resolution happens synchronously
+  /// (e.g. auto-approved read-only methods): records the round-trip in a
+  /// single call.
+  void record({
+    required String method,
+    Object? request,
+    Object? response,
+    Object? error,
+    Duration? elapsed,
+  }) {
+    final id = begin(method: method, request: request);
+    if (error != null) {
+      reject(id, error: error, elapsed: elapsed);
+    } else {
+      resolve(id, response: response, elapsed: elapsed);
+    }
+  }
+
+  void clear() {
+    if (_entries.isEmpty) return;
+    _entries.clear();
+    notifyListeners();
+  }
+
+  void _complete(
+    int id, {
+    required BridgeLogStatus status,
+    Object? response,
+    Duration? elapsed,
+  }) {
+    final index = _entries.lastIndexWhere((e) => e.id == id);
+    if (index < 0) return;
+    final current = _entries[index];
+    _entries[index] = current.copyWith(
+      status: status,
+      response: response,
+      elapsedMicros: elapsed?.inMicroseconds ?? current.elapsedMicros,
+    );
+    notifyListeners();
+  }
+
+  void _append(BridgeLogEntry entry) {
+    _entries.add(entry);
+    while (_entries.length > capacity) {
+      _entries.removeAt(0);
+    }
+    notifyListeners();
+  }
+}
+
+/// Inherited handle for the [BridgeLog], matching the
+/// [WalletStateScope] pattern so widgets reach it through
+/// `BridgeLogScope.of(context)`.
+class BridgeLogScope extends InheritedNotifier<BridgeLog> {
+  const BridgeLogScope({
+    super.key,
+    required BridgeLog super.notifier,
+    required super.child,
+  });
+
+  static BridgeLog of(BuildContext context) {
+    final scope =
+        context.dependOnInheritedWidgetOfExactType<BridgeLogScope>();
+    assert(scope != null, 'BridgeLogScope missing in widget tree');
+    return scope!.notifier!;
+  }
+
+  static BridgeLog read(BuildContext context) {
+    final scope =
+        context.getInheritedWidgetOfExactType<BridgeLogScope>();
+    assert(scope != null, 'BridgeLogScope missing in widget tree');
+    return scope!.notifier!;
+  }
+}

--- a/examples/web3_webview_demo/lib/services/wallet_state.dart
+++ b/examples/web3_webview_demo/lib/services/wallet_state.dart
@@ -1,0 +1,198 @@
+import 'package:flutter/widgets.dart';
+
+import 'package:web3_webview_demo/data/chains.dart';
+
+/// Pre-generated demo wallet identity.
+///
+/// The Phase 4/5 commits replace the placeholder addresses below with real
+/// BIP-39 → BIP-44 → secp256k1 / ed25519 derivations off the well-known
+/// `"test test test test test test test test test test test junk"`
+/// mnemonic. Until then we surface the labels so the UI / chip / picker
+/// affordances can be wired up against a deterministic identity list.
+@immutable
+class DemoAccount {
+  /// Display name shown in pickers ("Account 1", "Account 2", …).
+  final String label;
+
+  /// 0x-prefixed checksummed EVM address.
+  final String evmAddress;
+
+  /// base58 Solana public key.
+  final String solanaAddress;
+
+  /// BIP-44 derivation index (0, 1, 2 …) — exposed so the Phase 4 signer
+  /// can derive the matching private key on demand.
+  final int derivationIndex;
+
+  const DemoAccount({
+    required this.label,
+    required this.evmAddress,
+    required this.solanaAddress,
+    required this.derivationIndex,
+  });
+}
+
+/// The fixed set of demo identities. Three accounts is enough to exercise
+/// the `accountsChanged` / `accountChanged` event flows without making the
+/// picker noisy.
+///
+/// **DO NOT** use these addresses for anything other than the demo. The
+/// BIP-39 mnemonic they derive from is the openly-known
+/// `"test test test test test test test test test test test junk"` phrase
+/// that every Ethereum tooling stack ships as a fixture; any funds sent to
+/// these addresses are immediately drained by the bots that scan for it.
+///
+/// The EVM and Solana addresses below are computed off-tree against that
+/// mnemonic so they stay stable across runs:
+///   * EVM uses BIP-44 path `m/44'/60'/0'/0/<index>`.
+///   * Solana uses BIP-44 path `m/44'/501'/<index>'/0'`.
+const List<DemoAccount> kDemoAccounts = <DemoAccount>[
+  DemoAccount(
+    label: 'Account 1',
+    evmAddress: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
+    solanaAddress: '5ZWj7a1f8tWkjBESHKgrLmZhGh7yBR8Cmjw6aQGhRTMQ',
+    derivationIndex: 0,
+  ),
+  DemoAccount(
+    label: 'Account 2',
+    evmAddress: '0x70997970C51812dc3A010C7d01b50e0d17dc79C8',
+    solanaAddress: 'GwHH8ciFhR8vejWCqmg8FWZUCNtubPY2esALvy5tBvji',
+    derivationIndex: 1,
+  ),
+  DemoAccount(
+    label: 'Account 3',
+    evmAddress: '0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC',
+    solanaAddress: 'FN5sV1iyrnUMtSdaXbq5o24WnTcyJ4MEArytfSe6gE2c',
+    derivationIndex: 2,
+  ),
+];
+
+/// Mutable state shared across the demo (active account, active chain,
+/// approval / broadcast preferences). Surfaces via `ChangeNotifier` so the
+/// UI can rebuild via [InheritedNotifier] — keeps the dependency footprint
+/// at zero third-party state-management packages.
+class WalletState extends ChangeNotifier {
+  WalletState({
+    int evmAccountIndex = 0,
+    int solanaAccountIndex = 0,
+    int evmChainId = 1,
+    String solanaClusterId = 'mainnet-beta',
+    bool autoApproveReadMethods = true,
+    bool realBroadcast = false,
+  })  : _evmAccountIndex = evmAccountIndex,
+        _solanaAccountIndex = solanaAccountIndex,
+        _evmChainId = evmChainId,
+        _solanaClusterId = solanaClusterId,
+        _autoApproveReadMethods = autoApproveReadMethods,
+        _realBroadcast = realBroadcast;
+
+  int _evmAccountIndex;
+  int _solanaAccountIndex;
+  int _evmChainId;
+  String _solanaClusterId;
+  bool _autoApproveReadMethods;
+  bool _realBroadcast;
+
+  /// Currently selected EVM account.
+  DemoAccount get evmAccount => kDemoAccounts[_evmAccountIndex];
+
+  /// Currently selected Solana account. The demo lets the user switch the
+  /// EVM and Solana accounts independently so the bridge log can show
+  /// `accountsChanged` (EIP-1193) and `accountChanged` (wallet-standard)
+  /// events firing on their own schedules.
+  DemoAccount get solanaAccount => kDemoAccounts[_solanaAccountIndex];
+
+  int get evmAccountIndex => _evmAccountIndex;
+  int get solanaAccountIndex => _solanaAccountIndex;
+
+  /// Active EVM chain id (decimal).
+  int get evmChainId => _evmChainId;
+
+  EvmChain get evmChain => evmChainById(_evmChainId);
+
+  /// Active Solana cluster id (`mainnet-beta`, `devnet`, …).
+  String get solanaClusterId => _solanaClusterId;
+
+  SolanaCluster get solanaCluster => solanaClusterById(_solanaClusterId);
+
+  /// When true, read-only RPC methods (`eth_accounts`, `eth_chainId`,
+  /// `solana_account`) resolve immediately from this state without an
+  /// approval dialog. Signing / sending / chain-switch requests always
+  /// require manual confirmation regardless.
+  bool get autoApproveReadMethods => _autoApproveReadMethods;
+
+  /// When true, `eth_sendTransaction` and `solana_signAndSendTransaction`
+  /// broadcast through the configured RPC endpoint instead of returning a
+  /// mock tx hash. Only ever flipped on for testnets in the Phase 4/5
+  /// settings UI — gating logic lives there so this flag stays a simple
+  /// boolean.
+  bool get realBroadcast => _realBroadcast;
+
+  set evmAccountIndex(int value) {
+    if (value < 0 || value >= kDemoAccounts.length) return;
+    if (value == _evmAccountIndex) return;
+    _evmAccountIndex = value;
+    notifyListeners();
+  }
+
+  set solanaAccountIndex(int value) {
+    if (value < 0 || value >= kDemoAccounts.length) return;
+    if (value == _solanaAccountIndex) return;
+    _solanaAccountIndex = value;
+    notifyListeners();
+  }
+
+  set evmChainId(int value) {
+    if (value == _evmChainId) return;
+    _evmChainId = value;
+    notifyListeners();
+  }
+
+  set solanaClusterId(String value) {
+    if (value == _solanaClusterId) return;
+    _solanaClusterId = value;
+    notifyListeners();
+  }
+
+  set autoApproveReadMethods(bool value) {
+    if (value == _autoApproveReadMethods) return;
+    _autoApproveReadMethods = value;
+    notifyListeners();
+  }
+
+  set realBroadcast(bool value) {
+    if (value == _realBroadcast) return;
+    _realBroadcast = value;
+    notifyListeners();
+  }
+}
+
+/// Inherited handle for [WalletState]. Pages call
+/// `WalletStateScope.of(context)` to read the current state (and trigger
+/// rebuilds), or `WalletStateScope.read(context)` for one-shot reads that
+/// should *not* re-subscribe.
+class WalletStateScope extends InheritedNotifier<WalletState> {
+  const WalletStateScope({
+    super.key,
+    required WalletState super.notifier,
+    required super.child,
+  });
+
+  /// Subscribing read: the calling widget rebuilds whenever
+  /// [WalletState] notifies. Throws in debug if no scope is in the tree.
+  static WalletState of(BuildContext context) {
+    final scope =
+        context.dependOnInheritedWidgetOfExactType<WalletStateScope>();
+    assert(scope != null, 'WalletStateScope missing in widget tree');
+    return scope!.notifier!;
+  }
+
+  /// Non-subscribing read for one-shot lookups inside callbacks / async
+  /// handlers where re-running on every change would be wrong.
+  static WalletState read(BuildContext context) {
+    final scope =
+        context.getInheritedWidgetOfExactType<WalletStateScope>();
+    assert(scope != null, 'WalletStateScope missing in widget tree');
+    return scope!.notifier!;
+  }
+}

--- a/examples/web3_webview_demo/pubspec.lock
+++ b/examples/web3_webview_demo/pubspec.lock
@@ -21,10 +21,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   clock:
     dependency: transitive
     description:
@@ -203,18 +203,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
@@ -296,10 +296,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.10"
   typed_data:
     dependency: transitive
     description:
@@ -341,5 +341,5 @@ packages:
     source: hosted
     version: "1.1.1"
 sdks:
-  dart: ">=3.8.0-0 <4.0.0"
+  dart: ">=3.9.0-0 <4.0.0"
   flutter: ">=3.24.0"

--- a/examples/web3_webview_demo/test/home_page_test.dart
+++ b/examples/web3_webview_demo/test/home_page_test.dart
@@ -1,0 +1,77 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:web3_webview_demo/app.dart';
+import 'package:web3_webview_demo/data/chains.dart';
+import 'package:web3_webview_demo/data/dapps.dart';
+import 'package:web3_webview_demo/services/wallet_state.dart';
+
+void main() {
+  group('HomePage', () {
+    testWidgets('renders the active identity card on first paint',
+        (tester) async {
+      final wallet = WalletState();
+      addTearDown(wallet.dispose);
+
+      await tester.pumpWidget(DemoApp(walletState: wallet));
+      await tester.pumpAndSettle();
+
+      expect(find.text(kDemoAccounts.first.label), findsOneWidget);
+      expect(find.text('Ethereum'), findsOneWidget);
+    });
+
+    testWidgets('settings gear pushes the settings page', (tester) async {
+      final wallet = WalletState();
+      addTearDown(wallet.dispose);
+
+      await tester.pumpWidget(DemoApp(walletState: wallet));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Web3 WebView Demo'), findsOneWidget);
+      await tester.tap(find.byTooltip('Settings'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Settings'), findsOneWidget);
+      expect(find.text('Active EVM chain'), findsOneWidget);
+    });
+
+    testWidgets(
+      'WalletState changes propagate via InheritedNotifier without third-party state',
+      (tester) async {
+        final wallet = WalletState();
+        addTearDown(wallet.dispose);
+
+        await tester.pumpWidget(DemoApp(walletState: wallet));
+        await tester.pumpAndSettle();
+
+        // Default chain is Ethereum (chainId 1).
+        expect(find.textContaining('Ethereum'), findsOneWidget);
+
+        // Switch to Polygon and confirm the home card rebuilds.
+        wallet.evmChainId = 137;
+        await tester.pumpAndSettle();
+        expect(find.textContaining('Polygon'), findsOneWidget);
+      },
+    );
+  });
+
+  group('chain + dapp registries', () {
+    test('every kEvmChains entry has a unique chainId', () {
+      final ids = kEvmChains.map((c) => c.chainId).toList();
+      expect(ids.toSet().length, ids.length);
+    });
+
+    test('every kDAppCatalog entry has a non-empty URL and a known scheme',
+        () {
+      for (final dapp in kDAppCatalog) {
+        expect(dapp.url, isNotEmpty, reason: dapp.name);
+        final uri = Uri.parse(dapp.url);
+        expect(uri.hasScheme, isTrue, reason: dapp.name);
+        expect(uri.scheme, anyOf('http', 'https'), reason: dapp.name);
+      }
+    });
+
+    test('evmChainById falls back to mainnet for unknown ids', () {
+      expect(evmChainById(99999).chainId, kEvmChains.first.chainId);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

First slice of the comprehensive `examples/web3_webview_demo` plan. Restructures the demo around a zero-dependency state layer (`ChangeNotifier` + `InheritedNotifier` — no provider / riverpod), a bookmark-grid landing page, and a settings page with account / chain pickers. Existing Uniswap-style read-only flow keeps working.

Signing, approval sheets, real broadcast, and the bridge-log viewer ship in subsequent phases.

## Layout

```
lib/
├── main.dart            # entrypoint
├── app.dart             # MaterialApp + named routes + service scopes
├── data/
│   ├── chains.dart      # 7 EVM chains + 2 Solana clusters
│   └── dapps.dart       # 12 DApps grouped into 4 categories
├── services/
│   ├── wallet_state.dart  # active account / chain / settings
│   └── bridge_log.dart    # ring-buffer log of bridge round-trips
└── pages/
    ├── home_page.dart      # bookmark grid + identity card
    ├── browser_page.dart   # Web3Webview + chain / account chips
    └── settings_page.dart  # account + chain picker (+ Phase 6 placeholders)
```

## Test plan

- [x] `flutter analyze` — no issues
- [x] `flutter test` — 6/6 passing
  - HomePage renders the active identity card on first paint
  - Settings gear pushes the settings page
  - `WalletState` changes propagate via `InheritedNotifier` without third-party state
  - Every `kEvmChains` entry has a unique chainId
  - Every `kDAppCatalog` entry has a valid http(s) URL
  - `evmChainById` falls back to mainnet for unknown ids
- [ ] Manual smoke: `flutter run` from `examples/web3_webview_demo` boots into the bookmark grid; tapping Uniswap loads it in a `Web3Webview` with the EVM chain / account chips populated; Settings round-trips and switching the active chain updates the home card live.

## Roadmap

| Phase | What it adds | Status |
|------:|--------------|--------|
| **1** | this PR — skeleton + state + bookmark grid + picker | ✅ |
| 2 | bookmark polish + custom URL + recent-DApp memory | ☐ |
| 3 | full callback wiring + approval bottom-sheet + bridge log capture | ☐ |
| 4 | EVM signing (`web3dart 3.0.2`) + mock/real-broadcast toggle | ☐ |
| 5 | Solana signing (`cryptography` + `bs58`, self-rolled) | ☐ |
| 6 | Auto-approve / real-broadcast switches + bridge-log viewer | ☐ |
| 7 | README screenshots + manual regression checklist + more widget tests | ☐ |

## Notes

- Demo identities use the well-known `"test test test … junk"` mnemonic. `wallet_state.dart` explicitly warns that any funds sent to those addresses are swept by bots that scan for the phrase. Real key derivation lands in Phase 4 / 5.
- `BridgeLog` is wired up but unused — Phase 3 starts recording every `Web3Webview` callback invocation into it.
- `SettingsPage`'s auto-approve / real-broadcast / log toggles render as disabled placeholders so the surface is visible before Phase 6 fills them in.