### PR TITLE
feat(demo): real Solana signing with ed25519 + base58 (Phase 5)

### DIFF
--- a/examples/web3_webview_demo/README.md
+++ b/examples/web3_webview_demo/README.md
@@ -25,8 +25,8 @@ reviewable.
 | **1** | App shell + zero-dep state mgmt + bookmark grid + chain / account pickers (placeholders for signing / approval / log) | ✅ |
 | **2** | Custom-URL bar, live bookmark search, in-memory recent-visit row | ✅ |
 | **3** | Full callback wiring + approval sheet + bridge log + wallet→DApp event emit (mock signers) | ✅ |
-| **4** | Real EVM signing (`web3dart` + self-rolled EIP-712): `personal_sign`, `eth_sign`, `eth_signTypedData_v4`, `eth_sendTransaction` | ✅ this commit |
-| 5 | Solana signing (`cryptography` + `bs58`): `solana_signMessage`, `solana_signTransaction` | ☐ |
+| **4** | Real EVM signing (`web3dart` + self-rolled EIP-712): `personal_sign`, `eth_sign`, `eth_signTypedData_v4`, `eth_sendTransaction` | ✅ |
+| **5** | Real Solana signing (`cryptography` ed25519 + self-rolled base58): `solana_signMessage`, `solana_signTransaction` | ✅ this commit |
 | 6 | Settings: auto-approve toggle, real-broadcast toggle, bridge-log viewer | ☐ |
 | 7 | README screenshots, manual regression checklist, more widget tests | ☐ |
 
@@ -107,9 +107,26 @@ Every round-trip — including the emits — is recorded in the `BridgeLog`,
 viewable from the browser AppBar's terminal icon.
 
 Signers are injected through `DemoApp` behind the `EthSigner` /
-`SolSigner` interfaces. The EVM side now uses the **real** `web3dart`
-implementation (`Web3DartEthSigner`); the Solana side is still
-`MockSolSigner` until Phase 5. `MockEthSigner` is retained for tests.
+`SolSigner` interfaces. Both sides now use **real** implementations
+(`Web3DartEthSigner`, `Ed25519SolSigner`); the `Mock*` signers are
+retained for tests.
+
+## Solana signing (Phase 5)
+
+`Ed25519SolSigner` signs with the `cryptography` package's ed25519 over
+each account's fixed demo seed, plus a hand-rolled base58 codec
+(`services/base58.dart`) — matching the "roll the Solana bits yourself"
+choice. The two methods return **different encodings** on purpose,
+matching what the injected provider JS expects:
+
+| Method | Returns | Why |
+|--------|---------|-----|
+| `solana_signMessage` | hex (`0x…`) | provider decodes via `messageToBuffer` (hex) |
+| `solana_signTransaction` | base58 | provider decodes via `bs58.decode` |
+
+The Solana demo addresses are `base58(ed25519PublicKey(seed))`, verified
+against the seeds in `test/sol_signing_test.dart` so the catalogue can
+never drift from the keys.
 
 ## EVM signing (Phase 4)
 

--- a/examples/web3_webview_demo/lib/app.dart
+++ b/examples/web3_webview_demo/lib/app.dart
@@ -20,7 +20,7 @@ class DemoApp extends StatefulWidget {
     BridgeLog? bridgeLog,
     RecentVisits? recentVisits,
     this.ethSigner = const Web3DartEthSigner(),
-    this.solSigner = const MockSolSigner(),
+    this.solSigner = const Ed25519SolSigner(),
   })  : _walletState = walletState,
         _bridgeLog = bridgeLog,
         _recentVisits = recentVisits;

