### PR TITLE
feat(demo): custom URL bar, search, recent visits (Phase 2)

### DIFF
--- a/examples/web3_webview_demo/README.md
+++ b/examples/web3_webview_demo/README.md
@@ -22,8 +22,8 @@ reviewable.
 
 | Phase | What it adds | Status |
 |------:|--------------|--------|
-| **1** | App shell + zero-dep state mgmt + bookmark grid + chain / account pickers (placeholders for signing / approval / log) | ✅ this commit |
-| 2 | Bookmark grid polish, custom-URL entry, recent-DApp memory | ☐ |
+| **1** | App shell + zero-dep state mgmt + bookmark grid + chain / account pickers (placeholders for signing / approval / log) | ✅ |
+| **2** | Custom-URL bar, live bookmark search, in-memory recent-visit row | ✅ this commit |
 | 3 | Full `Web3Webview` callback wiring + approval bottom-sheet + bridge log capture | ☐ |
 | 4 | EVM signing (`web3dart`): `personal_sign`, `eth_signTypedData_v3/v4`, `eth_sendTransaction` (mock hash by default, real broadcast on toggle) | ☐ |
 | 5 | Solana signing (`cryptography` + `bs58`): `solana_signMessage`, `solana_signTransaction` | ☐ |
@@ -63,14 +63,18 @@ lib/
 ├── data/
 │   ├── chains.dart      # EVM chains + Solana clusters catalogue
 │   └── dapps.dart       # bookmark catalogue grouped by category
+├── data/
+│   └── url_utils.dart   # custom-URL normalisation + host labelling
 ├── services/
-│   ├── wallet_state.dart # ChangeNotifier — active account / chain / settings
-│   └── bridge_log.dart   # ring-buffer log of bridge round-trips
+│   ├── wallet_state.dart   # ChangeNotifier — active account / chain / settings
+│   ├── bridge_log.dart     # ring-buffer log of bridge round-trips
+│   └── recent_visits.dart  # in-memory MRU of opened DApps
 ├── pages/
-│   ├── home_page.dart   # bookmark grid + active-identity card
+│   ├── home_page.dart   # URL bar + search + recent row + bookmark grid
 │   ├── browser_page.dart # Web3Webview + AppBar chain / account chips
 │   └── settings_page.dart # account / chain picker + (pending) toggles
