### PR TITLE
fix(web3): make isMetaMask configurable + fix the dead config field

### DIFF
--- a/examples/web3_webview_demo/README.md
+++ b/examples/web3_webview_demo/README.md
@@ -187,6 +187,19 @@ reads inside async handlers.
 Use this to verify a provider-JS or dispatcher change end-to-end. Run
 `flutter run`, then:
 
+> **Two gotchas when testing on real EVM DApps:**
+> 1. The demo sets `overwriteMetamask: true` (in `browser_page.dart`) so
+>    `window.ethereum.isMetaMask` reports `true`. The official MetaMask
+>    test dapp and many others gate signing / advanced features on this
+>    flag; without it those buttons stay disabled. The package itself
+>    defaults to `false` (`Web3EthSettings.overwriteMetamask`).
+> 2. The demo's EVM accounts are the **public Hardhat keys**, which
+>    mainstream DApps (OpenSea, …) block as known/abused addresses
+>    ("account has been disabled"). For EVM signing flows prefer a DApp
+>    that doesn't reputation-gate the address, or a testnet. The Solana
+>    accounts have no such problem (Magic Eden SIWS login works
+>    end-to-end).
+
 **EVM (open the MetaMask test dapp from the Tools bookmarks)**
 
 - [ ] **Connect** — the page shows the active account address; with

--- a/examples/web3_webview_demo/lib/pages/browser_page.dart
+++ b/examples/web3_webview_demo/lib/pages/browser_page.dart
@@ -156,6 +156,10 @@ class _BrowserPageState extends State<BrowserPage> {
           eth: Web3EthSettings(
             chainId: wallet.evmChainId,
             rdns: 'com.fxfi.fxwallet',
+            // Impersonate MetaMask so DApps that gate signing on
+            // `isMetaMask` (e.g. the official MetaMask test dapp) expose
+            // their full surface to the demo.
+            overwriteMetamask: true,
           ),
         ),
         onWebViewCreated: (c) => _controller = c,

--- a/packages/flutter_web3_webview/CHANGELOG.md
+++ b/packages/flutter_web3_webview/CHANGELOG.md
@@ -8,6 +8,7 @@
 * FIX: Surface EIP-1193 `4001` (user rejected) instead of the invalid `4092` code when a chain switch is declined, and reject `wallet_switchEthereumChain` with `4902` for any chain id that is missing or is not a `0x`-prefixed hex string (previously `'1'`, `'0xzz'`, `' 0x1 '` and similar values still reached the wallet callback).
 * FIX: Introduce `Web3RpcError` for structured Dart-side handling of provider failures. The `flutter_inappwebview` bridge still re-wraps the exception before it reaches the in-page DApp, so DApps continue to see a string; `Web3RpcError.toString()` now prefixes its JSON payload with the `Web3RpcError: ` sentinel so the provider JavaScript can extract the structured `{code,message}` once it is rebuilt from source (tracked separately).
 * FIX: Back `JsTransactionObject` fields with the underlying raw map so setting a typed field to `null` actually clears the value (was leaking the original DApp value through `toJson()`), while still preserving DApp-provided fields like `nonce` / `maxFeePerGas` / numeric `gas`.
+* FIX: Pass `overwriteMetamask` to the injected provider at the top level of the config object where the vendored `EthereumProvider` actually reads it. The previous `config.ethereum.isMetamask` field was never read (the rebuilt provider reads `config.overwriteMetamask`), so `window.ethereum.isMetaMask` was permanently `false` — breaking DApps that gate signing on it (e.g. the MetaMask test dapp). Add `Web3EthSettings.overwriteMetamask` (default `false`) so callers can opt into MetaMask impersonation.
 
 ## [0.1.0]
 

