### PR TITLE
feat(demo): settings toggles + bridge-log viewer (Phase 6)

### DIFF
--- a/examples/web3_webview_demo/README.md
+++ b/examples/web3_webview_demo/README.md
@@ -26,8 +26,8 @@ reviewable.
 | **2** | Custom-URL bar, live bookmark search, in-memory recent-visit row | ✅ |
 | **3** | Full callback wiring + approval sheet + bridge log + wallet→DApp event emit (mock signers) | ✅ |
 | **4** | Real EVM signing (`web3dart` + self-rolled EIP-712): `personal_sign`, `eth_sign`, `eth_signTypedData_v4`, `eth_sendTransaction` | ✅ |
-| **5** | Real Solana signing (`cryptography` ed25519 + self-rolled base58): `solana_signMessage`, `solana_signTransaction` | ✅ this commit |
-| 6 | Settings: auto-approve toggle, real-broadcast toggle, bridge-log viewer | ☐ |
+| **5** | Real Solana signing (`cryptography` ed25519 + self-rolled base58): `solana_signMessage`, `solana_signTransaction` | ✅ |
+| **6** | Settings: auto-approve toggle, real-broadcast toggle (testnet warning), full-screen bridge-log viewer | ✅ this commit |
 | 7 | README screenshots, manual regression checklist, more widget tests | ☐ |
 
 ## Run it
@@ -75,12 +75,21 @@ lib/
 ├── pages/
 │   ├── home_page.dart    # URL bar + search + recent row + bookmark grid
 │   ├── browser_page.dart # Web3Webview — full callback wiring + emits
-│   └── settings_page.dart # account / chain picker + (pending) toggles
+│   ├── settings_page.dart # account / chain pickers + behaviour toggles
+│   └── log_page.dart      # full-screen bridge-log viewer
 └── widgets/
     ├── dapp_bookmark_grid.dart # reusable grid + tile + filter helper
     ├── approval_sheet.dart     # modal confirm sheet (approve / reject)