-└── widgets/             # filled in by Phase 3+
+└── widgets/
+    └── dapp_bookmark_grid.dart # reusable grid + tile + filter helper
 ```
 
 State propagates through `InheritedNotifier`-backed scopes

--- a/examples/web3_webview_demo/lib/app.dart
+++ b/examples/web3_webview_demo/lib/app.dart
@@ -4,6 +4,7 @@ import 'package:web3_webview_demo/pages/browser_page.dart';
 import 'package:web3_webview_demo/pages/home_page.dart';
 import 'package:web3_webview_demo/pages/settings_page.dart';
 import 'package:web3_webview_demo/services/bridge_log.dart';
+import 'package:web3_webview_demo/services/recent_visits.dart';
 import 'package:web3_webview_demo/services/wallet_state.dart';
 
 /// Root widget. Hosts the two long-lived services ([WalletState],
@@ -15,13 +16,16 @@ class DemoApp extends StatefulWidget {
     super.key,
     WalletState? walletState,
     BridgeLog? bridgeLog,
+    RecentVisits? recentVisits,
   })  : _walletState = walletState,
-        _bridgeLog = bridgeLog;
+        _bridgeLog = bridgeLog,
+        _recentVisits = recentVisits;
 
   // Tests inject their own instances so each `pumpWidget` starts from a
   // known state; production code constructs the defaults in [initState].
   final WalletState? _walletState;
   final BridgeLog? _bridgeLog;
+  final RecentVisits? _recentVisits;
 
   @override
   State<DemoApp> createState() => _DemoAppState();
@@ -30,18 +34,21 @@ class DemoApp extends StatefulWidget {
 class _DemoAppState extends State<DemoApp> {
   late final WalletState _walletState;
   late final BridgeLog _bridgeLog;
+  late final RecentVisits _recentVisits;
 
   @override
   void initState() {
     super.initState();
     _walletState = widget._walletState ?? WalletState();
     _bridgeLog = widget._bridgeLog ?? BridgeLog();
+    _recentVisits = widget._recentVisits ?? RecentVisits();
   }
 
   @override
   void dispose() {
     if (widget._walletState == null) _walletState.dispose();
     if (widget._bridgeLog == null) _bridgeLog.dispose();
+    if (widget._recentVisits == null) _recentVisits.dispose();
     super.dispose();
   }
 
@@ -51,14 +58,17 @@ class _DemoAppState extends State<DemoApp> {
       notifier: _walletState,
       child: BridgeLogScope(
         notifier: _bridgeLog,
-        child: MaterialApp(
-          title: 'Flutter Web3 WebView Demo',
-          theme: ThemeData(
-            colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
-            useMaterial3: true,
+        child: RecentVisitsScope(
+          notifier: _recentVisits,
+          child: MaterialApp(
+            title: 'Flutter Web3 WebView Demo',
+            theme: ThemeData(
+              colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
+              useMaterial3: true,
+            ),
+            initialRoute: '/',
+            onGenerateRoute: _onGenerateRoute,
           ),
-          initialRoute: '/',
-          onGenerateRoute: _onGenerateRoute,
         ),
       ),
     );

--- a/examples/web3_webview_demo/lib/data/url_utils.dart
+++ b/examples/web3_webview_demo/lib/data/url_utils.dart
@@ -1,0 +1,47 @@
+/// Normalises whatever the user typed in the custom-URL bar into a
+/// loadable `https://` (or `http://`) URL, or returns `null` if the input
+/// can't be coerced into something sensible.
+///
+/// Rules:
+///   * blank input → `null`
+///   * already has an http/https scheme → trimmed as-is
+///   * has some *other* scheme (ftp:, javascript:, …) → rejected (`null`)
+///     so the demo never hands the WebView a non-web URL
+///   * looks like a bare host / host+path (`uniswap.org`,
+///     `app.uniswap.org/swap`) → prefixed with `https://`
+///   * a single word with no dot (`uniswap`) → treated as a search-ish
+///     host is *not* assumed; returns `null` so the caller can show an
+///     error rather than navigate somewhere surprising
+String? normalizeDAppUrl(String raw) {
+  final input = raw.trim();
+  if (input.isEmpty) return null;
+
+  final lower = input.toLowerCase();
+
+  if (lower.startsWith('http://') || lower.startsWith('https://')) {
+    final uri = Uri.tryParse(input);
+    if (uri == null || uri.host.isEmpty) return null;
+    return input;
+  }
+
+  // Reject any other explicit scheme — only web URLs belong in the WebView.
+  final schemeMatch = RegExp(r'^[a-zA-Z][a-zA-Z0-9+.-]*:').firstMatch(input);
+  if (schemeMatch != null) return null;
+
+  // Bare host / host+path. Require at least one dot so we don't navigate
+  // to single-word junk; the host part must parse cleanly.
+  if (!input.contains('.')) return null;
+
+  final candidate = 'https://$input';
+  final uri = Uri.tryParse(candidate);
+  if (uri == null || uri.host.isEmpty || !uri.host.contains('.')) return null;
+  return candidate;
+}
+
+/// Best-effort display label for a URL — the host without a leading
+/// `www.`, used as the initial title before the page reports its own.
+String hostLabel(String url) {
+  final uri = Uri.tryParse(url);
+  final host = uri?.host ?? url;
+  return host.startsWith('www.') ? host.substring(4) : host;
+}

--- a/examples/web3_webview_demo/lib/pages/home_page.dart
+++ b/examples/web3_webview_demo/lib/pages/home_page.dart
@@ -1,24 +1,59 @@
 import 'package:flutter/material.dart';
 
 import 'package:web3_webview_demo/data/dapps.dart';
+import 'package:web3_webview_demo/data/url_utils.dart';
 import 'package:web3_webview_demo/pages/browser_page.dart';
+import 'package:web3_webview_demo/services/recent_visits.dart';
 import 'package:web3_webview_demo/services/wallet_state.dart';