--- a/packages/flutter_web3_webview/lib/src/models/settings.dart
+++ b/packages/flutter_web3_webview/lib/src/models/settings.dart
@@ -16,7 +16,21 @@ class Web3EthSettings {
   /// Rdns display for EIP-6369.
   final String? rdns;
 
-  Web3EthSettings({this.chainId, this.icon, this.rdns});
+  /// When true, `window.ethereum.isMetaMask` reports `true`.
+  ///
+  /// Defaults to `false` — the wallet identifies as itself. Set it to `true`
+  /// to impersonate MetaMask, which some DApps still require (they gate
+  /// signing / advanced features on `isMetaMask`, e.g. the official
+  /// MetaMask test dapp). This is a per-integration choice; the package
+  /// does not impersonate by default.
+  final bool overwriteMetamask;
+
+  Web3EthSettings({
+    this.chainId,
+    this.icon,
+    this.rdns,
+    this.overwriteMetamask = false,
+  });
 }
 
 class Web3SolSettings {

--- a/packages/flutter_web3_webview/lib/src/utils/provider.dart
+++ b/packages/flutter_web3_webview/lib/src/utils/provider.dart
@@ -49,15 +49,28 @@ class Providers {
     final ethereumIcon = jsonEncode(settings?.eth?.icon ?? '');
     final rdns = jsonEncode(settings?.eth?.rdns ?? '');
     final providerUuid = jsonEncode(uuid);
+    final overwriteMetamask = settings?.eth?.overwriteMetamask ?? false;
 
+    // NOTE on the config shape: `EthereumProvider` / `SolanaProvider` read
+    // their options from the *top level* of this object (`config.chainId`,
+    // `config.overwriteMetamask`, `config.isFxWallet`, …). The nested
+    // `ethereum` / `solana` blocks below are legacy from the pre-rebuild
+    // fork and are NOT read by the vendored providers — they are kept only
+    // for backwards-compatibility with anything that might inspect them.
+    // Anything that must actually reach a provider has to be a top-level
+    // field, which is why `overwriteMetamask` lives here and not under
+    // `ethereum`. (`chainId` / `cluster` are intentionally NOT promoted:
+    // chain id is served by the Dart `ethChainId` callback, and promoting
+    // `cluster: 'mainnet-beta'` would make SolanaProvider construct a
+    // `Connection('mainnet-beta')` against an invalid RPC URL.)
     return '''
       (function() {
         if (window.ethereum != null) return;
 
         const config = {
+          overwriteMetamask: $overwriteMetamask,
           ethereum: {
-            chainId: ${settings?.eth?.chainId ?? 1},
-            isMetamask: false
+            chainId: ${settings?.eth?.chainId ?? 1}
           },
           solana: {
             cluster: 'mainnet-beta',

--- a/packages/flutter_web3_webview/test/provider_test.dart
+++ b/packages/flutter_web3_webview/test/provider_test.dart
@@ -109,6 +109,20 @@ void main() {
           contains("window.addEventListener('eip6963:requestProvider'"));
     });
 
+    test('emits overwriteMetamask at the top level of the config', () {
+      // The vendored EthereumProvider reads `config.overwriteMetamask`
+      // (top level), not a nested `ethereum.isMetamask`, so the flag must
+      // be a top-level field for `window.ethereum.isMetaMask` to take it.
+      expect(Providers().getInitJs(),
+          contains('overwriteMetamask: false'));
+
+      final impersonating = Providers(
+        settings: Web3Settings(eth: Web3EthSettings(overwriteMetamask: true)),
+      );
+      expect(impersonating.getInitJs(),
+          contains('overwriteMetamask: true'));
+    });
+
     test('uses custom EVM and Solana configuration', () {
       final provider = Providers(
         settings: Web3Settings(


### PR DESCRIPTION
## Summary

`window.ethereum.isMetaMask` was permanently `false`, silently breaking DApps that gate signing on it (the official MetaMask test dapp among them). Surfaced while manually verifying the demo on the iOS simulator.

### Root cause

`Providers.getInitJs` passed `isMetamask` inside a **nested** `config.ethereum` block, but the rebuilt/vendored `EthereumProvider` reads `config.overwriteMetamask` from the **top level**. Name + nesting both mismatched → never read → `isMetaMask` stuck at `false`.

The same nested-vs-flat mismatch also drops `chainId` / `isFxWallet`, but those are masked (chain id comes from the Dart `ethChainId` callback; `isFxWallet` defaults to `true`). Only `isMetaMask` actually surfaced.

### Changes

- `Web3EthSettings.overwriteMetamask` (default **false**) — opt-in MetaMask impersonation. Package doesn't impersonate by default; it's a per-integration choice (you picked this over defaulting `true`).
- `getInitJs` emits `overwriteMetamask` as a top-level config field, with a comment on why the nested blocks are legacy and why `cluster` is intentionally NOT promoted (would make `SolanaProvider` build a `Connection('mainnet-beta')` against an invalid RPC URL).
- Demo `browser_page.dart` sets `overwriteMetamask: true`.
- Demo README documents the flag + that the public Hardhat EVM keys are reputation-blocked by mainstream DApps (OpenSea: "account has been disabled").

## Test plan

- [x] `flutter test` (package) 70/70 — new `getInitJs` case asserts `overwriteMetamask` at top level for default (`false`) and opt-in (`true`)
- [x] `flutter analyze` clean (package + demo)
- [x] Simulator: app rebuilt with the fix loads; Solana signing proven end-to-end (Magic Eden SIWS login succeeds). EVM `isMetaMask`-gated dapp surface no longer blocked by the dead flag.

## Context

This came out of a full manual verification pass of the demo on the simulator. Solana is fully proven (wallet-standard detection → `solana_account` → `solana_signMessage` → Magic Eden server-side SIWS verify passes). EVM signing真机 was blocked by this `isMetaMask` flag + the Hardhat-address reputation gate, both now documented.