--- a/examples/web3_webview_demo/lib/services/base58.dart
+++ b/examples/web3_webview_demo/lib/services/base58.dart
@@ -1,0 +1,108 @@
+import 'dart:typed_data';
+
+/// Bitcoin / Solana base58 alphabet (no 0, O, I, l).
+const String _alphabet =
+    '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
+
+/// Encode [bytes] to a base58 string. Hand-rolled (rather than a `bs58`
+/// dependency) per the demo's "roll the Solana bits yourself" choice.
+String base58Encode(Uint8List bytes) {
+  if (bytes.isEmpty) return '';
+
+  var zeros = 0;
+  while (zeros < bytes.length && bytes[zeros] == 0) {
+    zeros++;
+  }
+
+  // Work on a mutable big-endian base-256 copy, repeatedly dividing by 58.
+  final input = Uint8List.fromList(bytes);
+  final encoded = <int>[];
+  var start = zeros;
+  while (start < input.length) {
+    var remainder = 0;
+    for (var i = start; i < input.length; i++) {
+      final acc = (remainder << 8) + input[i];
+      input[i] = acc ~/ 58;
+      remainder = acc % 58;
+    }
+    encoded.add(remainder);
+    while (start < input.length && input[start] == 0) {
+      start++;
+    }
+  }
+
+  final sb = StringBuffer();
+  for (var i = 0; i < zeros; i++) {
+    sb.write('1');
+  }
+  for (var i = encoded.length - 1; i >= 0; i--) {
+    sb.write(_alphabet[encoded[i]]);
+  }
+  return sb.toString();
+}
+
+/// Decode a base58 [input] string to bytes. Throws [FormatException] on an
+/// out-of-alphabet character.
+Uint8List base58Decode(String input) {
+  if (input.isEmpty) return Uint8List(0);
+
+  final digits = List<int>.filled(input.length, 0);
+  for (var i = 0; i < input.length; i++) {
+    final idx = _alphabet.indexOf(input[i]);
+    if (idx < 0) {
+      throw FormatException('Invalid base58 character: ${input[i]}');
+    }
+    digits[i] = idx;
+  }
+
+  var zeros = 0;
+  while (zeros < input.length && input[zeros] == '1') {
+    zeros++;
+  }
+
+  final decoded = <int>[];
+  var start = zeros;
+  while (start < digits.length) {
+    var remainder = 0;
+    for (var i = start; i < digits.length; i++) {
+      final acc = remainder * 58 + digits[i];
+      digits[i] = acc ~/ 256;
+      remainder = acc % 256;
+    }
+    decoded.add(remainder);
+    while (start < digits.length && digits[start] == 0) {
+      start++;
+    }
+  }
+
+  final result = <int>[];
+  for (var i = 0; i < zeros; i++) {
+    result.add(0);
+  }
+  for (var i = decoded.length - 1; i >= 0; i--) {
+    result.add(decoded[i]);
+  }
+  return Uint8List.fromList(result);
+}
+
+/// Decode a hex string (with or without a `0x` prefix) to bytes.
+Uint8List hexDecode(String input) {
+  var hex = input.startsWith('0x') || input.startsWith('0X')
+      ? input.substring(2)
+      : input;
+  if (hex.length.isOdd) hex = '0$hex';
+  final out = Uint8List(hex.length ~/ 2);
+  for (var i = 0; i < out.length; i++) {
+    out[i] = int.parse(hex.substring(i * 2, i * 2 + 2), radix: 16);
+  }
+  return out;
+}
+
+/// Encode bytes to a lower-case hex string (no `0x` prefix).
+String hexEncode(Uint8List bytes) {
+  final sb = StringBuffer();
+  for (final b in bytes) {
+    sb.write(b.toRadixString(16).padLeft(2, '0'));
+  }
+  return sb.toString();
+}

--- a/examples/web3_webview_demo/lib/services/sol_signer.dart
+++ b/examples/web3_webview_demo/lib/services/sol_signer.dart
@@ -1,5 +1,9 @@
+import 'dart:typed_data';
+
+import 'package:cryptography/cryptography.dart';
 import 'package:flutter_web3_webview/flutter_web3_webview.dart';
 
+import 'package:web3_webview_demo/services/base58.dart';
 import 'package:web3_webview_demo/services/wallet_state.dart';
 
 /// Solana signing surface the browser page drives.
@@ -64,5 +68,67 @@ class MockSolSigner implements SolSigner {
       value = (value * 1103515245 + 12345) & 0x7fffffff;
     }
     return buffer.toString();