+import 'package:web3_webview_demo/widgets/dapp_bookmark_grid.dart';
 
 /// Bookmark-grid landing page.
 ///
-/// The bookmark grid is filled in by Phase 2 — at the skeleton stage the
-/// page only proves that the routing wiring is in place: the `Settings`
-/// destination round-trips, the active-account chip reads from
-/// [WalletState] (and would rebuild on `notifyListeners()`), and the
-/// catalogue groupings come from [groupedDApps] so subsequent phases just
-/// have to render the cards.
-class HomePage extends StatelessWidget {
+/// Phase 2 adds the custom-URL bar, live search filtering, and a
+/// recently-opened row. Tapping any bookmark / recent / typed URL routes
+/// to the [BrowserPage] and records the visit in [RecentVisits].
+class HomePage extends StatefulWidget {
   const HomePage({super.key});
+
+  @override
+  State<HomePage> createState() => _HomePageState();
+}
+
+class _HomePageState extends State<HomePage> {
+  final TextEditingController _urlController = TextEditingController();
+  final TextEditingController _searchController = TextEditingController();
+  String _searchQuery = '';
+  String? _urlError;
+
+  @override
+  void dispose() {
+    _urlController.dispose();
+    _searchController.dispose();
+    super.dispose();
+  }
+
+  void _openUrl(String url, String title) {
+    RecentVisitsScope.read(context).record(url: url, title: title);
+    Navigator.of(context).pushNamed(
+      '/browser',
+      arguments: BrowserPageArgs(url: url, title: title),
+    );
+  }
+
+  void _submitCustomUrl() {
+    final normalized = normalizeDAppUrl(_urlController.text);
+    if (normalized == null) {
+      setState(() => _urlError = 'Enter a valid http(s) URL or host');
+      return;
+    }
+    setState(() => _urlError = null);
+    _openUrl(normalized, hostLabel(normalized));
+  }
 
   @override
   Widget build(BuildContext context) {
     final wallet = WalletStateScope.of(context);
-    final groups = groupedDApps();
+    final searching = _searchQuery.trim().isNotEmpty;
 
     return Scaffold(
       appBar: AppBar(
@@ -36,17 +71,179 @@ class HomePage extends StatelessWidget {
         children: [
           _ActiveIdentityCard(wallet: wallet),
           const SizedBox(height: 16),
-          for (final entry in groups.entries) ...[
-            Text(
-              entry.key.label,
-              style: Theme.of(context).textTheme.titleMedium,
-            ),
-            const SizedBox(height: 8),
-            _CategoryRow(entries: entry.value),
-            const SizedBox(height: 24),
-          ],
+          _CustomUrlBar(
+            controller: _urlController,
+            errorText: _urlError,
+            onSubmit: _submitCustomUrl,
+          ),
+          const SizedBox(height: 12),
+          _SearchField(
+            controller: _searchController,
+            onChanged: (value) => setState(() => _searchQuery = value),
+          ),
+          const SizedBox(height: 16),
+          if (!searching) ...[
+            _RecentRow(onOpen: _openUrl),
+            ..._buildGroupedSections(),
+          ] else
+            _buildSearchResults(),
         ],
       ),
+    );
+  }
+
+  List<Widget> _buildGroupedSections() {
+    final groups = groupedDApps();
+    final widgets = <Widget>[];
+    for (final entry in groups.entries) {
+      widgets.add(Padding(
+        padding: const EdgeInsets.only(top: 8, bottom: 8),
+        child: Text(entry.key.label,
+            style: Theme.of(context).textTheme.titleMedium),
+      ));
+      widgets.add(DAppBookmarkGrid(
+        entries: entry.value,
+        onTap: (e) => _openUrl(e.url, e.name),
+      ));
+      widgets.add(const SizedBox(height: 16));
+    }
+    return widgets;
+  }
+
+  Widget _buildSearchResults() {
+    final results = filterDApps(_searchQuery);
+    if (results.isEmpty) {
+      return Padding(
+        padding: const EdgeInsets.symmetric(vertical: 32),
+        child: Center(
+          child: Text('No dApps match "${_searchQuery.trim()}"',
+              style: Theme.of(context).textTheme.bodyMedium),
+        ),
+      );
+    }
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Padding(
+          padding: const EdgeInsets.only(bottom: 8),
+          child: Text('${results.length} result(s)',
+              style: Theme.of(context).textTheme.titleMedium),
+        ),
+        DAppBookmarkGrid(
+          entries: results,
+          onTap: (e) => _openUrl(e.url, e.name),
+        ),
+      ],
+    );
+  }
+}
+
+class _CustomUrlBar extends StatelessWidget {
+  const _CustomUrlBar({
+    required this.controller,
+    required this.errorText,
+    required this.onSubmit,
+  });
+
+  final TextEditingController controller;
+  final String? errorText;
+  final VoidCallback onSubmit;
+
+  @override
+  Widget build(BuildContext context) {
+    return TextField(
+      controller: controller,
+      keyboardType: TextInputType.url,
+      autocorrect: false,
+      textInputAction: TextInputAction.go,
+      onSubmitted: (_) => onSubmit(),
+      decoration: InputDecoration(
+        labelText: 'Open a custom URL',
+        hintText: 'app.uniswap.org  or  https://…',
+        errorText: errorText,
+        prefixIcon: const Icon(Icons.public),
+        suffixIcon: IconButton(
+          icon: const Icon(Icons.arrow_forward),
+          tooltip: 'Open',
+          onPressed: onSubmit,
+        ),
+        border: const OutlineInputBorder(),
+      ),
+    );
+  }
+}
+
+class _SearchField extends StatelessWidget {
+  const _SearchField({required this.controller, required this.onChanged});
+
+  final TextEditingController controller;
+  final ValueChanged<String> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return TextField(
+      controller: controller,
+      onChanged: onChanged,
+      decoration: InputDecoration(
+        labelText: 'Search bookmarks',
+        prefixIcon: const Icon(Icons.search),
+        suffixIcon: controller.text.isEmpty
+            ? null
+            : IconButton(
+                icon: const Icon(Icons.clear),
+                onPressed: () {
+                  controller.clear();
+                  onChanged('');
+                },
+              ),
+        border: const OutlineInputBorder(),
+      ),
+    );
+  }
+}
+
+class _RecentRow extends StatelessWidget {
+  const _RecentRow({required this.onOpen});
+
+  final void Function(String url, String title) onOpen;
+
+  @override
+  Widget build(BuildContext context) {
+    final recent = RecentVisitsScope.of(context);
+    if (recent.isEmpty) return const SizedBox.shrink();
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          children: [
+            Text('Recent', style: Theme.of(context).textTheme.titleMedium),
+            const Spacer(),
+            TextButton(
+              onPressed: recent.clear,
+              child: const Text('Clear'),
+            ),
+          ],
+        ),
+        const SizedBox(height: 4),
+        SizedBox(
+          height: 40,
+          child: ListView.separated(
+            scrollDirection: Axis.horizontal,
+            itemCount: recent.visits.length,
+            separatorBuilder: (_, __) => const SizedBox(width: 8),
+            itemBuilder: (context, index) {
+              final visit = recent.visits[index];
+              return ActionChip(
+                avatar: const Icon(Icons.history, size: 18),
+                label: Text(visit.title),
+                onPressed: () => onOpen(visit.url, visit.title),
+              );
+            },
+          ),
+        ),
+        const SizedBox(height: 16),
+      ],
     );
   }
 }
