### PR TITLE
chore(web3-webview): prep flutter_web3_webview 1.0.0 for pub.dev

### DIFF
--- a/packages/flutter_web3_webview/.pubignore
+++ b/packages/flutter_web3_webview/.pubignore
@@ -1,0 +1,9 @@
+# Files kept in git but excluded from the package published to pub.dev.
+# (A .pubignore replaces .gitignore for publishing, but the publish file set
+# starts from git-tracked files, so build artefacts already ignored by
+# .gitignore — build/, .dart_tool/, … — are never included anyway.)
+
+# TypeScript build source for the injected provider bundle. Only the
+# pre-built asset (lib/js/provider.min.js) ships; the source and its large
+# vendored dependency tree are for maintainers and stay in the repo.
+provider/

--- a/packages/flutter_web3_webview/CHANGELOG.md
+++ b/packages/flutter_web3_webview/CHANGELOG.md
@@ -1,16 +1,55 @@
-## Unreleased
+## [1.0.0]
 
-* SECURITY: Deny WebView permission requests by default unless the caller provides an explicit permission handler.
-* FIX: JSON-encode wallet metadata before injecting it into JavaScript.
-* FIX: Share provider asset loading across concurrent initialization calls.
-* FIX: Serialize user-confirmed EVM and Solana requests and safely encode chain change events.
-* FIX: Respect `isWeb3` when injecting provider scripts and forward Ajax ready-state callbacks.
-* FIX: Surface EIP-1193 `4001` (user rejected) instead of the invalid `4092` code when a chain switch is declined, and reject `wallet_switchEthereumChain` with `4902` for any chain id that is missing or is not a `0x`-prefixed hex string (previously `'1'`, `'0xzz'`, `' 0x1 '` and similar values still reached the wallet callback).
-* FIX: Introduce `Web3RpcError` for structured Dart-side handling of provider failures. The `flutter_inappwebview` bridge still re-wraps the exception before it reaches the in-page DApp, so DApps continue to see a string; `Web3RpcError.toString()` now prefixes its JSON payload with the `Web3RpcError: ` sentinel so the provider JavaScript can extract the structured `{code,message}` once it is rebuilt from source (tracked separately).
-* FIX: Back `JsTransactionObject` fields with the underlying raw map so setting a typed field to `null` actually clears the value (was leaking the original DApp value through `toJson()`), while still preserving DApp-provided fields like `nonce` / `maxFeePerGas` / numeric `gas`.
-* FIX: Pass `overwriteMetamask` to the injected provider at the top level of the config object where the vendored `EthereumProvider` actually reads it. The previous `config.ethereum.isMetamask` field was never read (the rebuilt provider reads `config.overwriteMetamask`), so `window.ethereum.isMetaMask` was permanently `false` — breaking DApps that gate signing on it (e.g. the MetaMask test dapp). Add `Web3EthSettings.overwriteMetamask` (default `false`) so callers can opt into MetaMask impersonation.
-* CHORE: Regenerate `lib/js/provider.min.js` from the vendored `provider/` source for the first time (it had remained the legacy fork artifact). The new esbuild bundle is **321 KB** vs the legacy ~1.46 MB: dropping the unreachable `MobileAdapter` from `EthereumProvider` / `SolanaProvider` cuts the `@metamask/eth-sig-util` dependency chain, and also fixes a latent P0 where `MobileAdapter` renamed EVM methods (`eth_sendTransaction → signTransaction`, etc.) that the Dart dispatcher doesn't recognise. DApp-facing surface is unchanged (verified against the legacy bundle).
-* FEAT: Serialize Solana `signTransaction` inside the provider. Concurrent `signTransaction` calls (directly or via `signAllTransactions`) now run one at a time through an instance-level promise queue, so a DApp can't race the wallet's single approval UI. A rejected signature does not wedge the queue. This replaces the host-app userscript that previously monkey-patched the behaviour onto the provider at runtime.
+First stable release. The injected Web3 provider is now built from vendored
+TypeScript source (`provider/`) instead of a lost pre-compiled artifact, and
+the EVM / Solana request pipeline has been hardened end-to-end.
+
+### Provider
+
+* NEW: `lib/js/provider.min.js` is generated from the vendored `provider/`
+  source via `bun run build:flutter` (**321 KB**, down from the legacy
+  ~1.46 MB bundle). Dropping the unreachable `MobileAdapter` from
+  `EthereumProvider` / `SolanaProvider` cuts the `@metamask/eth-sig-util`
+  dependency chain and fixes a latent issue where the adapter renamed EVM
+  methods (`eth_sendTransaction → signTransaction`, etc.) that the Dart
+  dispatcher doesn't recognise. DApp-facing surface is unchanged (verified
+  against the legacy bundle).
+* NEW: Serialize Solana `signTransaction` inside the provider. Concurrent
+  calls (directly or via `signAllTransactions`) run one at a time through an
+  instance-level promise queue, so a DApp can't race the wallet's single
+  approval UI; a rejected signature does not wedge the queue. This replaces
+  the host-app userscript that previously monkey-patched the behaviour onto
+  the provider at runtime.
+
+### Fixes
+
+* SECURITY: Deny WebView permission requests by default unless the caller
+  provides an explicit permission handler.
+* Surface EIP-1193 `4001` (user rejected) instead of the invalid `4092` code
+  when a chain switch is declined, and reject `wallet_switchEthereumChain`
+  with `4902` for any chain id that is missing or is not a `0x`-prefixed hex
+  string (previously `'1'`, `'0xzz'`, `' 0x1 '` and similar values still
+  reached the wallet callback).
+* Introduce `Web3RpcError` for structured Dart-side handling of provider
+  failures. The `flutter_inappwebview` bridge re-wraps the exception before
+  it reaches the in-page DApp, so DApps still see a string;
+  `Web3RpcError.toString()` prefixes its JSON payload with the
+  `Web3RpcError: ` sentinel so the provider can extract the structured
+  `{code,message}` (extraction itself is tracked separately).
+* Add `Web3EthSettings.overwriteMetamask` (default `false`). Previously
+  `window.ethereum.isMetaMask` was permanently `false` because the value was
+  injected under a config field the provider never read — breaking DApps
+  that gate signing on it (e.g. the MetaMask test dapp).
+* Back `JsTransactionObject` fields with the underlying raw map so setting a
+  typed field to `null` actually clears the value (was leaking the original
+  DApp value through `toJson()`), while preserving DApp-provided fields like
+  `nonce` / `maxFeePerGas` / numeric `gas`.
+* JSON-encode wallet metadata before injecting it into JavaScript.
+* Share provider asset loading across concurrent initialization calls.
+* Serialize user-confirmed EVM and Solana requests and safely encode chain
+  change events.
+* Respect `isWeb3` when injecting provider scripts and forward Ajax
+  ready-state callbacks.
 
 ## [0.1.0]
 

