### PR TITLE
feat(demo): full callback wiring + approval sheet + bridge log (Phase 3)

### DIFF
--- a/examples/web3_webview_demo/README.md
+++ b/examples/web3_webview_demo/README.md
@@ -23,8 +23,8 @@ reviewable.
 | Phase | What it adds | Status |
 |------:|--------------|--------|
 | **1** | App shell + zero-dep state mgmt + bookmark grid + chain / account pickers (placeholders for signing / approval / log) | ✅ |
-| **2** | Custom-URL bar, live bookmark search, in-memory recent-visit row | ✅ this commit |
-| 3 | Full `Web3Webview` callback wiring + approval bottom-sheet + bridge log capture | ☐ |
+| **2** | Custom-URL bar, live bookmark search, in-memory recent-visit row | ✅ |
+| **3** | Full callback wiring + approval sheet + bridge log + wallet→DApp event emit (mock signers) | ✅ this commit |
 | 4 | EVM signing (`web3dart`): `personal_sign`, `eth_signTypedData_v3/v4`, `eth_sendTransaction` (mock hash by default, real broadcast on toggle) | ☐ |
 | 5 | Solana signing (`cryptography` + `bs58`): `solana_signMessage`, `solana_signTransaction` | ☐ |
 | 6 | Settings: auto-approve toggle, real-broadcast toggle, bridge-log viewer | ☐ |
@@ -66,16 +66,50 @@ lib/
 ├── data/
 │   └── url_utils.dart   # custom-URL normalisation + host labelling
 ├── services/
-│   ├── wallet_state.dart   # ChangeNotifier — active account / chain / settings
-│   ├── bridge_log.dart     # ring-buffer log of bridge round-trips
-│   └── recent_visits.dart  # in-memory MRU of opened DApps
+│   ├── wallet_state.dart    # ChangeNotifier — active account / chain / settings
+│   ├── bridge_log.dart      # ring-buffer log of bridge round-trips
+│   ├── recent_visits.dart   # in-memory MRU of opened DApps
+│   ├── request_summary.dart # parses a request into approval-sheet rows
+│   ├── eth_signer.dart      # EthSigner interface + MockEthSigner
+│   └── sol_signer.dart      # SolSigner interface + MockSolSigner
 ├── pages/
-│   ├── home_page.dart   # URL bar + search + recent row + bookmark grid
-│   ├── browser_page.dart # Web3Webview + AppBar chain / account chips
+│   ├── home_page.dart    # URL bar + search + recent row + bookmark grid
+│   ├── browser_page.dart # Web3Webview — full callback wiring + emits
 │   └── settings_page.dart # account / chain picker + (pending) toggles
 └── widgets/