@@ -94,63 +291,3 @@ class _ActiveIdentityCard extends StatelessWidget {
     return '${address.substring(0, 6)}…${address.substring(address.length - 4)}';
   }
 }
-
-class _CategoryRow extends StatelessWidget {
-  const _CategoryRow({required this.entries});
-
-  final List<DAppEntry> entries;
-
-  @override
-  Widget build(BuildContext context) {
-    // Two-column grid; the bookmark tiles get their full rendering in
-    // Phase 2, but skeleton stage exercises the data wiring + navigation
-    // hand-off to the browser page.
-    return GridView.builder(
-      shrinkWrap: true,
-      physics: const NeverScrollableScrollPhysics(),
-      gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
-        crossAxisCount: 2,
-        mainAxisSpacing: 12,
-        crossAxisSpacing: 12,
-        childAspectRatio: 2.2,
-      ),
-      itemCount: entries.length,
-      itemBuilder: (context, index) {
-        final entry = entries[index];
-        return Card(
-          color: entry.color.withValues(alpha: 0.08),
-          child: InkWell(
-            onTap: () => Navigator.of(context).pushNamed(
-              '/browser',
-              arguments: BrowserPageArgs(url: entry.url, title: entry.name),
-            ),
-            child: Padding(
-              padding: const EdgeInsets.all(12),
-              child: Row(
-                children: [
-                  Icon(entry.icon, color: entry.color),
-                  const SizedBox(width: 12),
-                  Expanded(
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Text(entry.name,
-                            style: Theme.of(context).textTheme.titleSmall),
-                        const SizedBox(height: 2),
-                        Text(entry.description,
-                            style: Theme.of(context).textTheme.bodySmall,
-                            maxLines: 2,
-                            overflow: TextOverflow.ellipsis),
-                      ],
-                    ),
-                  ),
-                ],
-              ),
-            ),
-          ),
-        );
-      },
-    );
-  }
-}
-