--- a/packages/flutter_web3_webview/README.md
+++ b/packages/flutter_web3_webview/README.md
@@ -1,39 +1,107 @@
 # flutter_web3_webview
 
-A Flutter WebView widget that supports wallet connection to Web3 DApps. Supports both EVM and Solana chains.
+A Flutter WebView widget that lets in-app web pages talk to a Web3 wallet. It
+injects a provider bridge into every page so DApps can connect and request
+signatures over **EIP-1193** (EVM) and the **Solana wallet standard**, while
+your Dart code stays in control of accounts, chains, and every signing
+prompt. Built on top of
+[`flutter_inappwebview`](https://pub.dev/packages/flutter_inappwebview).
 
 ## Features
 
-- WalletConnect support
-- EVM and Solana chain support
-- Custom provider JS injection
-- Ideal for DApp browsers and in-app Web3 scenarios
+- Injects `window.ethereum` (EIP-1193 + EIP-6963) and a Solana
+  wallet-standard provider (`window.fxwallet`) before page scripts run.
+- Routes every wallet request to your Dart callbacks — you decide what to
+  approve, sign, and return.
+- EVM: `eth_requestAccounts`, `eth_accounts`, `eth_chainId`, `personal_sign`,
+  `eth_sign`, `eth_signTypedData` (`v3` / `v4`), `eth_sendTransaction`,
+  `wallet_switchEthereumChain` / `wallet_addEthereumChain`.
+- Solana: connect (`solana_account`), `solana_signMessage`,
+  `solana_signTransaction` (serialised so concurrent requests are approved
+  one at a time).
+- Push wallet-side changes back into the page: chain and account switches
+  emit `chainChanged` / `accountsChanged` to listening DApps.
+- Optional MetaMask impersonation (`window.ethereum.isMetaMask`) for DApps
+  that gate on it — off by default.
+- A drop-in superset of `InAppWebView`: every `flutter_inappwebview`
+  callback is forwarded through.
 
 ## Installation
 
 ```yaml
 dependencies:
-  flutter_web3_webview: ^0.1.5
+  flutter_web3_webview: ^1.0.0
 ```
 
-## Quick Start
+## Usage
+
+Load the injected provider asset once (e.g. in `main`), then drop a
+`Web3Webview` into your widget tree and wire the wallet callbacks:
 
 ```dart
-// Initialize provider JS asset before use
-await Web3Webview.initJs();
+import 'package:flutter_web3_webview/flutter_web3_webview.dart';
 
-// Use the Web3Webview
-Web3Webview();
+void main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  await Web3Webview.initJs(); // load the provider bundle once
+  runApp(const MyApp());
+}
+
+Web3Webview(
+  initialUrlRequest: URLRequest(url: WebUri('https://app.uniswap.org')),
+  settings: Web3Settings(
+    name: 'My Wallet',
+    eth: Web3EthSettings(
+      chainId: 1,
+      // Report window.ethereum.isMetaMask === true for DApps that require it.
+      overwriteMetamask: false,
+    ),
+  ),
+
+  // EVM ------------------------------------------------------------------
+  ethAccounts: () async => ['0xYourAddress'],
+  ethChainId: () async => 1,
+  ethPersonalSign: (message) async => wallet.personalSign(message),
+  ethSignTypedData: (json) async => wallet.signTypedDataV4(json),
+  ethSendTransaction: (tx) async => wallet.sendTransaction(tx),
+  walletSwitchEthereumChain: (chain) async {
+    // Return true to accept the switch, false to reject (DApp sees 4001).
+    return askUserToSwitch(chain);
+  },
+
+  // Solana ---------------------------------------------------------------
+  solAccount: () async => 'YourBase58SolanaAddress',
+  solSignMessage: (data) async => wallet.solSignMessage(data),
+  solSignTransaction: (data) async => wallet.solSignTransaction(data),
+)
 ```
+
+Returning a value resolves the DApp's request; throwing rejects it. To
+surface a real wallet rejection, throw an error whose `toString()` carries
+the EIP-1193 `4001` shape.
+
+## Wallet callbacks
+
+| Callback | Triggered by | Returns |
+|----------|--------------|---------|
+| `ethAccounts` | `eth_requestAccounts` / `eth_accounts` | `List<String>` of addresses |
+| `ethChainId` | `eth_chainId` | chain id as `int` |
+| `ethPersonalSign` | `personal_sign` | signature hex |
+| `ethSign` | `eth_sign` | signature hex |
+| `ethSignTypedData` | `eth_signTypedData` / `_v3` / `_v4` | signature hex |
+| `ethSendTransaction` | `eth_sendTransaction` | transaction hash |
+| `walletSwitchEthereumChain` | `wallet_switchEthereumChain` / `wallet_addEthereumChain` | `bool` accept / reject |
+| `solAccount` | Solana connect | base58 address |
+| `solSignMessage` | `solana_signMessage` | signature (hex) |
+| `solSignTransaction` | `solana_signTransaction` | signature (base58) |
+| `onDefaultCallback` | any other method | anything (or throw) |
 
 ## Example
 
-A full demo app is available at `examples/web3_webview_demo` in this repository. You can run and debug it locally.
-
-## Contributing
-
-Issues and PRs are welcome!
+A full end-to-end demo — exercising every callback against real DApps, with
+real signing — lives at
+[`examples/web3_webview_demo`](https://github.com/fxwalletOfficial/fx-wallet-packages/tree/main/examples/web3_webview_demo).
 
 ## License
 
-MIT
+MIT — see [LICENSE](LICENSE).

--- a/packages/flutter_web3_webview/provider/README.md
+++ b/packages/flutter_web3_webview/provider/README.md
@@ -9,26 +9,33 @@ EIP-1193 and the Solana wallet standard.
 
 ```
 packages/
-  core/       # base provider + adapter strategies
-  ethereum/   # EIP-1193 EthereumProvider + MobileAdapter
+  core/       # base provider + the shared Flutter bridge (callFlutterHandler)
+  ethereum/   # EIP-1193 EthereumProvider
   solana/     # SolanaProvider + wallet-standard adapter
+bundle/
+  index.ts    # aggregator entry — assigns the providers to window.fxwallet
+  build.mjs   # esbuild bundle → ../lib/js/provider.min.js
 scripts/
-  build.ts             # iterate workspaces, run each `bun run build:source`
-  packages.ts          # list of allowed sub-packages
+  build.ts    # iterate workspaces, run each per-package build
+  packages.ts # list of allowed sub-packages
 ```
 
 The source carries the FxWallet brand throughout (the `window.fxwallet`
 global, the `'fxwallet:'` Solana wallet-standard namespace, the `isFxWallet`
 feature flag, …). The chains we don't expose through the WebView, the native
 wrappers, and the npm-publishing / chain-scaffolding tooling we don't use
-have been removed.
+have been removed. `MobileAdapter` is left vendored under `packages/ethereum`
+/ `packages/solana` for reference, but is kept off the request hot path —
+both providers forward requests straight through the bridge, so the Dart
+`Web3RequestDispatcher` switches on the original EIP-1193 / `solana_*` method
+names rather than the adapter's rewrites.
 
 ## Build workflow
 
 ```bash
 bun install
-bun run build:packages   # validate the upstream per-package rollup builds
-bun run build:flutter    # generate ../lib/js/provider.min.js via esbuild
+bun run build:packages   # validate the per-package rollup builds
+bun run build:flutter    # regenerate ../lib/js/provider.min.js via esbuild
 ```
 
 `bundle/index.ts` is the aggregator entry point; it imports
@@ -36,17 +43,16 @@ bun run build:flutter    # generate ../lib/js/provider.min.js via esbuild
 and assigns them to `window.fxwallet`. `bundle/build.mjs` invokes esbuild
 with Node-builtin polyfills (Buffer / events / crypto / http / https /
 stream / url / util / zlib) and writes the IIFE bundle to the
-`flutter_web3_webview` asset path so a successful build refreshes the
+`flutter_web3_webview` asset path, so a successful build refreshes the
 Flutter package in place.
 
-> ⚠️ The build pipeline is wired up, but the resulting bundle is **not yet
-> functionally equivalent** to the legacy `provider.min.js`. The legacy
-> asset was produced by a now-lost fork that added a custom WebView bridge
-> on top of the upstream source. See [RECOVERY.md](./RECOVERY.md) for the
-> complete inventory of what still needs to be ported back into the
-> vendored packages before the build can replace the legacy artifact.
+> `lib/js/provider.min.js` is built from this source tree — the ~321 KB
+> bundle currently shipped was produced by `bun run build:flutter`. See
+> [RECOVERY.md](./RECOVERY.md) for how the WebView bridge was recovered from
+> the now-lost fork and how the regenerated bundle was verified against the
+> legacy artifact.
 
 ## Requirements
 
-* [Bun](https://bun.sh) for the upstream rollup-based per-package build.
+* [Bun](https://bun.sh) for the per-package rollup build.
 * Node ≥ 18 for the esbuild bundle (`bundle/build.mjs`).

--- a/packages/flutter_web3_webview/provider/RECOVERY.md
+++ b/packages/flutter_web3_webview/provider/RECOVERY.md
@@ -1,99 +1,105 @@
 # Provider bundle recovery notes
 
-The current `lib/js/provider.min.js` was generated from a previously-modified
-provider fork whose source modifications were lost, so this document tracks
-what was inferred from the minified bundle and what has / has not been
-ported back into `provider/packages/`.
+`lib/js/provider.min.js` was originally generated from a previously-modified
+provider fork whose source modifications were lost. This document records
+what was inferred from the minified bundle and how the bridge layer was
+ported back into `provider/packages/` so the asset can be rebuilt from
+source.
 
-> **Status update (resolved):** `lib/js/provider.min.js` is now built from
-> this source tree — `bun run build:flutter` produces a **321 KB** esbuild
-> bundle that replaced the legacy ~1.46 MB fork artifact. The Flutter
-> bridge layer is restored in source
-> (`packages/core/adapter/FlutterBridge.ts` plus the per-package
-> overrides), the unreachable `MobileAdapter` is off the request hot path
-> (so the `@metamask/eth-sig-util` chain is no longer pulled in), and
-> Solana `signTransaction` is serialised through an instance-level queue.
-> Surface was diffed against the legacy bundle (every `FxWalletHandler` /
-> `emitChainChanged` / `solana_*` / `wallet-standard:register-wallet` /
-> `Not init finished` token present; no `MobileAdapter` EVM-rename
-> literals leak in). To refresh after a source change, re-run
-> `bun run build:flutter`.
+> **Status: resolved.** `lib/js/provider.min.js` is now built from this
+> source tree — `bun run build:flutter` produces the ~321 KB esbuild bundle
+> that replaced the legacy ~1.46 MB fork artifact. The Flutter bridge layer
+> lives in source (`packages/core/adapter/FlutterBridge.ts` plus the
+> per-package overrides), the unreachable `MobileAdapter` is off the request
+> hot path (so the `@metamask/eth-sig-util` chain is no longer pulled in),
+> and Solana `signTransaction` is serialised through an instance-level queue.
+> Re-run `bun run build:flutter` to refresh the asset after a source change.
 
-## What's in the legacy bundle but not in upstream source
+## What the legacy bundle did differently from upstream
+
+These are the behaviours observed in the *legacy* minified bundle (the lost
+fork). They explain why the vendored source carries custom bridge code on top
+of upstream; the current source reproduces the same wire protocol except
+where noted.
 
 ### 1. Direct `window.flutter_inappwebview.callHandler` bridge
 
 The legacy bundle bypasses the upstream `Adapter` / `IHandler` abstraction
-and instead calls the WebView's JS handler directly. Four distinct call
-sites are visible in the minified output:
+and calls the WebView's JS handler directly. The call sites visible in the
+minified output:
 
 | Caller | Payload |
 |--------|---------|
-| Ethereum bridge (generic) | `callHandler("FxWalletHandler", payload)` — `payload` is the `args` object from `internalRequest`, so the method name is whatever `MobileAdapter` rewrote it to (`requestAccounts`, `signTransaction`, `signPersonalMessage`, `signTypedMessage`, `ecRecover`, `watchAsset`, `addEthereumChain`, `switchEthereumChain`, …). |
+| Ethereum (generic) | `callHandler("FxWalletHandler", args)` — `args` is the DApp's `{ method, params }`. In the legacy bundle the method name was whatever `MobileAdapter` had rewritten it to (`requestAccounts`, `signTransaction`, `signPersonalMessage`, …); **the current source skips that rewrite** and forwards the original `eth_*` / `personal_*` / `wallet_*` names (see "Restored bridge" below). |
 | Solana connect | `callHandler("FxWalletHandler", { method: "solana_account" })` |
 | Solana `signMessage` | `callHandler("FxWalletHandler", { method: "solana_signMessage", params: { raw: hex } })` |
-| Solana `signTransaction` | `callHandler("FxWalletHandler", { method: "solana_signTransaction", params: { raw: message.toString("hex"), message: message.toString("base64") } })` |
+| Solana `signTransaction` | `callHandler("FxWalletHandler", { method: "solana_signTransaction", params: { raw: hex, message: base64 } })` |
 
 ### 2. Solana method-name and parameter rewrites
 
 Upstream `SolanaProvider.signMessage` sends
 `{ method: "signMessage", params: { data, originalMethod: "signMessage" } }`.
 The legacy bundle instead sends
-`{ method: "solana_signMessage", params: { raw: hex } }`. The fork therefore
-introduced both a `solana_` prefix and a renamed `data → raw` parameter
-shape. The `signTransaction` path serialises the transaction message twice
-(`hex` *and* `base64`), which is not how upstream's adapter packs it.
+`{ method: "solana_signMessage", params: { raw: hex } }` — both a `solana_`
+prefix and a renamed `data → raw` parameter. The `signTransaction` path
+serialises the transaction message twice (`hex` *and* `base64`), which is not
+how upstream's adapter packs it. The current source reproduces this exactly.
 
-### 3. Lost Solana methods
+### 3. Solana methods that were not bridged
 
-Methods like `signAllTransactions`, `signRawTransactionMulti`, `signIn`,
-`signAndSendTransaction` exist in the upstream source but the legacy bundle
-either does not bridge them or routes them through a different code path
-that we have not yet traced. The Dart dispatcher
-(`lib/src/utils/request_dispatcher.dart`) currently only handles
-`solana_account`, `solana_signTransaction`, `solana_signMessage`, so the
-gap is largely informational.
+`signIn` / `signAndSendTransaction` exist in the upstream API but the legacy
+bundle did not bridge them through `FxWalletHandler`. The Dart dispatcher
+(`lib/src/utils/request_dispatcher.dart`) only handles `solana_account`,
+`solana_signTransaction`, `solana_signMessage`, so this gap is largely
+informational. `signRawTransactionMulti` (upstream-only, never shipped in the
+legacy bundle, no Dart case) was removed from the current source to keep the
+typed API honest — batch signing composes from `signTransaction` via
+`signAllTransactions`.
 
-## Phase 3 — restored bridge
+## Restored bridge (current source)
 
-The bridge layer has been ported back into the vendored source:
+The bridge layer ported back into the vendored source:
 
 1. **`packages/core/adapter/FlutterBridge.ts`** — single shared helper that
    guards `window.flutter_inappwebview` (throwing `Not init finished.` to
    match the legacy error message) and invokes
    `callHandler('FxWalletHandler', payload)`. Re-exported from
-   `packages/core/index.ts` as `callFlutterHandler` so neither chain
-   package has to re-declare the global.
+   `packages/core/index.ts` as `callFlutterHandler` so neither chain package
+   re-declares the global.
 2. **`packages/ethereum/EthereumProvider.ts`**
-   * `internalRequest(args)` now forwards `args` through the bridge
-     verbatim. `MobileAdapter` still performs the EIP-1193 → mobile
-     method rewrites first, so the Dart dispatcher sees `requestAccounts`,
-     `signTransaction`, `signPersonalMessage`, `signTypedMessage`,
-     `ecRecover`, `watchAsset`, `wallet_addEthereumChain`,
-     `wallet_switchEthereumChain`, etc.
+   * `request(args)` → `internalRequest(args)` → `callFlutterHandler(args)`
+     is a single-step pass-through: the DApp's `{ method, params }` reaches
+     the Dart side **unmodified**. `MobileAdapter` is *not* on this path, so
+     the Dart `Web3RequestDispatcher` switches on the original
+     `eth_sendTransaction` / `personal_sign` / `eth_signTypedData_v4` /
+     `wallet_switchEthereumChain` / `wallet_addEthereumChain` names. (The
+     upstream design routed everything through `MobileAdapter`, which renamed
+     these to `signTransaction` / `signPersonalMessage` / … — those would
+     fall through to `_defaultCallback`. Dropping the adapter also keeps the
+     `@metamask/eth-sig-util` dependency chain out of the bundle.)
    * `emitChainChanged(chainId)` and `emitAccountsChanged(accounts)` are
-     exposed publicly so the Dart side can fire EIP-1193 events after
+     public so the Dart side can fire EIP-1193 events after
      `wallet_switchEthereumChain` or an account switch (matching the
      `window.ethereum.emitChainChanged(...)` injection in
      `lib/src/utils/request_dispatcher.dart`).
 3. **`packages/solana/SolanaProvider.ts`**
-   * `isConnected` boolean field added so DApps can sniff the connection
-     state directly (matching the legacy bundle).
-   * `connect()` now bridges to `{ method: 'solana_account' }`, sets
-     `publicKey` / `isConnected`, and emits `connect`.
-   * `disconnect()` clears `publicKey` / `isConnected` and emits
-     `disconnect`.
+   * `isConnected` boolean field so DApps can sniff connection state.
+   * `connect()` bridges to `{ method: 'solana_account' }`, sets `publicKey`
+     / `isConnected`, and emits `connect`.
+   * `disconnect()` clears `publicKey` / `isConnected` and emits `disconnect`.
    * `signMessage(message)` bridges to
      `{ method: 'solana_signMessage', params: { raw: hex } }`.
-   * `signTransaction(tx)` serialises the transaction message (handling
-     both legacy `Transaction` and `VersionedTransaction`) and bridges to
-     `{ method: 'solana_signTransaction', params: { raw, message } }`,
-     then attaches the returned signature via `mapSignedTransaction`.
-   * `emitAccountChanged()` exposed for the wallet-standard adapter and
-     DApp listeners.
-   * `internalRequest(args)` forwards generic Solana requests through the
-     bridge unchanged so any future method that doesn't have a bespoke
-     wrapper still works.
+   * `signTransaction(tx)` serialises the transaction message (both legacy
+     `Transaction` and `VersionedTransaction`) and bridges to
+     `{ method: 'solana_signTransaction', params: { raw, message } }`, then
+     attaches the returned signature via `mapSignedTransaction`. Calls are
+     serialised through an instance-level `#signTransactionQueue` so a DApp
+     issuing several at once (directly or via `signAllTransactions`) gets them
+     approved one at a time instead of racing the single approval UI.
+   * `emitAccountChanged()` exposed for the wallet-standard adapter and DApp
+     listeners.
+   * `internalRequest(args)` forwards any future un-bridged Solana request
+     through the bridge unchanged.
 
 ### Surface verification (regenerated bundle vs legacy)
 
@@ -111,40 +117,30 @@ The bridge layer has been ported back into the vendored source:
 | `solana_signMessage` | 1 | 1 |
 | `Not init finished` guard | 5 | 1 (minifier dedupes) |
 
-`registerWallet` itself does not appear by name in the regenerated bundle
-because esbuild's minifier renamed the local symbol — the dispatched
-event names (`wallet-standard:register-wallet`, `wallet-standard:app-ready`)
-are present and that is the contract DApps observe.
+`registerWallet` does not appear by name in the regenerated bundle because
+esbuild's minifier renamed the local symbol — the dispatched event names
+(`wallet-standard:register-wallet`, `wallet-standard:app-ready`) are present,
+and that is the contract DApps observe.
 
-## Phase 5 — outstanding regression verification
-
-Before the regenerated bundle replaces `lib/js/provider.min.js`:
-
-1. Run the wallet against a representative DApp set (Uniswap V3, OpenSea,
-   Aave on EVM; Jupiter, Drift on Solana) using **both** bundles.
-2. Intercept every `window.flutter_inappwebview.callHandler('FxWalletHandler',
-   …)` invocation and confirm the new bundle emits payloads byte-for-byte
-   identical to the legacy bundle for: `eth_accounts`, `eth_chainId`,
-   `eth_requestAccounts`, `personal_sign`, `eth_signTypedData_v4`,
-   `eth_sendTransaction`, `wallet_switchEthereumChain`,
-   `wallet_addEthereumChain`, `solana_account`, `solana_signMessage`,
-   `solana_signTransaction`.
-3. Bundle size: regenerated ≈ 2.95 MB vs legacy ≈ 1.46 MB. The growth is
-   driven by the newer Solana / wallet-standard dependency tree esbuild
-   pulls in. Confirm WebView cold-start latency is acceptable before
-   shipping.
+The regenerated bundle was additionally smoke-tested on-device (Magic Eden
+SIWS login over the Solana path). If you change the source again, re-verify
+the wire payloads for `eth_accounts`, `eth_chainId`, `eth_requestAccounts`,
+`personal_sign`, `eth_signTypedData_v4`, `eth_sendTransaction`,
+`wallet_switchEthereumChain`, `wallet_addEthereumChain`, `solana_account`,
+`solana_signMessage`, and `solana_signTransaction` against a representative
+DApp set before shipping.
 
 ## Known gaps (deferred)
 
-The legacy bundle also added the following niceties that are **not yet**
-ported back because they aren't required for the wire protocol:
+The legacy bundle added a few niceties that are **not** ported back because
+they aren't required for the wire protocol:
 
-* `EthereumProvider.setAddress` lower-cases the address, sets
-  `provider.ready`, and walks `window.frames[*].ethereum` to mirror the
-  state into iframes branded with `isFxWallet`. The vendored source still
-  has the upstream stub that just stores the private `#address`.
-* `EthereumProvider.isConnected()` always-returns-true legacy stub.
-* `EthereumProvider.setConfig(config)` aggregate setter.
+* `EthereumProvider.setAddress` in the legacy fork lower-cased the address,
+  set `provider.ready`, and mirrored state into `window.frames[*].ethereum`
+  for iframes branded with `isFxWallet`. The vendored source keeps the
+  upstream stub that just stores the private `#address`.
+* The legacy `isConnected()` stub always returned `true`; the vendored source
+  exposes a `connected` getter that does the same.
+* `EthereumProvider.setConfig(config)` aggregate setter — not present.
 
-These can be ported in a follow-up once a DApp is observed to depend on
-them.
+These can be ported in a follow-up once a DApp is observed to depend on them.

--- a/packages/flutter_web3_webview/provider/packages/ethereum/README.md
+++ b/packages/flutter_web3_webview/provider/packages/ethereum/README.md
@@ -13,12 +13,9 @@
 
 ```typescript
 const config: {
-  rpc?: string;
-  chainId?: string;
-  overwriteMetamask?: boolean;
-  supportedMethods?: string[];
-  unsupportedMethods?: string[];
-  disableMobileAdapter?: boolean;
+  chainId?: string;            // hex chain id, e.g. '0x1'
+  rpc?: string;                // custom RPC URL (also accepts `rpcUrl`)
+  overwriteMetamask?: boolean; // make window.ethereum.isMetaMask report true
   isFxWallet?: boolean;
 } = {};
 ```

--- a/packages/flutter_web3_webview/provider/packages/solana/README.md
+++ b/packages/flutter_web3_webview/provider/packages/solana/README.md
@@ -16,9 +16,8 @@
 ```typescript
 const config: {
   isFxWallet?: boolean;
-  enableAdapter?: boolean;
-  cluster?: string;
-  disableMobileAdapter?: boolean;
+  enableAdapter?: boolean;     // register with the Solana wallet standard
+  cluster?: string;            // RPC cluster URL for the connection
 } = {};
 ```
 

--- a/packages/flutter_web3_webview/provider/packages/solana/adapter/window.ts
+++ b/packages/flutter_web3_webview/provider/packages/solana/adapter/window.ts
@@ -1,18 +1,18 @@
-export interface TrustEvent {
+export interface FxWalletEvent {
   connect(...args: unknown[]): unknown;
   disconnect(...args: unknown[]): unknown;
   accountChanged(...args: unknown[]): unknown;
 }
 
-export interface TrustEventEmitter {
-  on<E extends keyof TrustEvent>(
+export interface FxWalletEventEmitter {
+  on<E extends keyof FxWalletEvent>(
     event: E,
-    listener: TrustEvent[E],
+    listener: FxWalletEvent[E],
     context?: any,
   ): void;
-  off<E extends keyof TrustEvent>(
+  off<E extends keyof FxWalletEvent>(
     event: E,
-    listener: TrustEvent[E],
+    listener: FxWalletEvent[E],
     context?: any,
   ): void;
 }

--- a/packages/flutter_web3_webview/provider/packages/solana/types/SolanaProvider.ts
+++ b/packages/flutter_web3_webview/provider/packages/solana/types/SolanaProvider.ts
@@ -9,7 +9,7 @@ import {
   SendOptions,
   TransactionSignature,
 } from '@solana/web3.js';
-import { TrustEventEmitter } from '../adapter/window';
+import { FxWalletEventEmitter } from '../adapter/window';
 import { FxWallet } from '../adapter/wallet';
 
 export interface ISolanaProviderConfig {
@@ -24,7 +24,7 @@ export interface ConnectOptions {
   onlyIfTrusted?: boolean | undefined;
 }
 
-export default interface ISolanaProvider extends TrustEventEmitter {
+export default interface ISolanaProvider extends FxWalletEventEmitter {
   publicKey: PublicKey | null;
   connect(options?: {
     onlyIfTrusted?: boolean;

--- a/packages/flutter_web3_webview/pubspec.yaml
+++ b/packages/flutter_web3_webview/pubspec.yaml
@@ -1,7 +1,15 @@
 name: flutter_web3_webview
-description: Webview supported connected to web3 DApp in Flutter. Now support EVM chain & Solana, and will support more at future.
+description: A Flutter WebView widget that bridges in-app web pages to a Web3 wallet over EIP-1193 (EVM) and the Solana wallet standard.
+version: 1.0.0
 homepage: https://github.com/fxwalletOfficial/fx-wallet-packages/tree/main/packages/flutter_web3_webview
-version: 0.1.5
+repository: https://github.com/fxwalletOfficial/fx-wallet-packages
+issue_tracker: https://github.com/fxwalletOfficial/fx-wallet-packages/issues
+topics:
+  - web3
+  - webview
+  - ethereum
+  - solana
+  - wallet
 
 environment:
   sdk: '>=3.3.4 <4.0.0'


### PR DESCRIPTION
## What

Release-prep for `flutter_web3_webview` **1.0.0** (pub.dev), plus a docs pass that fixes stale / contradictory content surfaced in review.

## Docs fixes (review findings)
- **provider/README.md** — drop the obsolete "bundle not yet functionally equivalent" warning (the asset is source-built now); fix the Layout (MobileAdapter is off the hot path) and add the `bundle/` entry.
- **provider/RECOVERY.md** — resolve the self-contradiction: rewrite the stale Phase 5 block (no more "before it replaces" framing / wrong ~2.95 MB size — shipped bundle is ~321 KB) and the Phase 3 EVM note that still claimed MobileAdapter rewrites the method names (it no longer does; the dispatcher sees the original `eth_*` names).
- **sub-package READMEs** — trim the config examples to the fields each provider constructor actually reads (drop dead `disableMobileAdapter` / `supportedMethods` / `unsupportedMethods`).

## Extra cleanup found during the pass
- **De-brand leftover TrustWallet naming**: `TrustEvent` / `TrustEventEmitter` → `FxWalletEvent` / `FxWalletEventEmitter`. These are compile-time TS interfaces — **no bundle impact, no rebuild needed**. `onlyIfTrusted` (Solana wallet-standard param) and `ServerTrustAuth*` (flutter_inappwebview SSL API) are legitimate and kept.
- **Package README** rewritten as the pub.dev landing page (features / usage / 11-callback table); install snippet bumped to `^1.0.0`.

## Release prep
- **pubspec**: `0.1.5 → 1.0.0`; better description; add `repository` / `issue_tracker` / `topics`.
- **CHANGELOG**: fold `Unreleased` into `[1.0.0]` with a stable-release summary.
- **.pubignore**: exclude the `provider/` build source from the published package.

## Verification
`flutter pub publish --dry-run`: **119 KB** archive, `provider/` absent, CHANGELOG / LICENSE / lib (incl. the 321 KB bundle) / test present, **0 warnings**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)