+  }
+}
+
+/// Real Solana signer: ed25519 over the demo account's fixed seed, using
+/// the `cryptography` package and the hand-rolled base58 codec.
+///
+/// The two methods return *different* encodings on purpose, matching what
+/// the injected provider JavaScript expects:
+///   * `solana_signMessage` → hex (the provider's `messageToBuffer` decodes
+///     the wallet response as hex);
+///   * `solana_signTransaction` → base58 (the provider's
+///     `mapSignedTransaction` runs `bs58.decode` on the response).
+class Ed25519SolSigner implements SolSigner {
+  const Ed25519SolSigner();
+
+  static final Ed25519 _ed = Ed25519();
+
+  Future<SimpleKeyPair> _keyPair(DemoAccount account) {
+    return _ed.newKeyPairFromSeed(hexDecode(account.solanaSeed));
+  }
+
+  /// base58 public key (Solana address) for [account]. Used by the tests to
+  /// assert the catalogue addresses match the seeds.
+  Future<String> addressOf(DemoAccount account) async {
+    final pub = await (await _keyPair(account)).extractPublicKey();
+    return base58Encode(Uint8List.fromList(pub.bytes));
+  }
+
+  @override
+  Future<String> signMessage({
+    required DemoAccount account,
+    required JsCallBackData data,
+  }) async {
+    final sig = await _sign(account, _rawBytes(data));
+    // hex out — the provider decodes this with messageToBuffer.
+    return '0x${hexEncode(sig)}';
+  }
+
+  @override
+  Future<String> signTransaction({
+    required DemoAccount account,
+    required JsCallBackData data,
+  }) async {
+    final sig = await _sign(account, _rawBytes(data));
+    // base58 out — the provider decodes this with bs58.decode.
+    return base58Encode(sig);
+  }
+
+  Future<Uint8List> _sign(DemoAccount account, Uint8List message) async {
+    final keyPair = await _keyPair(account);
+    final signature = await _ed.sign(message, keyPair: keyPair);
+    return Uint8List.fromList(signature.bytes);
+  }
+
+  /// Extract the signed-over bytes from the `{ raw: <hex>, … }` params both
+  /// Solana methods carry.
+  Uint8List _rawBytes(JsCallBackData data) {
+    final params = data.params;
+    if (params is Map && params['raw'] is String) {
+      return hexDecode(params['raw'] as String);
+    }
+    return Uint8List(0);
   }
 }

--- a/examples/web3_webview_demo/lib/services/wallet_state.dart
+++ b/examples/web3_webview_demo/lib/services/wallet_state.dart
@@ -23,9 +23,13 @@ class DemoAccount {
   /// key** (see the class doc) — never reuse for anything with value.
   final String evmPrivateKey;
 
-  /// base58 Solana public key. The matching ed25519 secret key is wired in
-  /// Phase 5 alongside the Solana signer.
+  /// base58 Solana public key derived from [solanaSeed].
   final String solanaAddress;
+
+  /// 0x-prefixed 32-byte ed25519 seed for the Solana account. A fixed demo
+  /// seed (not a real BIP-44 derivation) — see the class doc. Public test
+  /// material; never reuse.
+  final String solanaSeed;
 
   /// BIP-44 derivation index (0, 1, 2 …).
   final int derivationIndex;
@@ -35,6 +39,7 @@ class DemoAccount {
     required this.evmAddress,
     required this.evmPrivateKey,
     required this.solanaAddress,
+    required this.solanaSeed,
     required this.derivationIndex,
   });
 }