--- a/examples/web3_webview_demo/lib/services/recent_visits.dart
+++ b/examples/web3_webview_demo/lib/services/recent_visits.dart
@@ -1,0 +1,85 @@
+import 'package:flutter/widgets.dart';
+
+/// A single entry in the "recently opened" list.
+@immutable
+class RecentVisit {
+  final String url;
+  final String title;
+  final DateTime visitedAt;
+
+  const RecentVisit({
+    required this.url,
+    required this.title,
+    required this.visitedAt,
+  });
+}
+
+/// In-memory most-recently-used list of opened DApps.
+///
+/// Kept in memory only (no `shared_preferences` dependency) so the demo
+/// stays free of platform-channel setup — the list resets on restart,
+/// which is fine for a within-session "jump back to what I was testing"
+/// affordance. If persistence is ever wanted, swapping the backing store
+/// here is the only change needed; the `*Scope` contract stays the same.
+class RecentVisits extends ChangeNotifier {
+  RecentVisits({this.capacity = 8});
+
+  final int capacity;
+  final List<RecentVisit> _visits = <RecentVisit>[];
+
+  /// Most-recent-first snapshot.
+  List<RecentVisit> get visits => List.unmodifiable(_visits);
+
+  bool get isEmpty => _visits.isEmpty;
+
+  /// Record a visit. If the URL is already present it is moved to the
+  /// front (and its title refreshed) rather than duplicated, so the list
+  /// behaves like a browser history MRU.
+  void record({required String url, required String title}) {
+    final normalized = url.trim();
+    if (normalized.isEmpty) return;
+
+    _visits.removeWhere((v) => v.url == normalized);
+    _visits.insert(
+      0,
+      RecentVisit(
+        url: normalized,
+        title: title.trim().isEmpty ? normalized : title.trim(),
+        visitedAt: DateTime.now(),
+      ),
+    );
+    while (_visits.length > capacity) {
+      _visits.removeLast();
+    }
+    notifyListeners();
+  }
+
+  void clear() {
+    if (_visits.isEmpty) return;
+    _visits.clear();
+    notifyListeners();
+  }
+}
+
+/// Inherited handle for [RecentVisits], matching the other service scopes.
+class RecentVisitsScope extends InheritedNotifier<RecentVisits> {
+  const RecentVisitsScope({
+    super.key,
+    required RecentVisits super.notifier,
+    required super.child,
+  });
+
+  static RecentVisits of(BuildContext context) {
+    final scope =
+        context.dependOnInheritedWidgetOfExactType<RecentVisitsScope>();
+    assert(scope != null, 'RecentVisitsScope missing in widget tree');
+    return scope!.notifier!;
+  }
+
+  static RecentVisits read(BuildContext context) {
+    final scope =
+        context.getInheritedWidgetOfExactType<RecentVisitsScope>();
+    assert(scope != null, 'RecentVisitsScope missing in widget tree');
+    return scope!.notifier!;
+  }
+}