-    └── debug_panel.dart        # bridge-log bottom sheet
+    └── debug_panel.dart        # BridgeLogList + browser-page bottom sheet
 ```
+
+## Settings (Phase 6)
+
+| Control | Effect |
+|---------|--------|
+| Auto-approve read-only methods | `eth_accounts` / `eth_chainId` / `solana_account` resolve without a sheet |
+| Broadcast transactions over RPC | `eth_sendTransaction` signs + submits over RPC instead of returning a mock hash; warns when the active chain is not a testnet |
+| Bridge call log | opens the full-screen viewer (live entry-count badge), shared rendering with the browser-page sheet via `BridgeLogList` |
 
 ## Bridge wiring (Phase 3)
 

--- a/examples/web3_webview_demo/lib/app.dart
+++ b/examples/web3_webview_demo/lib/app.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import 'package:web3_webview_demo/pages/browser_page.dart';
 import 'package:web3_webview_demo/pages/home_page.dart';
+import 'package:web3_webview_demo/pages/log_page.dart';
 import 'package:web3_webview_demo/pages/settings_page.dart';
 import 'package:web3_webview_demo/services/bridge_log.dart';
 import 'package:web3_webview_demo/services/eth_signer.dart';
@@ -95,6 +96,11 @@ class _DemoAppState extends State<DemoApp> {
         return MaterialPageRoute(
           settings: settings,
           builder: (_) => const SettingsPage(),
+        );
+      case '/log':
+        return MaterialPageRoute(
+          settings: settings,
+          builder: (_) => const LogPage(),
         );
       case '/browser':
         final args = settings.arguments;

--- a/examples/web3_webview_demo/lib/pages/log_page.dart
+++ b/examples/web3_webview_demo/lib/pages/log_page.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+
+import 'package:web3_webview_demo/services/bridge_log.dart';
+import 'package:web3_webview_demo/widgets/debug_panel.dart';
+
+/// Full-screen bridge-log viewer reached from Settings. Reuses
+/// [BridgeLogList] so entries render the same as the browser-page sheet.
+class LogPage extends StatelessWidget {
+  const LogPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final log = BridgeLogScope.of(context);
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Bridge log'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.delete_outline),
+            tooltip: 'Clear',
+            onPressed: log.clear,
+          ),
+        ],
+      ),
+      body: BridgeLogList(log: log),
+    );
+  }
+}

--- a/examples/web3_webview_demo/lib/pages/settings_page.dart
+++ b/examples/web3_webview_demo/lib/pages/settings_page.dart
@@ -1,22 +1,15 @@
 // `RadioListTile` here intentionally uses the pre-3.32 `groupValue` /
-// `onChanged` flow. Phase 6 of the demo plan rebuilds this whole screen
-// around the new `RadioGroup` widget along with the auto-approve / real-
-// broadcast switches, so this scoped ignore stays in lock-step with the
-// rewrite rather than churning the file twice.
+// `onChanged` flow rather than the newer `RadioGroup` ancestor.
 // ignore_for_file: deprecated_member_use
 
 import 'package:flutter/material.dart';
 
 import 'package:web3_webview_demo/data/chains.dart';
+import 'package:web3_webview_demo/services/bridge_log.dart';
 import 'package:web3_webview_demo/services/wallet_state.dart';
 
-/// Skeleton settings page.
-///
-/// Phase 6 fills in the auto-approve / real-broadcast toggles plus the
-/// bridge-log viewer; today the page just exposes the picker for the
-/// active EVM account / chain so the rest of the demo has a way to
-/// exercise the `WalletState` listeners and prove the `InheritedNotifier`
-/// rebuild path works.
+/// Settings: active EVM / Solana account + chain pickers, the behaviour
+/// toggles (auto-approve reads, real broadcast) and the bridge-log entry.
 class SettingsPage extends StatelessWidget {
   const SettingsPage({super.key});
 
@@ -102,29 +95,64 @@ class SettingsPage extends StatelessWidget {
             ),
 
           const Divider(),
-          const _PendingSection(
-            label: 'Auto-approve read-only methods',
-            description:
-                'Phase 6 — toggles whether eth_accounts / eth_chainId / '
-                'solana_account resolve without a confirmation sheet.',
+          const _SectionHeader('Behaviour'),
+          SwitchListTile(
+            value: wallet.autoApproveReadMethods,
+            onChanged: (v) => wallet.autoApproveReadMethods = v,
+            title: const Text('Auto-approve read-only methods'),
+            subtitle: const Text(
+                'eth_accounts / eth_chainId / solana_account resolve '
+                'without a confirmation sheet.'),
           ),
-          const _PendingSection(
-            label: 'Broadcast transactions over RPC',
-            description:
-                'Phase 6 — when enabled (testnets only), eth_sendTransaction '
-                'and Solana signAndSendTransaction will be broadcast through '
-                "the active chain's public endpoint instead of returning a "
-                'mock tx hash.',
+          SwitchListTile(
+            value: wallet.realBroadcast,
+            onChanged: (v) => wallet.realBroadcast = v,
+            title: const Text('Broadcast transactions over RPC'),
+            isThreeLine: true,
+            subtitle: Text(
+              wallet.realBroadcast && !wallet.evmChain.isTestnet
+                  ? '⚠️ Active chain (${wallet.evmChain.name}) is not a '
+                      'testnet. These demo keys hold no funds, so a real '
+                      'broadcast will just fail with insufficient balance.'
+                  : 'When on, eth_sendTransaction is signed and submitted '
+                      'through the active chain\'s RPC instead of returning '
+                      'a mock hash. Use a testnet.',
+            ),
           ),
-          const _PendingSection(
-            label: 'Bridge call log',
-            description:
-                'Phase 3+ — every request the WebView bridge issues plus '
-                'the wallet response will land here so you can reproduce a '
-                'failed DApp interaction by replaying the JSON.',
-          ),
+
+          const Divider(),
+          const _SectionHeader('Diagnostics'),
+          _BridgeLogTile(),
         ],
       ),
+    );
+  }
+}
+
+/// Bridge-log entry with a live count badge, navigating to the full
+/// log viewer.
+class _BridgeLogTile extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    final log = BridgeLogScope.of(context);
+    return ListTile(
+      leading: const Icon(Icons.receipt_long_outlined),
+      title: const Text('Bridge call log'),
+      subtitle: const Text(
+          'Every request the WebView bridge issues, with the wallet '
+          'response — replay a failed DApp interaction from the JSON.'),
+      trailing: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          if (log.entries.isNotEmpty)
+            Chip(
+              label: Text('${log.entries.length}'),
+              visualDensity: VisualDensity.compact,
+            ),
+          const Icon(Icons.chevron_right),
+        ],
+      ),
+      onTap: () => Navigator.of(context).pushNamed('/log'),
     );
   }
 }
@@ -146,20 +174,3 @@ class _SectionHeader extends StatelessWidget {
   }
 }
 
-class _PendingSection extends StatelessWidget {
-  const _PendingSection({required this.label, required this.description});
-
-  final String label;
-  final String description;
-
-  @override
-  Widget build(BuildContext context) {
-    return ListTile(
-      leading: const Icon(Icons.construction, color: Colors.grey),
-      title: Text(label, style: const TextStyle(color: Colors.grey)),
-      subtitle: Text(description,
-          style: const TextStyle(color: Colors.grey, fontSize: 12)),
-      enabled: false,
-    );
-  }
-}

--- a/examples/web3_webview_demo/lib/widgets/debug_panel.dart
+++ b/examples/web3_webview_demo/lib/widgets/debug_panel.dart
@@ -2,10 +2,36 @@ import 'package:flutter/material.dart';
 
 import 'package:web3_webview_demo/services/bridge_log.dart';
 
-/// Bottom-sheet view of the [BridgeLog]. Phase 3 surfaces it from the
-/// browser page's AppBar so a tester can immediately see the request /
-/// response JSON for whatever the DApp just triggered. Phase 6 reuses the
-/// same entry rendering in the full settings log viewer.
+/// Scrolling list of [BridgeLog] entries (most-recent first), rebuilding on
+/// every new entry. Shared by the browser-page bottom sheet ([DebugPanel])
+/// and the full-screen settings log viewer so both render entries
+/// identically.
+class BridgeLogList extends StatelessWidget {
+  const BridgeLogList({super.key, required this.log});
+
+  final BridgeLog log;
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedBuilder(
+      animation: log,
+      builder: (context, _) {
+        final entries = log.entries.reversed.toList();
+        if (entries.isEmpty) {
+          return const Center(child: Text('No bridge calls yet'));
+        }
+        return ListView.separated(
+          itemCount: entries.length,
+          separatorBuilder: (_, __) => const Divider(height: 1),
+          itemBuilder: (_, i) => _LogTile(entry: entries[i]),
+        );
+      },
+    );
+  }
+}
+
+/// Bottom-sheet view of the [BridgeLog], shown from the browser page's
+/// AppBar terminal icon.
 class DebugPanel extends StatelessWidget {
   const DebugPanel({super.key, required this.log});
 
@@ -27,40 +53,26 @@ class DebugPanel extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return AnimatedBuilder(
-      animation: log,
-      builder: (context, _) {
-        final entries = log.entries.reversed.toList();
-        return Column(
-          children: [
-            Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 16),
-              child: Row(
-                children: [
-                  Text('Bridge log',
-                      style: Theme.of(context).textTheme.titleLarge),
-                  const Spacer(),
-                  TextButton.icon(
-                    onPressed: log.clear,
-                    icon: const Icon(Icons.delete_outline),
-                    label: const Text('Clear'),
-                  ),
-                ],
+    return Column(
+      children: [
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16),
+          child: Row(
+            children: [
+              Text('Bridge log',
+                  style: Theme.of(context).textTheme.titleLarge),
+              const Spacer(),
+              TextButton.icon(
+                onPressed: log.clear,
+                icon: const Icon(Icons.delete_outline),
+                label: const Text('Clear'),
               ),
-            ),
-            const Divider(height: 1),
-            Expanded(
-              child: entries.isEmpty
-                  ? const Center(child: Text('No bridge calls yet'))
-                  : ListView.separated(
-                      itemCount: entries.length,
-                      separatorBuilder: (_, __) => const Divider(height: 1),
-                      itemBuilder: (_, i) => _LogTile(entry: entries[i]),
-                    ),
-            ),
-          ],
-        );
-      },
+            ],
+          ),
+        ),
+        const Divider(height: 1),
+        Expanded(child: BridgeLogList(log: log)),
+      ],
     );
   }
 }

--- a/examples/web3_webview_demo/test/settings_test.dart
+++ b/examples/web3_webview_demo/test/settings_test.dart
@@ -1,0 +1,114 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:web3_webview_demo/app.dart';
+import 'package:web3_webview_demo/services/bridge_log.dart';
+import 'package:web3_webview_demo/services/wallet_state.dart';
+
+void main() {
+  // The settings screen is a long ListView; a tall viewport keeps the
+  // behaviour toggles + diagnostics tile on-screen so finders don't have
+  // to scroll lazily-built rows into view.
+  void useTallViewport(WidgetTester tester) {
+    tester.view.physicalSize = const Size(1200, 4000);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+  }
+
+  Future<void> openSettings(WidgetTester tester) async {
+    await tester.tap(find.byTooltip('Settings'));
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('auto-approve switch reflects and mutates WalletState',
+      (tester) async {
+    useTallViewport(tester);
+    final wallet = WalletState(autoApproveReadMethods: true);
+    addTearDown(wallet.dispose);
+
+    await tester.pumpWidget(DemoApp(walletState: wallet));
+    await tester.pumpAndSettle();
+    await openSettings(tester);
+
+    final switchFinder = find.widgetWithText(
+        SwitchListTile, 'Auto-approve read-only methods');
+    expect(tester.widget<SwitchListTile>(switchFinder).value, isTrue);
+
+    await tester.tap(switchFinder);
+    await tester.pumpAndSettle();
+
+    expect(wallet.autoApproveReadMethods, isFalse);
+    expect(tester.widget<SwitchListTile>(switchFinder).value, isFalse);
+  });
+
+  testWidgets('real-broadcast switch warns on a non-testnet chain',
+      (tester) async {
+    useTallViewport(tester);
+    final wallet = WalletState(evmChainId: 1); // Ethereum mainnet
+    addTearDown(wallet.dispose);
+
+    await tester.pumpWidget(DemoApp(walletState: wallet));
+    await tester.pumpAndSettle();
+    await openSettings(tester);
+
+    final switchFinder = find.widgetWithText(
+        SwitchListTile, 'Broadcast transactions over RPC');
+    await tester.tap(switchFinder);
+    await tester.pumpAndSettle();
+
+    expect(wallet.realBroadcast, isTrue);
+    expect(find.textContaining('not a'), findsOneWidget);
+    expect(find.textContaining('Ethereum'), findsWidgets);
+  });
+
+  testWidgets('bridge-log tile shows the entry count and opens the viewer',
+      (tester) async {
+    useTallViewport(tester);
+    final wallet = WalletState();
+    final log = BridgeLog();
+    addTearDown(wallet.dispose);
+    addTearDown(log.dispose);
+
+    log.record(method: 'eth_accounts', response: ['0xabc']);
+    log.record(method: 'personal_sign', response: '0xsig');
+
+    await tester.pumpWidget(DemoApp(walletState: wallet, bridgeLog: log));
+    await tester.pumpAndSettle();
+    await openSettings(tester);
+
+    // Count badge.
+    expect(find.widgetWithText(Chip, '2'), findsOneWidget);
+
+    await tester.tap(find.text('Bridge call log'));
+    await tester.pumpAndSettle();
+
+    // Full-screen viewer with both entries.
+    expect(find.widgetWithText(AppBar, 'Bridge log'), findsOneWidget);
+    expect(find.text('eth_accounts'), findsOneWidget);
+    expect(find.text('personal_sign'), findsOneWidget);
+  });
+
+  testWidgets('log viewer Clear empties the list', (tester) async {
+    useTallViewport(tester);
+    final wallet = WalletState();
+    final log = BridgeLog();
+    addTearDown(wallet.dispose);
+    addTearDown(log.dispose);
+
+    log.record(method: 'eth_chainId', response: '0x1');
+
+    await tester.pumpWidget(DemoApp(walletState: wallet, bridgeLog: log));
+    await tester.pumpAndSettle();
+    await openSettings(tester);
+    await tester.tap(find.text('Bridge call log'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('eth_chainId'), findsOneWidget);
+    await tester.tap(find.byTooltip('Clear'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('eth_chainId'), findsNothing);
+    expect(find.text('No bridge calls yet'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary

Phase 6 — turn the disabled Settings placeholders into working controls and add a full-screen bridge-log viewer.

- **Auto-approve read-only methods** — `SwitchListTile` bound to `WalletState.autoApproveReadMethods`.
- **Broadcast transactions over RPC** — bound to `WalletState.realBroadcast`; shows a warning when the active EVM chain isn't a testnet (the demo keys hold no funds, so a real broadcast just fails — the copy says so).
- **Bridge call log** — tile with a live entry-count chip → navigates to the new `/log` route.

`widgets/debug_panel.dart` is refactored to extract `BridgeLogList` so the browser-page bottom sheet and the new `pages/log_page.dart` render entries identically.

## Test plan

- [x] `flutter analyze` clean
- [x] `flutter test` 55/55 (4 new)
  - auto-approve switch reflects + mutates `WalletState`
  - real-broadcast switch warns on a non-testnet chain
  - bridge-log tile shows the entry count and opens the viewer
  - log viewer Clear empties the list
- [ ] Manual: toggle auto-approve off → connecting now prompts; flip real-broadcast on mainnet → warning shows; open the log after a few DApp calls → entries with expandable request/response JSON.

## Roadmap

| Phase | Status |
|------:|--------|
| 1-5 | ✅ merged |
| **6 settings + log viewer (this)** | ✅ |
| 7 README screenshots + manual regression checklist | last |