@@ -50,14 +55,18 @@ class DemoAccount {
 /// scan for them.
 ///
 ///   * EVM uses BIP-44 path `m/44'/60'/0'/0/<index>` (keys below).
-///   * Solana uses BIP-44 path `m/44'/501'/<index>'/0'` (Phase 5).
+///   * Solana uses a fixed demo ed25519 seed per account (not BIP-44); the
+///     `solanaAddress` is `base58(ed25519PublicKey(solanaSeed))`, verified
+///     in `test/sol_signing_test.dart`.
 const List<DemoAccount> kDemoAccounts = <DemoAccount>[
   DemoAccount(
     label: 'Account 1',
     evmAddress: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
     evmPrivateKey:
         '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80',
-    solanaAddress: '5ZWj7a1f8tWkjBESHKgrLmZhGh7yBR8Cmjw6aQGhRTMQ',
+    solanaAddress: 'F25s3DdjXdCxYBhh2z8FBusVEMT4b9bGNFVKJi3wFoF4',
+    solanaSeed:
+        '0x1111111111111111111111111111111111111111111111111111111111111111',
     derivationIndex: 0,
   ),
   DemoAccount(
@@ -65,7 +74,9 @@ const List<DemoAccount> kDemoAccounts = <DemoAccount>[
     evmAddress: '0x70997970C51812dc3A010C7d01b50e0d17dc79C8',
     evmPrivateKey:
         '0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d',
-    solanaAddress: 'GwHH8ciFhR8vejWCqmg8FWZUCNtubPY2esALvy5tBvji',
+    solanaAddress: 'Bow1CGKGDB9mNxeWdw85E2aCthQ1oZX4oFEe7fYT17ew',
+    solanaSeed:
+        '0x2222222222222222222222222222222222222222222222222222222222222222',
     derivationIndex: 1,
   ),
   DemoAccount(
@@ -73,7 +84,9 @@ const List<DemoAccount> kDemoAccounts = <DemoAccount>[
     evmAddress: '0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC',
     evmPrivateKey:
         '0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a',
-    solanaAddress: 'FN5sV1iyrnUMtSdaXbq5o24WnTcyJ4MEArytfSe6gE2c',
+    solanaAddress: '2btLJAAb1S3x6hZYdVyAePjqtQYi2ZBSRGy4569RZu8h',
+    solanaSeed:
+        '0x3333333333333333333333333333333333333333333333333333333333333333',
     derivationIndex: 2,
   ),
 ];

--- a/examples/web3_webview_demo/pubspec.lock
+++ b/examples/web3_webview_demo/pubspec.lock
@@ -57,6 +57,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.6"
+  cryptography:
+    dependency: "direct main"
+    description:
+      name: cryptography
+      sha256: "3eda3029d34ec9095a27a198ac9785630fe525c0eb6a49f3d575272f8e792ef0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.9.0"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -89,6 +97,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.3"
+  ffi:
+    dependency: transitive
+    description:
+      name: ffi
+      sha256: "6d7fd89431262d8f3125e81b50d3847a091d846eafcd4fdb88dd06f36d705a45"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.0"
   fixnum:
     dependency: transitive
     description:

--- a/examples/web3_webview_demo/pubspec.yaml
+++ b/examples/web3_webview_demo/pubspec.yaml
@@ -20,6 +20,7 @@ dependencies:
   web3dart: ^3.0.2
   http: ^1.6.0
   wallet: ^0.0.18
+  cryptography: ^2.9.0
 
 dev_dependencies:
   flutter_test:

--- a/examples/web3_webview_demo/test/sol_signing_test.dart
+++ b/examples/web3_webview_demo/test/sol_signing_test.dart
@@ -1,0 +1,105 @@
+import 'dart:typed_data';
+
+import 'package:cryptography/cryptography.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_web3_webview/flutter_web3_webview.dart';
+
+import 'package:web3_webview_demo/services/base58.dart';
+import 'package:web3_webview_demo/services/sol_signer.dart';
+import 'package:web3_webview_demo/services/wallet_state.dart';
+
+void main() {
+  final account = kDemoAccounts.first;
+  const signer = Ed25519SolSigner();
+  final ed = Ed25519();
+
+  // Verify an ed25519 signature [sig] over [message] for [account].
+  Future<bool> verify(
+      Uint8List sig, Uint8List message, DemoAccount account) async {
+    final keyPair = await ed.newKeyPairFromSeed(hexDecode(account.solanaSeed));
+    final pub = await keyPair.extractPublicKey();
+    return ed.verify(
+      message,
+      signature: Signature(sig, publicKey: pub),
+    );
+  }
+
+  group('base58 codec', () {
+    test('round-trips arbitrary bytes', () {
+      final cases = [
+        Uint8List.fromList([0, 0, 1, 2, 3]),
+        Uint8List.fromList(List.generate(32, (i) => i)),
+        Uint8List.fromList([255, 254, 253]),
+      ];
+      for (final bytes in cases) {
+        expect(base58Decode(base58Encode(bytes)), bytes);
+      }
+    });
+
+    test('preserves leading zeros as 1s', () {
+      final bytes = Uint8List.fromList([0, 0, 5]);
+      final encoded = base58Encode(bytes);
+      expect(encoded, startsWith('11'));
+      expect(base58Decode(encoded), bytes);
+    });
+
+    test('rejects invalid characters', () {
+      expect(() => base58Decode('0OIl'), throwsFormatException);
+    });
+  });
+
+  group('Ed25519SolSigner addresses', () {
+    test('catalogue solanaAddress matches the seed-derived public key',
+        () async {
+      for (final account in kDemoAccounts) {
+        final derived = await signer.addressOf(account);
+        expect(derived, account.solanaAddress, reason: account.label);
+      }
+    });
+  });
+
+  group('Ed25519SolSigner signing', () {
+    test('signMessage returns a verifiable hex signature', () async {
+      final message = Uint8List.fromList([1, 2, 3, 4, 5]);
+      final data = JsCallBackData(
+        method: 'solana_signMessage',
+        params: {'raw': '0x${hexEncode(message)}'},
+      );
+      final sigHex = await signer.signMessage(account: account, data: data);
+
+      expect(sigHex, startsWith('0x'));
+      final sig = hexDecode(sigHex);
+      expect(sig.length, 64);
+      expect(await verify(sig, message, account), isTrue);
+    });
+
+    test('signTransaction returns a verifiable base58 signature', () async {
+      final message = Uint8List.fromList(List.generate(40, (i) => i));
+      final data = JsCallBackData(
+        method: 'solana_signTransaction',
+        params: {
+          'raw': hexEncode(message),
+          'message': 'unused-base64',
+        },
+      );
+      final sigB58 =
+          await signer.signTransaction(account: account, data: data);
+
+      final sig = base58Decode(sigB58);
+      expect(sig.length, 64);
+      expect(await verify(sig, message, account), isTrue);
+    });
+
+    test('different accounts produce different signatures', () async {
+      final data = JsCallBackData(
+        method: 'solana_signMessage',
+        params: {'raw': '0xabcdef'},
+      );
+      final sigs = <String>{};
+      for (final account in kDemoAccounts) {
+        sigs.add(await signer.signMessage(account: account, data: data));
+      }
+      expect(sigs.length, kDemoAccounts.length);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Phase 5 — swap the mock Solana signer for `Ed25519SolSigner`: real ed25519 signatures (`cryptography` package) over each account's fixed demo seed, plus a hand-rolled base58 codec (no `bs58` dependency, per the "roll the Solana bits yourself" choice).

### Encoding matters

The two Solana methods return **different** encodings, matching what the injected provider JS decodes:

| Method | Returns | Provider decodes via |
|--------|---------|----------------------|
| `solana_signMessage` | hex (`0x…`) | `messageToBuffer` (hex) |
| `solana_signTransaction` | base58 | `mapSignedTransaction` → `bs58.decode` |

Getting this wrong would silently corrupt signatures, so both are covered by tests that ed25519-`verify` the result.

### Addresses

`DemoAccount.solanaAddress` values are now the real `base58(ed25519PublicKey(seed))`, verified against the seeds in the test so the catalogue can't drift.

Dependency added: `cryptography` (pure Dart — no pointycastle conflict).

## Test plan

- [x] `flutter analyze` clean
- [x] `flutter test` 51/51 (10 new)
  - base58 round-trip / leading-zero preservation / invalid-char rejection
  - catalogue `solanaAddress` matches seed-derived public key
  - `signMessage` hex signature ed25519-verifies
  - `signTransaction` base58 signature ed25519-verifies
  - different accounts → different signatures
- [ ] Manual: open a Solana dApp (Jupiter / Magic Eden), connect, sign a message + a transaction, confirm the dApp accepts the signature.

## Roadmap

| Phase | Status |
|------:|--------|
| 1-4 | ✅ merged |
| **5 Solana signing (this)** | ✅ |
| 6 settings toggles + bridge-log viewer | next |
| 7 docs + checklist | ☐ |