--- a/examples/web3_webview_demo/lib/widgets/dapp_bookmark_grid.dart
+++ b/examples/web3_webview_demo/lib/widgets/dapp_bookmark_grid.dart
@@ -1,0 +1,97 @@
+import 'package:flutter/material.dart';
+
+import 'package:web3_webview_demo/data/dapps.dart';
+
+/// Two-column bookmark grid for one category. Pulled out of the home page
+/// so Phase 2's search filtering can reuse the same tile rendering for
+/// both the grouped and the flat (search-results) layouts.
+class DAppBookmarkGrid extends StatelessWidget {
+  const DAppBookmarkGrid({
+    super.key,
+    required this.entries,
+    required this.onTap,
+  });
+
+  final List<DAppEntry> entries;
+  final void Function(DAppEntry entry) onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return GridView.builder(
+      shrinkWrap: true,
+      physics: const NeverScrollableScrollPhysics(),
+      gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+        crossAxisCount: 2,
+        mainAxisSpacing: 12,
+        crossAxisSpacing: 12,
+        childAspectRatio: 2.2,
+      ),
+      itemCount: entries.length,
+      itemBuilder: (context, index) => DAppBookmarkTile(
+        entry: entries[index],
+        onTap: () => onTap(entries[index]),
+      ),
+    );
+  }
+}
+
+/// One bookmark card.
+class DAppBookmarkTile extends StatelessWidget {
+  const DAppBookmarkTile({
+    super.key,
+    required this.entry,
+    required this.onTap,
+  });
+
+  final DAppEntry entry;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      color: entry.color.withValues(alpha: 0.08),
+      child: InkWell(
+        onTap: onTap,
+        child: Padding(
+          padding: const EdgeInsets.all(12),
+          child: Row(
+            children: [
+              Icon(entry.icon, color: entry.color),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    Text(entry.name,
+                        style: Theme.of(context).textTheme.titleSmall),
+                    const SizedBox(height: 2),
+                    Text(entry.description,
+                        style: Theme.of(context).textTheme.bodySmall,
+                        maxLines: 2,
+                        overflow: TextOverflow.ellipsis),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Case-insensitive substring filter over name + description + host.
+/// Lives next to the grid so the home page and any future search surface
+/// share the exact same matching rules.
+List<DAppEntry> filterDApps(String query) {
+  final q = query.trim().toLowerCase();
+  if (q.isEmpty) return kDAppCatalog;
+  return kDAppCatalog.where((entry) {
+    final host = Uri.tryParse(entry.url)?.host ?? '';
+    return entry.name.toLowerCase().contains(q) ||
+        entry.description.toLowerCase().contains(q) ||
+        host.toLowerCase().contains(q) ||
+        entry.category.label.toLowerCase().contains(q);
+  }).toList();
+}

--- a/examples/web3_webview_demo/test/home_polish_test.dart
+++ b/examples/web3_webview_demo/test/home_polish_test.dart
@@ -1,0 +1,113 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:web3_webview_demo/data/dapps.dart';
+import 'package:web3_webview_demo/data/url_utils.dart';
+import 'package:web3_webview_demo/services/recent_visits.dart';
+import 'package:web3_webview_demo/widgets/dapp_bookmark_grid.dart';
+
+void main() {
+  group('normalizeDAppUrl', () {
+    test('passes through valid http(s) URLs', () {
+      expect(normalizeDAppUrl('https://app.uniswap.org'),
+          'https://app.uniswap.org');
+      expect(normalizeDAppUrl('http://example.com/path'),
+          'http://example.com/path');
+    });
+
+    test('prefixes https:// onto bare hosts', () {
+      expect(normalizeDAppUrl('app.uniswap.org'), 'https://app.uniswap.org');
+      expect(normalizeDAppUrl('uniswap.org/swap'), 'https://uniswap.org/swap');
+    });
+
+    test('trims surrounding whitespace', () {
+      expect(normalizeDAppUrl('  jup.ag  '), 'https://jup.ag');
+    });
+
+    test('rejects blank, scheme-less single words, and non-web schemes', () {
+      expect(normalizeDAppUrl(''), isNull);
+      expect(normalizeDAppUrl('   '), isNull);
+      expect(normalizeDAppUrl('uniswap'), isNull);
+      expect(normalizeDAppUrl('javascript:alert(1)'), isNull);
+      expect(normalizeDAppUrl('ftp://files.example.com'), isNull);
+    });
+  });
+
+  group('hostLabel', () {
+    test('strips www. and the scheme', () {
+      expect(hostLabel('https://www.opensea.io'), 'opensea.io');
+      expect(hostLabel('https://app.uniswap.org/swap'), 'app.uniswap.org');
+    });
+  });
+
+  group('filterDApps', () {
+    test('returns the full catalogue for an empty query', () {
+      expect(filterDApps(''), kDAppCatalog);
+      expect(filterDApps('   ').length, kDAppCatalog.length);
+    });
+
+    test('matches on name, description, host, and category', () {
+      expect(filterDApps('uniswap').map((e) => e.name), contains('Uniswap'));
+      expect(filterDApps('SOLANA').map((e) => e.name), contains('Jupiter'));
+      expect(filterDApps('opensea.io').map((e) => e.name), contains('OpenSea'));
+      // description keyword
+      expect(filterDApps('aggregator').map((e) => e.name), contains('1inch'));
+    });
+
+    test('returns empty for a no-match query', () {
+      expect(filterDApps('zzzzz-no-such-dapp'), isEmpty);
+    });
+  });
+
+  group('RecentVisits', () {
+    test('records most-recent-first and de-duplicates by URL', () {
+      final recent = RecentVisits();
+      addTearDown(recent.dispose);
+
+      recent.record(url: 'https://a.com', title: 'A');
+      recent.record(url: 'https://b.com', title: 'B');
+      recent.record(url: 'https://a.com', title: 'A again');
+
+      expect(recent.visits.map((v) => v.url), ['https://a.com', 'https://b.com']);
+      expect(recent.visits.first.title, 'A again');
+    });
+
+    test('honours the capacity bound', () {
+      final recent = RecentVisits(capacity: 2);
+      addTearDown(recent.dispose);
+
+      recent.record(url: 'https://a.com', title: 'A');
+      recent.record(url: 'https://b.com', title: 'B');
+      recent.record(url: 'https://c.com', title: 'C');
+
+      expect(recent.visits.length, 2);
+      expect(recent.visits.map((v) => v.url), ['https://c.com', 'https://b.com']);
+    });
+
+    test('ignores blank URLs and supports clear', () {
+      final recent = RecentVisits();
+      addTearDown(recent.dispose);
+
+      recent.record(url: '   ', title: 'blank');
+      expect(recent.isEmpty, isTrue);
+
+      recent.record(url: 'https://a.com', title: 'A');
+      expect(recent.isEmpty, isFalse);
+
+      recent.clear();
+      expect(recent.isEmpty, isTrue);
+    });
+
+    test('notifies listeners on record and clear', () {
+      final recent = RecentVisits();
+      addTearDown(recent.dispose);
+
+      var notifications = 0;
+      recent.addListener(() => notifications++);
+
+      recent.record(url: 'https://a.com', title: 'A');
+      recent.clear();
+
+      expect(notifications, 2);
+    });
+  });
+}

--- a/examples/web3_webview_demo/test/home_search_test.dart
+++ b/examples/web3_webview_demo/test/home_search_test.dart
@@ -1,0 +1,82 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:web3_webview_demo/app.dart';
+import 'package:web3_webview_demo/services/recent_visits.dart';
+import 'package:web3_webview_demo/services/wallet_state.dart';
+
+void main() {
+  testWidgets('search field filters the bookmark grid to matching dApps',
+      (tester) async {
+    final wallet = WalletState();
+    addTearDown(wallet.dispose);
+
+    await tester.pumpWidget(DemoApp(walletState: wallet));
+    await tester.pumpAndSettle();
+
+    // Grouped category headers are visible before searching.
+    expect(find.text('DeFi'), findsOneWidget);
+
+    await tester.enterText(
+        find.widgetWithText(TextField, 'Search bookmarks'), 'jupiter');
+    await tester.pumpAndSettle();
+
+    // Search mode replaces the grouped headers with a result count.
+    expect(find.text('DeFi'), findsNothing);
+    expect(find.textContaining('result(s)'), findsOneWidget);
+    expect(find.text('Jupiter'), findsOneWidget);
+    expect(find.text('Uniswap'), findsNothing);
+  });
+
+  testWidgets('search with no matches shows the empty-state message',
+      (tester) async {
+    final wallet = WalletState();
+    addTearDown(wallet.dispose);
+
+    await tester.pumpWidget(DemoApp(walletState: wallet));
+    await tester.pumpAndSettle();
+
+    await tester.enterText(
+        find.widgetWithText(TextField, 'Search bookmarks'), 'zzzznope');
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('No dApps match'), findsOneWidget);
+  });
+
+  testWidgets('a recorded recent visit surfaces a Recent chip',
+      (tester) async {
+    final wallet = WalletState();
+    final recent = RecentVisits();
+    addTearDown(wallet.dispose);
+    addTearDown(recent.dispose);
+
+    await tester.pumpWidget(
+        DemoApp(walletState: wallet, recentVisits: recent));
+    await tester.pumpAndSettle();
+
+    // No Recent section until something is recorded.
+    expect(find.text('Recent'), findsNothing);
+
+    recent.record(url: 'https://app.uniswap.org', title: 'Uniswap');
+    await tester.pumpAndSettle();
+
+    expect(find.text('Recent'), findsOneWidget);
+    // The ActionChip carries the recorded title.
+    expect(find.widgetWithText(ActionChip, 'Uniswap'), findsOneWidget);
+  });
+
+  testWidgets('invalid custom URL shows an inline error', (tester) async {
+    final wallet = WalletState();
+    addTearDown(wallet.dispose);
+
+    await tester.pumpWidget(DemoApp(walletState: wallet));
+    await tester.pumpAndSettle();
+
+    await tester.enterText(
+        find.widgetWithText(TextField, 'Open a custom URL'), 'not a url');
+    await tester.testTextInput.receiveAction(TextInputAction.go);
+    await tester.pumpAndSettle();
+
+    expect(find.text('Enter a valid http(s) URL or host'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary

Phase 2 of the demo, stacked on #31. Builds out the home screen:

- **Custom URL bar** — normalises typed input into a loadable http(s) URL (passthrough valid URLs, prefix `https://` onto bare hosts, reject blanks / single words / non-web schemes). Invalid input shows an inline error.
- **Live bookmark search** — case-insensitive match across name / description / host / category. Swaps grouped layout for a flat result list; empty result shows a "No dApps match …" message.
- **Recent visits** — in-memory MRU (cap 8) via `RecentVisitsScope`. Opening any bookmark / recent chip / typed URL records a visit, rendered as a horizontal chip row with Clear.

The bookmark grid + tile move into `widgets/dapp_bookmark_grid.dart` so grouped and search layouts share rendering. No new third-party dependency (recent visits stays in memory — no `shared_preferences`).

> **Stacked on #31.** Review/merge #31 first; GitHub will retarget this PR's base to `epic/...` once #31 lands. The diff here is Phase 2 only.

## Test plan

- [x] `flutter analyze` — no issues
- [x] `flutter test` — 22/22 passing (16 new this phase)
  - `normalizeDAppUrl` passthrough / host-prefix / trim / rejections
  - `hostLabel` strips scheme + www.
  - `filterDApps` empty / multi-field / no-match
  - `RecentVisits` MRU de-dup / capacity / blank-skip / clear / notifications
  - widget: search filters grid; no-match empty state; recent chip appears; invalid URL inline error
- [ ] Manual smoke: type `jup.ag` in the URL bar → opens Jupiter; search "solana" narrows the grid; opening a dApp then returning shows it in the Recent row.

## Roadmap

| Phase | Status |
|------:|--------|
| 1 skeleton (#31) | ✅ |
| **2 home polish (this)** | ✅ |
| 3 callback wiring + approval sheet + bridge log | next |
| 4 EVM signing | ☐ |
| 5 Solana signing | ☐ |
| 6 settings toggles + log viewer | ☐ |
| 7 docs + checklist | ☐ |