-    └── dapp_bookmark_grid.dart # reusable grid + tile + filter helper
+    ├── dapp_bookmark_grid.dart # reusable grid + tile + filter helper
+    ├── approval_sheet.dart     # modal confirm sheet (approve / reject)
+    └── debug_panel.dart        # bridge-log bottom sheet
 ```
+
+## Bridge wiring (Phase 3)
+
+`browser_page.dart` connects every `Web3Webview` callback:
+
+| Callback | Behaviour |
+|----------|-----------|
+| `ethAccounts` / `ethChainId` / `solAccount` | resolve immediately when *auto-approve reads* is on, else prompt |
+| `ethPersonalSign` / `ethSign` / `ethSignTypedData` | approval sheet → `EthSigner` |
+| `ethSendTransaction` | approval sheet (danger styling) → `EthSigner`, mock hash unless *real broadcast* |
+| `walletSwitchEthereumChain` | approval sheet → updates `WalletState` (returns `false` on reject so the dispatcher raises EIP-1193 `4001`) |
+| `solSignMessage` / `solSignTransaction` | approval sheet → `SolSigner` |
+| `onDefaultCallback` | logged + rejected so unknown methods fail loudly |
+
+Rejecting any sheet throws `UserRejectedException` whose `toString()` is the
+EIP-1193 `4001` JSON, so the DApp sees a real wallet's rejection shape.
+
+The page also shows the **wallet → DApp** direction: while a DApp is open,
+switching the active chain / EVM account / Solana account (e.g. from
+Settings) pushes `emitChainChanged` / `emitAccountsChanged` /
+`solana.emitAccountChanged` into the page via `evaluateJavascript`.
+
+Every round-trip — including the emits — is recorded in the `BridgeLog`,
+viewable from the browser AppBar's terminal icon.
+
+Signers are **mock** in this phase: deterministic placeholder signatures
+that exercise the plumbing but are not cryptographically valid. Phase 4 / 5
+swap in the real `web3dart` / ed25519 implementations behind the same
+`EthSigner` / `SolSigner` interfaces (injected through `DemoApp`).
 
 State propagates through `InheritedNotifier`-backed scopes
 (`WalletStateScope`, `BridgeLogScope`) — zero third-party state

--- a/examples/web3_webview_demo/lib/app.dart
+++ b/examples/web3_webview_demo/lib/app.dart
@@ -4,7 +4,9 @@ import 'package:web3_webview_demo/pages/browser_page.dart';
 import 'package:web3_webview_demo/pages/home_page.dart';
 import 'package:web3_webview_demo/pages/settings_page.dart';
 import 'package:web3_webview_demo/services/bridge_log.dart';
+import 'package:web3_webview_demo/services/eth_signer.dart';
 import 'package:web3_webview_demo/services/recent_visits.dart';
+import 'package:web3_webview_demo/services/sol_signer.dart';
 import 'package:web3_webview_demo/services/wallet_state.dart';
 
 /// Root widget. Hosts the two long-lived services ([WalletState],
@@ -17,6 +19,8 @@ class DemoApp extends StatefulWidget {
     WalletState? walletState,
     BridgeLog? bridgeLog,
     RecentVisits? recentVisits,
+    this.ethSigner = const MockEthSigner(),
+    this.solSigner = const MockSolSigner(),
   })  : _walletState = walletState,
         _bridgeLog = bridgeLog,
         _recentVisits = recentVisits;
@@ -26,6 +30,12 @@ class DemoApp extends StatefulWidget {
   final WalletState? _walletState;
   final BridgeLog? _bridgeLog;
   final RecentVisits? _recentVisits;
+
+  /// Signers are injectable so Phase 4 / 5 can swap the deterministic
+  /// [MockEthSigner] / [MockSolSigner] for the real `web3dart` / ed25519
+  /// implementations without touching the routing wiring.
+  final EthSigner ethSigner;
+  final SolSigner solSigner;
 
   @override
   State<DemoApp> createState() => _DemoAppState();
@@ -97,7 +107,11 @@ class _DemoAppState extends State<DemoApp> {
         }
         return MaterialPageRoute(
           settings: settings,
-          builder: (_) => BrowserPage(args: args),
+          builder: (_) => BrowserPage(
+            args: args,
+            ethSigner: widget.ethSigner,
+            solSigner: widget.solSigner,
+          ),
         );
       default:
         return null;

--- a/examples/web3_webview_demo/lib/pages/browser_page.dart
+++ b/examples/web3_webview_demo/lib/pages/browser_page.dart
@@ -1,7 +1,14 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_web3_webview/flutter_web3_webview.dart';
 
+import 'package:web3_webview_demo/data/chains.dart';
+import 'package:web3_webview_demo/services/bridge_log.dart';
+import 'package:web3_webview_demo/services/eth_signer.dart';
+import 'package:web3_webview_demo/services/request_summary.dart';
+import 'package:web3_webview_demo/services/sol_signer.dart';
 import 'package:web3_webview_demo/services/wallet_state.dart';
+import 'package:web3_webview_demo/widgets/approval_sheet.dart';
+import 'package:web3_webview_demo/widgets/debug_panel.dart';
 
 /// Navigation argument carried by the `/browser` route.
 @immutable
@@ -12,16 +19,34 @@ class BrowserPageArgs {
   const BrowserPageArgs({required this.url, required this.title});
 }
 
-/// In-WebView dApp page.
+/// Thrown when the user rejects an approval sheet. Its [toString] is the
+/// EIP-1193 `4001` JSON shape so the DApp sees the same rejection a real
+/// wallet would surface through the bridge.
+class UserRejectedException implements Exception {
+  const UserRejectedException();
+
+  @override
+  String toString() => '{"code":4001,"message":"User rejected the request"}';
+}
+
+/// In-WebView dApp page with the full `flutter_web3_webview` callback set
+/// wired through an approval sheet and a bridge log.
 ///
-/// Phase 1 only wires the read-only callbacks (`ethAccounts`, `ethChainId`,
-/// `walletSwitchEthereumChain`) end-to-end so the existing `app.uniswap.org`
-/// flow keeps working after the skeleton refactor. The signing / send /
-/// Solana / approval-sheet behaviour ships in Phase 3+.
+/// Read-only methods (`eth_accounts`, `eth_chainId`, `solana_account`)
+/// resolve immediately when `autoApproveReadMethods` is on; everything
+/// that signs / sends / switches chain always prompts. Every round-trip is
+/// recorded in the [BridgeLog].
 class BrowserPage extends StatefulWidget {
-  const BrowserPage({super.key, required this.args});
+  const BrowserPage({
+    super.key,
+    required this.args,
+    this.ethSigner = const MockEthSigner(),
+    this.solSigner = const MockSolSigner(),
+  });
 
   final BrowserPageArgs args;
+  final EthSigner ethSigner;
+  final SolSigner solSigner;
 
   @override
   State<BrowserPage> createState() => _BrowserPageState();
@@ -29,11 +54,81 @@ class BrowserPage extends StatefulWidget {
 
 class _BrowserPageState extends State<BrowserPage> {
   String _title = '';
+  InAppWebViewController? _controller;
+
+  // The WalletState this page is currently subscribed to, plus the last
+  // values we pushed to the page, so we only emit an event when something
+  // actually changed (e.g. the user switched account / chain in Settings
+  // while this DApp stayed open in the background).
+  WalletState? _boundWallet;
+  int? _lastChainId;
+  String? _lastEvmAddress;
+  String? _lastSolAddress;
 
   @override
   void initState() {
     super.initState();
     _title = widget.args.title;
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    final wallet = WalletStateScope.of(context);
+    if (!identical(wallet, _boundWallet)) {
+      _boundWallet?.removeListener(_onWalletChanged);
+      _boundWallet = wallet;
+      _boundWallet!.addListener(_onWalletChanged);
+      _lastChainId = wallet.evmChainId;
+      _lastEvmAddress = wallet.evmAccount.evmAddress;
+      _lastSolAddress = wallet.solanaAccount.solanaAddress;
+    }
+  }
+
+  @override
+  void dispose() {
+    _boundWallet?.removeListener(_onWalletChanged);
+    super.dispose();
+  }
+
+  /// Push EIP-1193 / wallet-standard events into the page when the active
+  /// identity changes out-of-band (i.e. not as the direct result of a DApp
+  /// request). This is the demo's showcase of the *wallet → DApp*
+  /// direction of the bridge.
+  void _onWalletChanged() {
+    final wallet = _boundWallet;
+    final controller = _controller;
+    if (wallet == null || controller == null) return;
+
+    if (wallet.evmChainId != _lastChainId) {
+      _lastChainId = wallet.evmChainId;
+      final hex = '0x${wallet.evmChainId.toRadixString(16)}';
+      _emit('window.ethereum.emitChainChanged("$hex")');
+      _log.record(method: 'emitChainChanged', request: hex);
+    }
+    if (wallet.evmAccount.evmAddress != _lastEvmAddress) {
+      _lastEvmAddress = wallet.evmAccount.evmAddress;
+      _emit('window.ethereum.emitAccountsChanged('
+          '["${wallet.evmAccount.evmAddress}"])');
+      _log.record(
+          method: 'emitAccountsChanged',
+          request: [wallet.evmAccount.evmAddress]);
+    }
+    if (wallet.solanaAccount.solanaAddress != _lastSolAddress) {
+      _lastSolAddress = wallet.solanaAccount.solanaAddress;
+      _emit('window.fxwallet && window.fxwallet.solana && '
+          'window.fxwallet.solana.emitAccountChanged()');
+      _log.record(
+          method: 'solana.emitAccountChanged',
+          request: wallet.solanaAccount.solanaAddress);
+    }
+  }
+
+  void _emit(String expression) {
+    // Guard every emit so a page that hasn't injected the provider (or a
+    // non-web3 page) never throws inside evaluateJavascript.
+    _controller?.evaluateJavascript(
+        source: 'try { $expression } catch (e) {}');
   }
 
   @override
@@ -44,10 +139,15 @@ class _BrowserPageState extends State<BrowserPage> {
       appBar: AppBar(
         title: Text(_title),
         actions: [
-          _ChainChip(chainId: wallet.evmChainId),
-          const SizedBox(width: 8),
+          _ChainChip(),
+          const SizedBox(width: 4),
           _AccountChip(address: wallet.evmAccount.evmAddress),
-          const SizedBox(width: 8),
+          IconButton(
+            icon: const Icon(Icons.terminal),
+            tooltip: 'Bridge log',
+            onPressed: () =>
+                DebugPanel.show(context, BridgeLogScope.read(context)),
+          ),
         ],
       ),
       body: Web3Webview(
@@ -58,40 +158,258 @@ class _BrowserPageState extends State<BrowserPage> {
             rdns: 'com.fxfi.fxwallet',
           ),
         ),
+        onWebViewCreated: (c) => _controller = c,
         shouldOverrideUrlLoading: (_, __) async =>
             NavigationActionPolicy.ALLOW,
         onTitleChanged: _onTitleChanged,
-        ethAccounts: () async => [wallet.evmAccount.evmAddress],
-        ethChainId: () async => wallet.evmChainId,
-        walletSwitchEthereumChain: (JsAddEthereumChain data) async {
-          final hex = (data.chainId ?? '').replaceFirst('0x', '');
-          if (hex.isEmpty) return false;
-          wallet.evmChainId = int.parse(hex, radix: 16);
-          return true;
-        },
+        // ── read-only ────────────────────────────────────────────────
+        ethAccounts: () => _runRead<List<String>>(
+          method: 'eth_accounts',
+          action: () async => [_wallet.evmAccount.evmAddress],
+        ),
+        ethChainId: () => _runRead<int>(
+          method: 'eth_chainId',
+          action: () async => _wallet.evmChainId,
+        ),
+        solAccount: () => _runRead<String>(
+          method: 'solana_account',
+          action: () async => _wallet.solanaAccount.solanaAddress,
+        ),
+        // ── EVM signing ─────────────────────────────────────────────
+        ethPersonalSign: (message) => _runApproved<String>(
+          method: 'personal_sign',
+          request: message,
+          summary: RequestSummary.ethMessage(
+            title: 'Sign message',
+            account: _wallet.evmAccount.evmAddress,
+            message: message,
+          ),
+          action: () => widget.ethSigner.personalSign(
+            account: _wallet.evmAccount,
+            message: message,
+          ),
+        ),
+        ethSign: (message) => _runApproved<String>(
+          method: 'eth_sign',
+          request: message,
+          summary: RequestSummary.ethMessage(
+            title: 'Sign message (eth_sign)',
+            account: _wallet.evmAccount.evmAddress,
+            message: message,
+          ),
+          action: () => widget.ethSigner.ethSign(
+            account: _wallet.evmAccount,
+            message: message,
+          ),
+        ),
+        ethSignTypedData: (payload) => _runApproved<String>(
+          method: 'eth_signTypedData',
+          request: payload,
+          summary: RequestSummary.ethTypedData(
+            account: _wallet.evmAccount.evmAddress,
+            payload: payload,
+          ),
+          action: () => widget.ethSigner.signTypedData(
+            account: _wallet.evmAccount,
+            payload: payload,
+          ),
+        ),
+        ethSendTransaction: (tx) => _runApproved<String>(
+          method: 'eth_sendTransaction',
+          request: tx.toJson(),
+          summary: RequestSummary.ethTransaction(transaction: tx),
+          dangerous: true,
+          confirmLabel: 'Send',
+          action: () => widget.ethSigner.sendTransaction(
+            account: _wallet.evmAccount,
+            transaction: tx,
+            broadcast: _wallet.realBroadcast,
+            rpcUrl: _wallet.evmChain.rpcUrl,
+          ),
+        ),
+        walletSwitchEthereumChain: _switchChain,
+        // ── Solana signing ──────────────────────────────────────────
+        solSignMessage: (data) => _runApproved<String>(
+          method: 'solana_signMessage',
+          request: data.params,
+          summary: RequestSummary.solMessage(
+            account: _wallet.solanaAccount.solanaAddress,
+            data: data,
+          ),
+          action: () => widget.solSigner.signMessage(
+            account: _wallet.solanaAccount,
+            data: data,
+          ),
+        ),
+        solSignTransaction: (data) => _runApproved<String>(
+          method: 'solana_signTransaction',
+          request: data.params,
+          summary: RequestSummary.solTransaction(
+            account: _wallet.solanaAccount.solanaAddress,
+            data: data,
+          ),
+          action: () => widget.solSigner.signTransaction(
+            account: _wallet.solanaAccount,
+            data: data,
+          ),
+        ),
+        onDefaultCallback: (data) => _runUnknown(data),
       ),
     );
   }
+
+  WalletState get _wallet => WalletStateScope.read(context);
+  BridgeLog get _log => BridgeLogScope.read(context);
 
   void _onTitleChanged(InAppWebViewController _, String? value) {
     if (value == null || value.isEmpty || value == _title) return;
     setState(() => _title = value);
   }
+
+  /// Read-only method runner: resolves immediately when auto-approve is on,
+  /// otherwise prompts. Always records the round-trip.
+  Future<T> _runRead<T>({
+    required String method,
+    required Future<T> Function() action,
+  }) async {
+    final log = _log;
+    final id = log.begin(method: method, request: null);
+    final sw = Stopwatch()..start();
+    try {
+      if (!_wallet.autoApproveReadMethods) {
+        final approved = await _confirm(
+          title: 'Connect request',
+          method: method,
+          rows: [
+            MapEntry('Method', method),
+            MapEntry('Account', _wallet.evmAccount.evmAddress),
+          ],
+        );
+        if (!approved) throw const UserRejectedException();
+      }
+      final result = await action();
+      sw.stop();
+      log.resolve(id, response: result, elapsed: sw.elapsed);
+      return result;
+    } catch (e) {
+      sw.stop();
+      log.reject(id, error: e.toString(), elapsed: sw.elapsed);
+      rethrow;
+    }
+  }
+
+  /// Signing / sending runner: always prompts, runs [action] on approval.
+  Future<T> _runApproved<T>({
+    required String method,
+    required Object? request,
+    required RequestSummary summary,
+    required Future<T> Function() action,
+    bool dangerous = false,
+    String confirmLabel = 'Approve',
+  }) async {
+    final log = _log;
+    final id = log.begin(method: method, request: request);
+    final sw = Stopwatch()..start();
+    try {
+      final approved = await _confirm(
+        title: summary.title,
+        method: method,
+        rows: summary.rows,
+        dangerous: dangerous,
+        confirmLabel: confirmLabel,
+      );
+      if (!approved) throw const UserRejectedException();
+      final result = await action();
+      sw.stop();
+      log.resolve(id, response: result, elapsed: sw.elapsed);
+      return result;
+    } catch (e) {
+      sw.stop();
+      log.reject(id, error: e.toString(), elapsed: sw.elapsed);
+      rethrow;
+    }
+  }
+
+  /// `wallet_switchEthereumChain` returns a bool — the dispatcher turns a
+  /// `false` into the EIP-1193 rejection itself, so we don't throw here.
+  Future<bool> _switchChain(JsAddEthereumChain data) async {
+    final log = _log;
+    final id = log.begin(
+        method: 'wallet_switchEthereumChain', request: data.toJson());
+    final sw = Stopwatch()..start();
+
+    final hex = (data.chainId ?? '').replaceFirst('0x', '');
+    if (hex.isEmpty) {
+      sw.stop();
+      log.reject(id, error: 'missing chainId', elapsed: sw.elapsed);
+      return false;
+    }
+    final targetId = int.tryParse(hex, radix: 16);
+    if (targetId == null) {
+      sw.stop();
+      log.reject(id, error: 'invalid chainId 0x$hex', elapsed: sw.elapsed);
+      return false;
+    }
+
+    final target = evmChainById(targetId);
+    final approved = await _confirm(
+      title: 'Switch chain',
+      method: 'wallet_switchEthereumChain',
+      rows: [
+        MapEntry('From', _wallet.evmChain.name),
+        MapEntry('To', '${target.name} (chainId $targetId)'),
+      ],
+    );
+    sw.stop();
+    if (!approved) {
+      log.reject(id, error: 'user rejected', elapsed: sw.elapsed);
+      return false;
+    }
+    _wallet.evmChainId = targetId;
+    log.resolve(id, response: '0x${targetId.toRadixString(16)}',
+        elapsed: sw.elapsed);
+    return true;
+  }
+
+  /// Anything the dispatcher didn't have a typed route for. We log it and
+  /// reject so a DApp calling an unsupported method gets a clear error
+  /// instead of a silent hang.
+  Future<dynamic> _runUnknown(JsCallBackData data) async {
+    _log.record(
+      method: data.method.isEmpty ? '(unknown)' : data.method,
+      request: data.params,
+      error: 'No handler in demo wallet for "${data.method}"',
+    );
+    throw Exception('Unsupported method: ${data.method}');
+  }
+
+  Future<bool> _confirm({
+    required String title,
+    required String method,
+    required List<MapEntry<String, String>> rows,
+    bool dangerous = false,
+    String confirmLabel = 'Approve',
+  }) async {
+    if (!mounted) return false;
+    return ApprovalSheet.show(
+      context,
+      title: title,
+      rows: rows,
+      method: method,
+      dangerous: dangerous,
+      confirmLabel: confirmLabel,
+    );
+  }
 }
 
 class _ChainChip extends StatelessWidget {
-  const _ChainChip({required this.chainId});
-
-  final int chainId;
-
   @override
   Widget build(BuildContext context) {
-    final wallet = WalletStateScope.of(context);
-    final chain = wallet.evmChain;
+    final chain = WalletStateScope.of(context).evmChain;
     return Chip(
       avatar: Icon(chain.icon, color: chain.color, size: 18),
       label: Text(chain.symbol),
-      labelPadding: const EdgeInsets.symmetric(horizontal: 4),
+      labelPadding: const EdgeInsets.symmetric(horizontal: 2),
       visualDensity: VisualDensity.compact,
     );
   }
@@ -110,7 +428,7 @@ class _AccountChip extends StatelessWidget {
     return Chip(
       avatar: const Icon(Icons.account_circle_outlined, size: 18),
       label: Text(short),
-      labelPadding: const EdgeInsets.symmetric(horizontal: 4),
+      labelPadding: const EdgeInsets.symmetric(horizontal: 2),
       visualDensity: VisualDensity.compact,
     );
   }

--- a/examples/web3_webview_demo/lib/services/eth_signer.dart
+++ b/examples/web3_webview_demo/lib/services/eth_signer.dart
@@ -1,0 +1,112 @@
+import 'dart:convert';
+
+import 'package:flutter_web3_webview/flutter_web3_webview.dart';
+
+import 'package:web3_webview_demo/services/wallet_state.dart';
+
+/// EVM signing surface the browser page drives.
+///
+/// Phase 3 wires the approval flow against [MockEthSigner], which returns
+/// deterministic placeholder signatures so the whole request → approval →
+/// response round-trip can be exercised before the real `web3dart`-backed
+/// implementation lands in Phase 4. Phase 4 adds a `Web3DartEthSigner`
+/// implementing this same interface and swaps it in at the app shell.
+abstract class EthSigner {
+  /// EIP-191 `personal_sign`. [message] is the raw message the DApp passed
+  /// (hex or UTF-8); the result is a 65-byte `0x`-prefixed signature.
+  Future<String> personalSign({
+    required DemoAccount account,
+    required String message,
+  });
+
+  /// Legacy `eth_sign`. Same signature shape as [personalSign].
+  Future<String> ethSign({
+    required DemoAccount account,
+    required String message,
+  });
+
+  /// `eth_signTypedData` (v1/v3/v4). [payload] is the typed-data JSON
+  /// string; the result is a 65-byte `0x`-prefixed signature.
+  Future<String> signTypedData({
+    required DemoAccount account,
+    required String payload,
+  });
+
+  /// `eth_sendTransaction`. Returns the `0x`-prefixed transaction hash.
+  ///
+  /// When [broadcast] is false the implementation signs but does not
+  /// submit, returning a deterministic mock hash; when true it broadcasts
+  /// over [rpcUrl] and returns the real hash.
+  Future<String> sendTransaction({
+    required DemoAccount account,
+    required JsTransactionObject transaction,
+    required bool broadcast,
+    required String rpcUrl,
+  });
+}
+
+/// Deterministic placeholder signer used until Phase 4 lands the real
+/// `web3dart` implementation. Signatures are stable functions of the
+/// account + payload so the demo stays reproducible, but they are **not**
+/// cryptographically valid — a DApp that verifies the signature on-chain
+/// will reject them. That's fine for exercising the bridge plumbing.
+class MockEthSigner implements EthSigner {
+  const MockEthSigner();
+
+  @override
+  Future<String> personalSign({
+    required DemoAccount account,
+    required String message,
+  }) async {
+    return _mockSignature('personal_sign', account, message);
+  }
+
+  @override
+  Future<String> ethSign({
+    required DemoAccount account,
+    required String message,
+  }) async {
+    return _mockSignature('eth_sign', account, message);
+  }
+
+  @override
+  Future<String> signTypedData({
+    required DemoAccount account,
+    required String payload,
+  }) async {
+    return _mockSignature('typed_data', account, payload);
+  }
+
+  @override
+  Future<String> sendTransaction({
+    required DemoAccount account,
+    required JsTransactionObject transaction,
+    required bool broadcast,
+    required String rpcUrl,
+  }) async {
+    // Mock signer never broadcasts; returns a deterministic fake hash.
+    return _mockHash(account, jsonEncode(transaction.toJson()));
+  }
+
+  String _mockSignature(String tag, DemoAccount account, String payload) {
+    // 65 bytes = 130 hex chars.
+    return '0x${_hexFill('$tag:${account.evmAddress}:$payload', 130)}';
+  }
+
+  String _mockHash(DemoAccount account, String payload) {
+    // 32 bytes = 64 hex chars.
+    return '0x${_hexFill('${account.evmAddress}:$payload', 64)}';
+  }
+
+  /// Deterministically expand a seed string into [length] hex characters by
+  /// repeatedly hashing the running buffer. Stable for identical input.
+  String _hexFill(String seed, int length) {
+    final buffer = StringBuffer();
+    var value = seed.hashCode.abs();
+    while (buffer.length < length) {
+      buffer.write(value.toRadixString(16).padLeft(8, '0'));
+      value = (value * 1103515245 + 12345) & 0x7fffffff;
+    }
+    return buffer.toString().substring(0, length);
+  }
+}

--- a/examples/web3_webview_demo/lib/services/request_summary.dart
+++ b/examples/web3_webview_demo/lib/services/request_summary.dart
@@ -1,0 +1,121 @@
+import 'dart:convert';
+
+import 'package:flutter_web3_webview/flutter_web3_webview.dart';
+
+/// Human-readable summary of a wallet request, shown in the approval sheet.
+///
+/// Decoupled from the signers (which only produce signatures) and from the
+/// sheet widget (which only renders), so the request-parsing logic lives in
+/// one testable place.
+class RequestSummary {
+  final String title;
+  final List<MapEntry<String, String>> rows;
+
+  const RequestSummary({required this.title, required this.rows});
+
+  /// personal_sign / eth_sign message.
+  factory RequestSummary.ethMessage({
+    required String title,
+    required String account,
+    required String message,
+  }) {
+    return RequestSummary(title: title, rows: [
+      MapEntry('Account', account),
+      MapEntry('Message', decodeEthMessage(message)),
+    ]);
+  }
+
+  /// eth_signTypedData (v1/v3/v4).
+  factory RequestSummary.ethTypedData({
+    required String account,
+    required String payload,
+  }) {
+    var primaryType = '(unknown)';
+    var domain = '(none)';
+    try {
+      final decoded = jsonDecode(payload);
+      if (decoded is Map) {
+        primaryType = decoded['primaryType']?.toString() ?? primaryType;
+        final domainObj = decoded['domain'];
+        if (domainObj is Map) {
+          domain = domainObj['name']?.toString() ?? domain;
+        }
+      }
+    } catch (_) {
+      // Leave placeholders; the title still tells the user what this is.
+    }
+    return RequestSummary(title: 'Sign typed data', rows: [
+      MapEntry('Account', account),
+      MapEntry('Domain', domain),
+      MapEntry('Primary type', primaryType),
+    ]);
+  }
+
+  /// eth_sendTransaction.
+  factory RequestSummary.ethTransaction({
+    required JsTransactionObject transaction,
+  }) {
+    final json = transaction.toJson();
+    return RequestSummary(title: 'Send transaction', rows: [
+      MapEntry('From', json['from']?.toString() ?? '(unset)'),
+      MapEntry('To', json['to']?.toString() ?? '(contract creation)'),
+      MapEntry('Value', json['value']?.toString() ?? '0x0'),
+      MapEntry('Gas', json['gas']?.toString() ?? '(estimate)'),
+      MapEntry('Data', truncate(json['data']?.toString() ?? '0x')),
+    ]);
+  }
+
+  /// solana_signMessage.
+  factory RequestSummary.solMessage({
+    required String account,
+    required JsCallBackData data,
+  }) {
+    final params = data.params;
+    var raw = '(none)';
+    if (params is Map && params['raw'] is String) {
+      raw = truncate(params['raw'] as String);
+    }
+    return RequestSummary(title: 'Sign Solana message', rows: [
+      MapEntry('Account', account),
+      MapEntry('Raw (hex)', raw),
+    ]);
+  }
+
+  /// solana_signTransaction.
+  factory RequestSummary.solTransaction({
+    required String account,
+    required JsCallBackData data,
+  }) {
+    final params = data.params;
+    var message = '(none)';
+    if (params is Map && params['message'] is String) {
+      message = truncate(params['message'] as String);
+    }
+    return RequestSummary(title: 'Sign Solana transaction', rows: [
+      MapEntry('Account', account),
+      MapEntry('Message (base64)', message),
+    ]);
+  }
+
+  /// Decode a hex-encoded message to UTF-8 for display when it round-trips
+  /// cleanly; otherwise return the raw input unchanged.
+  static String decodeEthMessage(String message) {
+    if (message.startsWith('0x') && (message.length - 2).isEven) {
+      try {
+        final bytes = <int>[];
+        for (var i = 2; i < message.length; i += 2) {
+          bytes.add(int.parse(message.substring(i, i + 2), radix: 16));
+        }
+        return utf8.decode(bytes);
+      } catch (_) {
+        return message;
+      }
+    }
+    return message;
+  }
+
+  static String truncate(String value, {int max = 80}) {
+    if (value.length <= max) return value;
+    return '${value.substring(0, max)}… (${value.length} chars)';
+  }
+}

--- a/examples/web3_webview_demo/lib/services/sol_signer.dart
+++ b/examples/web3_webview_demo/lib/services/sol_signer.dart
@@ -1,0 +1,68 @@
+import 'package:flutter_web3_webview/flutter_web3_webview.dart';
+
+import 'package:web3_webview_demo/services/wallet_state.dart';
+
+/// Solana signing surface the browser page drives.
+///
+/// Mirrors [EthSigner]: Phase 3 wires the approval flow against
+/// [MockSolSigner]; Phase 5 adds the real ed25519 implementation
+/// (`cryptography` + `bs58`) behind the same interface.
+abstract class SolSigner {
+  /// `solana_signMessage`. The wallet receives `{ raw: <hex> }`; the
+  /// result is the base58-encoded signature the JS bridge decodes back
+  /// into bytes.
+  Future<String> signMessage({
+    required DemoAccount account,
+    required JsCallBackData data,
+  });
+
+  /// `solana_signTransaction`. The wallet receives
+  /// `{ raw: <hex>, message: <base64> }`; the result is the base58-encoded
+  /// signature the JS bridge attaches to the transaction.
+  Future<String> signTransaction({
+    required DemoAccount account,
+    required JsCallBackData data,
+  });
+}
+
+/// Deterministic placeholder Solana signer (see [MockEthSigner] for the
+/// rationale). Returns a stable base58-ish string keyed off the account +
+/// payload; not a valid ed25519 signature.
+class MockSolSigner implements SolSigner {
+  const MockSolSigner();
+
+  static const String _base58Alphabet =
+      '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
+
+  @override
+  Future<String> signMessage({
+    required DemoAccount account,
+    required JsCallBackData data,
+  }) async {
+    return _mockSignature('msg', account, data);
+  }
+
+  @override
+  Future<String> signTransaction({
+    required DemoAccount account,
+    required JsCallBackData data,
+  }) async {
+    return _mockSignature('tx', account, data);
+  }
+
+  String _mockSignature(String tag, DemoAccount account, JsCallBackData data) {
+    final seed =
+        '$tag:${account.solanaAddress}:${data.method}:${data.params}'
+            .hashCode
+            .abs();
+    // ed25519 signatures are 64 bytes → ~88 base58 chars. Build a stable
+    // pseudo-base58 string of that length from the seed.
+    final buffer = StringBuffer();
+    var value = seed;
+    while (buffer.length < 88) {
+      buffer.write(_base58Alphabet[value % _base58Alphabet.length]);
+      value = (value * 1103515245 + 12345) & 0x7fffffff;
+    }
+    return buffer.toString();
+  }
+}

--- a/examples/web3_webview_demo/lib/widgets/approval_sheet.dart
+++ b/examples/web3_webview_demo/lib/widgets/approval_sheet.dart
@@ -1,0 +1,153 @@
+import 'package:flutter/material.dart';
+
+/// A single labelled row in the approval sheet.
+typedef ApprovalRow = MapEntry<String, String>;
+
+/// Modal confirmation sheet shown before the demo signs / sends / switches
+/// chain on a DApp's behalf. Returns `true` when the user approves and
+/// `false` (or `null`, treated as reject) when they cancel or dismiss.
+///
+/// The browser page maps a `false` result to an EIP-1193 `4001`
+/// user-rejected error so the DApp sees the same rejection it would from a
+/// real wallet.
+class ApprovalSheet extends StatelessWidget {
+  const ApprovalSheet({
+    super.key,
+    required this.title,
+    required this.rows,
+    this.method,
+    this.confirmLabel = 'Approve',
+    this.dangerous = false,
+  });
+
+  final String title;
+  final List<ApprovalRow> rows;
+
+  /// Raw method name (`personal_sign`, `eth_sendTransaction`, …) shown as a
+  /// monospace chip so testers can see exactly what the DApp asked for.
+  final String? method;
+
+  final String confirmLabel;
+
+  /// When true the confirm button uses the error colour — used for
+  /// send-transaction so it visually stands apart from read-only signs.
+  final bool dangerous;
+
+  /// Present the sheet and resolve to the user's decision. A barrier tap or
+  /// back gesture resolves to `false` (reject).
+  static Future<bool> show(
+    BuildContext context, {
+    required String title,
+    required List<ApprovalRow> rows,
+    String? method,
+    String confirmLabel = 'Approve',
+    bool dangerous = false,
+  }) async {
+    final result = await showModalBottomSheet<bool>(
+      context: context,
+      isScrollControlled: true,
+      showDragHandle: true,
+      builder: (_) => ApprovalSheet(
+        title: title,
+        rows: rows,
+        method: method,
+        confirmLabel: confirmLabel,
+        dangerous: dangerous,
+      ),
+    );
+    return result ?? false;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return SafeArea(
+      child: Padding(
+        padding: EdgeInsets.only(
+          left: 20,
+          right: 20,
+          bottom: MediaQuery.of(context).viewInsets.bottom + 16,
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Row(
+              children: [
+                Expanded(
+                  child: Text(title, style: theme.textTheme.titleLarge),
+                ),
+                if (method != null)
+                  Container(
+                    padding:
+                        const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                    decoration: BoxDecoration(
+                      color: theme.colorScheme.surfaceContainerHighest,
+                      borderRadius: BorderRadius.circular(6),
+                    ),
+                    child: Text(method!,
+                        style: const TextStyle(
+                            fontFamily: 'monospace', fontSize: 12)),
+                  ),
+              ],
+            ),
+            const SizedBox(height: 16),
+            for (final row in rows) _DetailRow(row: row),
+            const SizedBox(height: 24),
+            Row(
+              children: [
+                Expanded(
+                  child: OutlinedButton(
+                    onPressed: () => Navigator.of(context).pop(false),
+                    child: const Text('Reject'),
+                  ),
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: FilledButton(
+                    style: dangerous
+                        ? FilledButton.styleFrom(
+                            backgroundColor: theme.colorScheme.error,
+                            foregroundColor: theme.colorScheme.onError,
+                          )
+                        : null,
+                    onPressed: () => Navigator.of(context).pop(true),
+                    child: Text(confirmLabel),
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _DetailRow extends StatelessWidget {
+  const _DetailRow({required this.row});
+
+  final ApprovalRow row;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 6),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(row.key,
+              style: Theme.of(context).textTheme.labelMedium?.copyWith(
+                    color: Theme.of(context).colorScheme.primary,
+                  )),
+          const SizedBox(height: 2),
+          SelectableText(
+            row.value,
+            style: const TextStyle(fontFamily: 'monospace', fontSize: 13),
+            maxLines: 6,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/examples/web3_webview_demo/lib/widgets/debug_panel.dart
+++ b/examples/web3_webview_demo/lib/widgets/debug_panel.dart
@@ -1,0 +1,131 @@
+import 'package:flutter/material.dart';
+
+import 'package:web3_webview_demo/services/bridge_log.dart';
+
+/// Bottom-sheet view of the [BridgeLog]. Phase 3 surfaces it from the
+/// browser page's AppBar so a tester can immediately see the request /
+/// response JSON for whatever the DApp just triggered. Phase 6 reuses the
+/// same entry rendering in the full settings log viewer.
+class DebugPanel extends StatelessWidget {
+  const DebugPanel({super.key, required this.log});
+
+  final BridgeLog log;
+
+  static Future<void> show(BuildContext context, BridgeLog log) {
+    return showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      showDragHandle: true,
+      builder: (_) => DraggableScrollableSheet(
+        expand: false,
+        initialChildSize: 0.6,
+        maxChildSize: 0.9,
+        builder: (_, controller) => DebugPanel(log: log),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedBuilder(
+      animation: log,
+      builder: (context, _) {
+        final entries = log.entries.reversed.toList();
+        return Column(
+          children: [
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16),
+              child: Row(
+                children: [
+                  Text('Bridge log',
+                      style: Theme.of(context).textTheme.titleLarge),
+                  const Spacer(),
+                  TextButton.icon(
+                    onPressed: log.clear,
+                    icon: const Icon(Icons.delete_outline),
+                    label: const Text('Clear'),
+                  ),
+                ],
+              ),
+            ),
+            const Divider(height: 1),
+            Expanded(
+              child: entries.isEmpty
+                  ? const Center(child: Text('No bridge calls yet'))
+                  : ListView.separated(
+                      itemCount: entries.length,
+                      separatorBuilder: (_, __) => const Divider(height: 1),
+                      itemBuilder: (_, i) => _LogTile(entry: entries[i]),
+                    ),
+            ),
+          ],
+        );
+      },
+    );
+  }
+}
+
+class _LogTile extends StatelessWidget {
+  const _LogTile({required this.entry});
+
+  final BridgeLogEntry entry;
+
+  @override
+  Widget build(BuildContext context) {
+    final (icon, color) = switch (entry.status) {
+      BridgeLogStatus.pending => (Icons.hourglass_empty, Colors.orange),
+      BridgeLogStatus.success => (Icons.check_circle_outline, Colors.green),
+      BridgeLogStatus.error => (Icons.error_outline, Colors.red),
+    };
+    final ms = entry.elapsedMicros == null
+        ? ''
+        : ' · ${(entry.elapsedMicros! / 1000).toStringAsFixed(1)}ms';
+
+    return ExpansionTile(
+      leading: Icon(icon, color: color),
+      title: Text(entry.method,
+          style: const TextStyle(fontFamily: 'monospace')),
+      subtitle: Text('${_time(entry.timestamp)}$ms'),
+      childrenPadding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+      children: [
+        _JsonBlock(label: 'request', value: entry.request),
+        if (entry.response != null)
+          _JsonBlock(label: 'response', value: entry.response),
+      ],
+    );
+  }
+
+  String _time(DateTime t) {
+    String two(int n) => n.toString().padLeft(2, '0');
+    return '${two(t.hour)}:${two(t.minute)}:${two(t.second)}';
+  }
+}
+
+class _JsonBlock extends StatelessWidget {
+  const _JsonBlock({required this.label, required this.value});
+
+  final String label;
+  final Object? value;
+
+  @override
+  Widget build(BuildContext context) {
+    return Align(
+      alignment: Alignment.centerLeft,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(label,
+              style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                    color: Theme.of(context).colorScheme.primary,
+                  )),
+          const SizedBox(height: 2),
+          SelectableText(
+            '$value',
+            style: const TextStyle(fontFamily: 'monospace', fontSize: 12),
+          ),
+          const SizedBox(height: 8),
+        ],
+      ),
+    );
+  }
+}

--- a/examples/web3_webview_demo/test/approval_sheet_test.dart
+++ b/examples/web3_webview_demo/test/approval_sheet_test.dart
@@ -1,0 +1,84 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:web3_webview_demo/widgets/approval_sheet.dart';
+
+void main() {
+  // Pumps a host with an "open" button that stores the sheet's result into
+  // [resultBox] when the async `ApprovalSheet.show` completes. Tests tap
+  // "open", then drive the sheet and read `resultBox.value`.
+  Future<void> pumpHost(WidgetTester tester, List<bool?> resultBox) async {
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: Builder(
+          builder: (context) => ElevatedButton(
+            onPressed: () async {
+              resultBox[0] = await ApprovalSheet.show(
+                context,
+                title: 'Sign message',
+                method: 'personal_sign',
+                rows: const [
+                  MapEntry('Account', '0xabc'),
+                  MapEntry('Message', 'gm'),
+                ],
+              );
+            },
+            child: const Text('open'),
+          ),
+        ),
+      ),
+    ));
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('renders title, method chip, and detail rows', (tester) async {
+    await tester.pumpWidget(const MaterialApp(
+      home: Scaffold(
+        body: ApprovalSheet(
+          title: 'Sign message',
+          method: 'personal_sign',
+          rows: [
+            MapEntry('Account', '0xabc'),
+            MapEntry('Message', 'gm'),
+          ],
+        ),
+      ),
+    ));
+
+    expect(find.text('Sign message'), findsOneWidget);
+    expect(find.text('personal_sign'), findsOneWidget);
+    expect(find.text('Account'), findsOneWidget);
+    expect(find.text('gm'), findsOneWidget);
+    expect(find.text('Approve'), findsOneWidget);
+    expect(find.text('Reject'), findsOneWidget);
+  });
+
+  testWidgets('Approve resolves to true', (tester) async {
+    final result = <bool?>[null];
+    await pumpHost(tester, result);
+
+    await tester.tap(find.text('Approve'));
+    await tester.pumpAndSettle();
+    expect(result[0], isTrue);
+  });
+
+  testWidgets('Reject resolves to false', (tester) async {
+    final result = <bool?>[null];
+    await pumpHost(tester, result);
+
+    await tester.tap(find.text('Reject'));
+    await tester.pumpAndSettle();
+    expect(result[0], isFalse);
+  });
+
+  testWidgets('barrier dismiss resolves to false', (tester) async {
+    final result = <bool?>[null];
+    await pumpHost(tester, result);
+
+    // Tap above the sheet to dismiss it via the modal barrier.
+    await tester.tapAt(const Offset(10, 10));
+    await tester.pumpAndSettle();
+    expect(result[0], isFalse);
+  });
+}

--- a/examples/web3_webview_demo/test/signing_flow_test.dart
+++ b/examples/web3_webview_demo/test/signing_flow_test.dart
@@ -1,0 +1,150 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_web3_webview/flutter_web3_webview.dart';
+
+import 'package:web3_webview_demo/services/bridge_log.dart';
+import 'package:web3_webview_demo/services/eth_signer.dart';
+import 'package:web3_webview_demo/services/request_summary.dart';
+import 'package:web3_webview_demo/services/sol_signer.dart';
+import 'package:web3_webview_demo/services/wallet_state.dart';
+
+void main() {
+  final account = kDemoAccounts.first;
+
+  group('MockEthSigner', () {
+    const signer = MockEthSigner();
+
+    test('personalSign returns a 65-byte 0x signature, stable per input',
+        () async {
+      final a = await signer.personalSign(account: account, message: '0xdead');
+      final b = await signer.personalSign(account: account, message: '0xdead');
+      final c = await signer.personalSign(account: account, message: '0xbeef');
+
+      expect(a, startsWith('0x'));
+      expect(a.length, 132); // 0x + 130 hex chars = 65 bytes
+      expect(a, b, reason: 'deterministic for identical input');
+      expect(a, isNot(c), reason: 'varies with the message');
+    });
+
+    test('sendTransaction returns a 32-byte 0x hash without broadcasting',
+        () async {
+      final tx = JsTransactionObject.fromJson({
+        'from': account.evmAddress,
+        'to': '0x0000000000000000000000000000000000000000',
+        'value': '0x1',
+      });
+      final hash = await signer.sendTransaction(
+        account: account,
+        transaction: tx,
+        broadcast: false,
+        rpcUrl: 'https://example.invalid',
+      );
+      expect(hash, startsWith('0x'));
+      expect(hash.length, 66); // 0x + 64 hex chars = 32 bytes
+    });
+  });
+
+  group('MockSolSigner', () {
+    const signer = MockSolSigner();
+
+    test('signMessage returns an 88-char base58-ish signature', () async {
+      final data = JsCallBackData(
+          method: 'solana_signMessage', params: {'raw': '0xabcd'});
+      final sig = await signer.signMessage(account: account, data: data);
+      expect(sig.length, 88);
+      // base58 never contains 0, O, I, or l.
+      expect(sig, isNot(contains('0')));
+      expect(sig, isNot(contains('O')));
+      expect(sig, isNot(contains('I')));
+      expect(sig, isNot(contains('l')));
+    });
+  });
+
+  group('RequestSummary', () {
+    test('decodes a hex-encoded personal_sign message to UTF-8', () {
+      final hex = '0x${utf8.encode('gm fren').map((b) => b.toRadixString(16).padLeft(2, '0')).join()}';
+      final summary = RequestSummary.ethMessage(
+        title: 'Sign message',
+        account: account.evmAddress,
+        message: hex,
+      );
+      final messageRow =
+          summary.rows.firstWhere((r) => r.key == 'Message').value;
+      expect(messageRow, 'gm fren');
+    });
+
+    test('pulls domain + primaryType out of typed data', () {
+      final payload = jsonEncode({
+        'domain': {'name': 'My DApp'},
+        'primaryType': 'Permit',
+        'message': {'value': 1},
+      });
+      final summary = RequestSummary.ethTypedData(
+        account: account.evmAddress,
+        payload: payload,
+      );
+      expect(summary.rows.firstWhere((r) => r.key == 'Domain').value,
+          'My DApp');
+      expect(summary.rows.firstWhere((r) => r.key == 'Primary type').value,
+          'Permit');
+    });
+
+    test('summarises a send-transaction with truncated calldata', () {
+      final tx = JsTransactionObject.fromJson({
+        'from': account.evmAddress,
+        'to': '0xdeadbeef',
+        'value': '0x2386f26fc10000',
+        'data': '0x${'ab' * 100}',
+      });
+      final summary = RequestSummary.ethTransaction(transaction: tx);
+      expect(summary.rows.firstWhere((r) => r.key == 'To').value, '0xdeadbeef');
+      expect(summary.rows.firstWhere((r) => r.key == 'Data').value,
+          contains('chars)'));
+    });
+  });
+
+  group('BridgeLog round-trip semantics', () {
+    test('begin → resolve records success with elapsed time', () {
+      final log = BridgeLog();
+      addTearDown(log.dispose);
+
+      final id = log.begin(method: 'personal_sign', request: '0xdead');
+      expect(log.entries.single.status, BridgeLogStatus.pending);
+
+      log.resolve(id, response: '0xsig', elapsed: const Duration(milliseconds: 12));
+      final entry = log.entries.single;
+      expect(entry.status, BridgeLogStatus.success);
+      expect(entry.response, '0xsig');
+      expect(entry.elapsedMicros, 12000);
+    });
+
+    test('begin → reject records error', () {
+      final log = BridgeLog();
+      addTearDown(log.dispose);
+
+      final id = log.begin(method: 'eth_sendTransaction', request: {});
+      log.reject(id, error: 'user rejected');
+      expect(log.entries.single.status, BridgeLogStatus.error);
+      expect(log.entries.single.response, 'user rejected');
+    });
+
+    test('record() captures a synchronous round-trip in one call', () {
+      final log = BridgeLog();
+      addTearDown(log.dispose);
+
+      log.record(method: 'eth_accounts', response: ['0xabc']);
+      expect(log.entries.single.status, BridgeLogStatus.success);
+    });
+
+    test('honours the capacity bound', () {
+      final log = BridgeLog(capacity: 2);
+      addTearDown(log.dispose);
+
+      log.record(method: 'a');
+      log.record(method: 'b');
+      log.record(method: 'c');
+      expect(log.entries.map((e) => e.method), ['b', 'c']);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Phase 3 — the core of the demo. Stacked on #32 (which is stacked on #31). Wires **every** `Web3Webview` callback through a confirmation sheet and a bridge log, against deterministic **mock** signers. Phase 4 / 5 swap in real `web3dart` / ed25519 signing behind the same interfaces.

### Callback coverage

| Callback | Behaviour |
|----------|-----------|
| `ethAccounts` / `ethChainId` / `solAccount` | resolve immediately when auto-approve-reads is on, else prompt |
| `ethPersonalSign` / `ethSign` / `ethSignTypedData` | approval sheet → `EthSigner` |
| `ethSendTransaction` | approval sheet (danger styling) → mock hash unless real-broadcast |
| `walletSwitchEthereumChain` | approval sheet → updates `WalletState`; returns `false` on reject so the dispatcher raises EIP-1193 `4001` |
| `solSignMessage` / `solSignTransaction` | approval sheet → `SolSigner` |
| `onDefaultCallback` | logged + rejected so unknown methods fail loudly |

Rejecting any sheet throws `UserRejectedException` whose `toString()` is the EIP-1193 `4001` JSON — the DApp sees a real wallet's rejection shape.

### Wallet → DApp direction

While a DApp is open, switching the active chain / EVM account / Solana account (e.g. from Settings) pushes `emitChainChanged` / `emitAccountsChanged` / `solana.emitAccountChanged` into the page via `evaluateJavascript`. This showcases the bidirectional bridge — not just DApp → wallet.

### Bridge log

Every round-trip (including emits) is recorded and viewable from the browser AppBar's terminal icon, with expandable request/response JSON per entry.

> **Stacked on #32 → #31.** Review/merge those first; GitHub retargets the base as each lands. The diff here is Phase 3 only.

## Test plan

- [x] `flutter analyze` — no issues
- [x] `flutter test` — 36/36 passing (16 new)
  - `MockEthSigner` / `MockSolSigner` signature shapes
  - `RequestSummary` hex→UTF-8 decode, typed-data extraction, calldata truncation
  - `BridgeLog` begin→resolve / reject / record / capacity
  - `ApprovalSheet` render + approve/reject/dismiss results
- [ ] Manual smoke: open the MetaMask test dapp → connect (auto-approves), then trigger personal_sign / signTypedData_v4 / sendTransaction and confirm each pops the sheet; reject one and confirm the dapp shows a 4001; open the bridge log and verify the entries.

## Roadmap

| Phase | Status |
|------:|--------|
| 1 skeleton (#31) | ✅ |
| 2 home polish (#32) | ✅ |
| **3 callback wiring (this)** | ✅ |
| 4 EVM signing (web3dart 3.0.2) | next |
| 5 Solana signing | ☐ |
| 6 settings toggles + log viewer | ☐ |
| 7 docs + checklist | ☐ |