### PR TITLE
Upgrade blockchain_utils 1.6.0 → 6.0.0 (closes #20)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Setup Dart
       uses: dart-lang/setup-dart@v1
       with:
-        sdk: '3.3.4'
+        sdk: '3.8.0'
 
     - name: Setup Flutter
       uses: subosito/flutter-action@v2
@@ -34,6 +34,10 @@ jobs:
 
     - name: Format
       run: melos run format
+
+    - name: Setup wasm_run native library (crypto_wallet_util)
+      run: dart run wasm_run:setup
+      working-directory: packages/crypto_wallet_util
 
     - name: Test
       run: melos run test

--- a/packages/crypto_wallet_util/CHANGELOG.md
+++ b/packages/crypto_wallet_util/CHANGELOG.md
@@ -257,3 +257,31 @@
 - SC transaction assembly with WASM integration (`package:wasm_run`).
 - SC transaction signer (Ed25519) and builder.
 - SC send example.
+
+
+## [2.0.0] - 2026-06-09
+### BREAKING
+
+- Upgrade `blockchain_utils` from `^1.4.1` to `^6.0.0`. Resolves the dependency
+  conflict reported in #20 (consumers using `bitcoin_base 7.x` / `xrpl_dart 7.x`,
+  which require `blockchain_utils ^6.0.0`).
+- Minimum Dart SDK raised to `>=3.7.0` (required by `blockchain_utils 6.0.0`).
+
+### Changed
+
+- Migrated the vendored `bitcoin_base_hd` and `xrpl_dart` forks to the
+  `blockchain_utils` 6.x API: relocated utility imports to the package barrel,
+  `Tuple`/`item1,item2` → Dart records (`$1`,`$2`), `mask*`/`writeUintXLE` →
+  `BinaryOps.*`, `bytesEqual`/`iterableIsEqual` → `BytesUtils`/`CompareUtils`,
+  `Secp256k1*KeyEcdsa` → `Secp256k1*Key`, `BitcoinSigner`/`BitcoinVerifier` →
+  `BitcoinKeySigner`/`BitcoinSignatureVerifier`, `BigintUtils.orderLen` →
+  `BigintUtils.bitlengthInBytes`.
+- ECDSA / Taproot / message signing outputs verified byte-for-byte identical to
+  the pre-upgrade implementation; XRP secp256k1 family-seed derivation and
+  classic/X-address conversion pinned with characterization tests.
+- `Bech32Validations` / `SegwitValidations` declared as `mixin` (Dart 3 language
+  level no longer permits using a plain class as a mixin).
+
+### Notes
+
+- No public API changes beyond the SDK floor; all 782 unit tests pass.

--- a/packages/crypto_wallet_util/lib/src/forked_lib/bitcoin_base_hd/src/bitcoin/address/legacy_address.dart
+++ b/packages/crypto_wallet_util/lib/src/forked_lib/bitcoin_base_hd/src/bitcoin/address/legacy_address.dart
@@ -1,6 +1,6 @@
 import 'package:blockchain_utils/base58/base58.dart';
 import 'package:blockchain_utils/bech32/bch_bech32.dart';
-import 'package:blockchain_utils/binary/utils.dart';
+import 'package:blockchain_utils/blockchain_utils.dart';
 import 'package:blockchain_utils/bip/ecc/keys/secp256k1_keys_ecdsa.dart';
 import 'package:blockchain_utils/crypto/quick_crypto.dart';
 
@@ -169,7 +169,7 @@ class P2pkhAddress extends LegacyAddress {
 class P2pkAddress extends LegacyAddress {
   P2pkAddress({required String publicKey}) : super._() {
     final toBytes = BytesUtils.fromHexString(publicKey);
-    if (!Secp256k1PublicKeyEcdsa.isValidBytes(toBytes)) {
+    if (!Secp256k1PublicKey.isValidBytes(toBytes)) {
       throw ArgumentError("The public key is wrong");
     }
     publicHex = publicKey;

--- a/packages/crypto_wallet_util/lib/src/forked_lib/bitcoin_base_hd/src/bitcoin/address/segwit_address.dart
+++ b/packages/crypto_wallet_util/lib/src/forked_lib/bitcoin_base_hd/src/bitcoin/address/segwit_address.dart
@@ -1,5 +1,5 @@
 import 'package:blockchain_utils/bech32/bech32.dart';
-import 'package:blockchain_utils/binary/utils.dart';
+import 'package:blockchain_utils/blockchain_utils.dart';
 import 'package:blockchain_utils/crypto/quick_crypto.dart';
 
 import '../address/core.dart';
@@ -47,11 +47,11 @@ abstract class SegwitAddress implements BitcoinAddress {
   String _addressToHash(String address, BasedUtxoNetwork network) {
     final convert = SegwitBech32Decoder.decode(network.p2wpkhHrp, address);
 
-    final version = convert.item1;
+    final version = convert.$1;
     if (version != segwitNumVersion) {
       throw ArgumentError("Invalid segwit version.");
     }
-    return BytesUtils.toHexString(convert.item2);
+    return BytesUtils.toHexString(convert.$2);
   }
 
   /// returns the address's string encoding (Bech32)

--- a/packages/crypto_wallet_util/lib/src/forked_lib/bitcoin_base_hd/src/bitcoin/address/validate.dart
+++ b/packages/crypto_wallet_util/lib/src/forked_lib/bitcoin_base_hd/src/bitcoin/address/validate.dart
@@ -1,6 +1,6 @@
 import 'package:blockchain_utils/base58/base58_base.dart';
 import 'package:blockchain_utils/bech32/bch_bech32.dart';
-import 'package:blockchain_utils/compare/compare.dart';
+import 'package:blockchain_utils/blockchain_utils.dart';
 import 'package:blockchain_utils/crypto/quick_crypto.dart';
 import 'core.dart';
 
@@ -22,14 +22,14 @@ List<int>? decodeLegacyAddress(String address, BitcoinAddressType type,
   List<int> checksum = decode.sublist(decode.length - 4);
   List<int> hash = QuickCrypto.sha256DoubleHash(data).sublist(0, 4);
 
-  if (!bytesEqual(checksum, hash)) {
+  if (!BytesUtils.bytesEqual(checksum, hash)) {
     return null;
   }
   final addrBytes =
       decode.sublist(1, decode.length - Base58Const.checksumByteLen);
   switch (type) {
     case BitcoinAddressType.p2pkh:
-      if (bytesEqual(networkPrefix, network.p2pkhNetVer)) {
+      if (BytesUtils.bytesEqual(networkPrefix, network.p2pkhNetVer)) {
         return addrBytes;
       }
       return null;
@@ -38,7 +38,7 @@ List<int>? decodeLegacyAddress(String address, BitcoinAddressType type,
     case BitcoinAddressType.p2pkInP2sh:
     case BitcoinAddressType.p2wshInP2sh:
     case BitcoinAddressType.p2wpkhInP2sh:
-      if (bytesEqual(networkPrefix, network.p2shNetVer)) {
+      if (BytesUtils.bytesEqual(networkPrefix, network.p2shNetVer)) {
         return addrBytes;
       }
       return null;
@@ -73,8 +73,8 @@ List<int>? decodeBchAddress(
     }
 
     final decode = BchBech32Decoder.decode(hrp, address);
-    if (bytesEqual(decode.item1, netVersion)) {
-      return decode.item2;
+    if (BytesUtils.bytesEqual(decode.$1, netVersion)) {
+      return decode.$2;
     }
     return null;
   } catch (e) {

--- a/packages/crypto_wallet_util/lib/src/forked_lib/bitcoin_base_hd/src/bitcoin/script/control_block.dart
+++ b/packages/crypto_wallet_util/lib/src/forked_lib/bitcoin_base_hd/src/bitcoin/script/control_block.dart
@@ -1,4 +1,4 @@
-import 'package:blockchain_utils/binary/utils.dart';
+import 'package:blockchain_utils/blockchain_utils.dart';
 
 import '../../bitcoin/script/op_code/constant.dart';
 import '../../crypto/keypair/ec_public.dart';

--- a/packages/crypto_wallet_util/lib/src/forked_lib/bitcoin_base_hd/src/bitcoin/script/input.dart
+++ b/packages/crypto_wallet_util/lib/src/forked_lib/bitcoin_base_hd/src/bitcoin/script/input.dart
@@ -1,7 +1,4 @@
-import 'package:blockchain_utils/binary/binary_operation.dart';
-import 'package:blockchain_utils/binary/utils.dart';
-import 'package:blockchain_utils/numbers/int_utils.dart';
-import 'package:blockchain_utils/tuple/tuple.dart';
+import 'package:blockchain_utils/blockchain_utils.dart';
 import 'script.dart';
 
 import '../../bitcoin/script/op_code/constant.dart';
@@ -38,7 +35,7 @@ class TxInput {
     final txidBytes = BytesUtils.fromHexString(txId).reversed.toList();
 
     final txoutBytes = List<int>.filled(4, 0);
-    writeUint32LE(txIndex, txoutBytes);
+    BinaryOps.writeUint32LE(txIndex, txoutBytes);
     final scriptSigBytes = scriptSig.toBytes();
 
     final scriptSigLengthVarint = IntUtils.encodeVarint(scriptSigBytes.length);
@@ -52,7 +49,7 @@ class TxInput {
     return data;
   }
 
-  static Tuple<TxInput, int> fromRaw(
+  static (TxInput, int) fromRaw(
       {required String raw, int cursor = 0, bool hasSegwit = false}) {
     final txInputRaw = BytesUtils.fromHexString(raw);
     List<int> inpHash =
@@ -65,12 +62,12 @@ class TxInput {
         txInputRaw.sublist(cursor + 32, cursor + 36).reversed.toList();
     cursor += 36;
     final vi = IntUtils.decodeVarint(txInputRaw.sublist(cursor, cursor + 9));
-    cursor += vi.item2;
-    List<int> unlockingScript = txInputRaw.sublist(cursor, cursor + vi.item1);
-    cursor += vi.item1;
+    cursor += vi.$2;
+    List<int> unlockingScript = txInputRaw.sublist(cursor, cursor + vi.$1);
+    cursor += vi.$1;
     List<int> sequenceNumberData = txInputRaw.sublist(cursor, cursor + 4);
     cursor += 4;
-    return Tuple(
+    return (
         TxInput(
             txId: BytesUtils.toHexString(inpHash),
             txIndex: int.parse(BytesUtils.toHexString(outputN), radix: 16),

--- a/packages/crypto_wallet_util/lib/src/forked_lib/bitcoin_base_hd/src/bitcoin/script/op_code/tools.dart
+++ b/packages/crypto_wallet_util/lib/src/forked_lib/bitcoin_base_hd/src/bitcoin/script/op_code/tools.dart
@@ -1,22 +1,21 @@
-import 'package:blockchain_utils/binary/binary_operation.dart';
-import 'package:blockchain_utils/binary/utils.dart';
+import 'package:blockchain_utils/blockchain_utils.dart';
 
 List<int> opPushData(String hexData) {
   final List<int> dataBytes = BytesUtils.fromHexString(hexData);
   if (dataBytes.length < 0x4c) {
     return List<int>.from([dataBytes.length]) + dataBytes;
-  } else if (dataBytes.length < mask8) {
+  } else if (dataBytes.length < BinaryOps.mask8) {
     return List<int>.from([0x4c]) +
         List<int>.from([dataBytes.length]) +
         dataBytes;
-  } else if (dataBytes.length < mask16) {
+  } else if (dataBytes.length < BinaryOps.mask16) {
     var lengthBytes = List<int>.filled(2, 0);
 
-    writeUint16LE(dataBytes.length, lengthBytes);
+    BinaryOps.writeUint16LE(dataBytes.length, lengthBytes);
     return List<int>.from([0x4d, ...lengthBytes, ...dataBytes]);
-  } else if (dataBytes.length < mask32) {
+  } else if (dataBytes.length < BinaryOps.mask32) {
     var lengthBytes = List<int>.filled(4, 0);
-    writeUint32LE(lengthBytes.length, lengthBytes);
+    BinaryOps.writeUint32LE(lengthBytes.length, lengthBytes);
     return List<int>.from([0x4e, ...lengthBytes, ...dataBytes]);
   } else {
     throw ArgumentError("Data too large. Cannot push into script");
@@ -34,7 +33,7 @@ List<int> pushInteger(int integer) {
   /// Convert to little-endian bytes
   List<int> integerBytes = List<int>.filled(numberOfBytes, 0);
   for (int i = 0; i < numberOfBytes; i++) {
-    integerBytes[i] = (integer >> (i * 8)) & mask8;
+    integerBytes[i] = (integer >> (i * 8)) & BinaryOps.mask8;
   }
 
   /// If the last bit is set, add a sign byte to signify a positive integer

--- a/packages/crypto_wallet_util/lib/src/forked_lib/bitcoin_base_hd/src/bitcoin/script/output.dart
+++ b/packages/crypto_wallet_util/lib/src/forked_lib/bitcoin_base_hd/src/bitcoin/script/output.dart
@@ -1,8 +1,5 @@
 import 'dart:typed_data';
-import 'package:blockchain_utils/binary/utils.dart';
-import 'package:blockchain_utils/numbers/bigint_utils.dart';
-import 'package:blockchain_utils/numbers/int_utils.dart';
-import 'package:blockchain_utils/tuple/tuple.dart';
+import 'package:blockchain_utils/blockchain_utils.dart';
 
 import '../script/script.dart';
 
@@ -33,7 +30,7 @@ class TxOutput {
     return data;
   }
 
-  static Tuple<TxOutput, int> fromRaw(
+  static (TxOutput, int) fromRaw(
       {required String raw, required int cursor, bool hasSegwit = false}) {
     final txoutPutRaw = BytesUtils.fromHexString(raw);
     final value = BigintUtils.fromBytes(txoutPutRaw.sublist(cursor, cursor + 8),
@@ -42,10 +39,10 @@ class TxOutput {
     cursor += 8;
 
     final vi = IntUtils.decodeVarint(txoutPutRaw.sublist(cursor, cursor + 9));
-    cursor += vi.item2;
-    List<int> lockScript = txoutPutRaw.sublist(cursor, cursor + vi.item1);
-    cursor += vi.item1;
-    return Tuple(
+    cursor += vi.$2;
+    List<int> lockScript = txoutPutRaw.sublist(cursor, cursor + vi.$1);
+    cursor += vi.$1;
+    return (
         TxOutput(
             amount: value,
             scriptPubKey: Script.fromRaw(

--- a/packages/crypto_wallet_util/lib/src/forked_lib/bitcoin_base_hd/src/bitcoin/script/script.dart
+++ b/packages/crypto_wallet_util/lib/src/forked_lib/bitcoin_base_hd/src/bitcoin/script/script.dart
@@ -1,6 +1,4 @@
-import 'package:blockchain_utils/binary/binary_operation.dart';
-import 'package:blockchain_utils/binary/utils.dart';
-import 'package:blockchain_utils/numbers/int_utils.dart';
+import 'package:blockchain_utils/blockchain_utils.dart' hide DynamicByteTracker;
 
 import '../address/legacy_address.dart';
 import '../script/op_code/constant_lib.dart';
@@ -48,7 +46,7 @@ class Script {
             .join());
         index = index + bytesToRead;
       } else if (!hasSegwit && byte == 0x4d) {
-        int bytesToRead = readUint16LE(scriptRaw, index + 1);
+        int bytesToRead = BinaryOps.readUint16LE(scriptRaw, index + 1);
 
         index = index + 3;
         commands.add(scriptRaw
@@ -57,7 +55,7 @@ class Script {
             .join());
         index = index + bytesToRead;
       } else if (!hasSegwit && byte == 0x4e) {
-        int bytesToRead = readUint32LE(scriptRaw, index + 1);
+        int bytesToRead = BinaryOps.readUint32LE(scriptRaw, index + 1);
 
         index = index + 5;
         commands.add(scriptRaw
@@ -68,8 +66,8 @@ class Script {
       } else {
         final viAndSize =
             IntUtils.decodeVarint(scriptRaw.sublist(index, index + 9));
-        int dataSize = viAndSize.item1;
-        int size = viAndSize.item2;
+        int dataSize = viAndSize.$1;
+        int size = viAndSize.$2;
         final lastIndex = (index + size + dataSize) > scriptRaw.length
             ? scriptRaw.length
             : (index + size + dataSize);

--- a/packages/crypto_wallet_util/lib/src/forked_lib/bitcoin_base_hd/src/bitcoin/script/sequence.dart
+++ b/packages/crypto_wallet_util/lib/src/forked_lib/bitcoin_base_hd/src/bitcoin/script/sequence.dart
@@ -1,7 +1,6 @@
 import 'dart:typed_data';
 
-import 'package:blockchain_utils/binary/binary_operation.dart';
-import 'package:blockchain_utils/numbers/int_utils.dart';
+import 'package:blockchain_utils/blockchain_utils.dart';
 
 import '../script/op_code/constant.dart';
 
@@ -14,7 +13,7 @@ class Sequence {
   Sequence(
       {required this.seqType, required this.value, this.isTypeBlock = true}) {
     if (seqType == BitcoinOpCodeConst.TYPE_RELATIVE_TIMELOCK &&
-        (value < 1 || value > mask16)) {
+        (value < 1 || value > BinaryOps.mask16)) {
       throw ArgumentError('Sequence should be between 1 and 65535');
     }
   }

--- a/packages/crypto_wallet_util/lib/src/forked_lib/bitcoin_base_hd/src/bitcoin/script/transaction.dart
+++ b/packages/crypto_wallet_util/lib/src/forked_lib/bitcoin_base_hd/src/bitcoin/script/transaction.dart
@@ -1,10 +1,7 @@
 import 'dart:typed_data';
 
-import 'package:blockchain_utils/binary/binary_operation.dart';
-import 'package:blockchain_utils/binary/utils.dart';
+import 'package:blockchain_utils/blockchain_utils.dart' hide DynamicByteTracker;
 import 'package:blockchain_utils/crypto/quick_crypto.dart';
-import 'package:blockchain_utils/numbers/bigint_utils.dart';
-import 'package:blockchain_utils/numbers/int_utils.dart';
 
 import 'input.dart';
 import 'output.dart';
@@ -75,40 +72,40 @@ class BtcTransaction {
       cursor += 2;
     }
     final vi = IntUtils.decodeVarint(rawtx.sublist(cursor, cursor + 9));
-    cursor += vi.item2;
+    cursor += vi.$2;
 
     List<TxInput> inputs = [];
-    for (int index = 0; index < vi.item1; index++) {
+    for (int index = 0; index < vi.$1; index++) {
       final inp =
           TxInput.fromRaw(raw: raw, hasSegwit: hasSegwit, cursor: cursor);
 
-      inputs.add(inp.item1);
-      cursor = inp.item2;
+      inputs.add(inp.$1);
+      cursor = inp.$2;
     }
 
     List<TxOutput> outputs = [];
     final viOut = IntUtils.decodeVarint(rawtx.sublist(cursor, cursor + 9));
-    cursor += viOut.item2;
-    for (int index = 0; index < viOut.item1; index++) {
+    cursor += viOut.$2;
+    for (int index = 0; index < viOut.$1; index++) {
       final inp =
           TxOutput.fromRaw(raw: raw, hasSegwit: hasSegwit, cursor: cursor);
-      outputs.add(inp.item1);
-      cursor = inp.item2;
+      outputs.add(inp.$1);
+      cursor = inp.$2;
     }
     List<TxWitnessInput> witnesses = [];
     // if (hasSegwit) {
     //   for (int n = 0; n < inputs.length; n++) {
     //     final wVi = IntUtils.decodeVarint(rawtx.sublist(cursor, cursor + 9));
-    //     cursor += wVi.item2;
+    //     cursor += wVi.$2;
     //     List<String> witnessesTmp = [];
-    //     for (int n = 0; n < wVi.item1; n++) {
+    //     for (int n = 0; n < wVi.$1; n++) {
     //       List<int> witness = <int>[];
     //       final wtVi = IntUtils.decodeVarint(rawtx.sublist(cursor, cursor + 9));
-    //       if (wtVi.item1 != 0) {
+    //       if (wtVi.$1 != 0) {
     //         witness = rawtx.sublist(
-    //             cursor + wtVi.item2, cursor + wtVi.item1 + wtVi.item2);
+    //             cursor + wtVi.$2, cursor + wtVi.$1 + wtVi.$2);
     //       }
-    //       cursor += wtVi.item1 + wtVi.item2;
+    //       cursor += wtVi.$1 + wtVi.$2;
     //       witnessesTmp.add(BytesUtils.toHexString(witness));
     //     }
 
@@ -413,7 +410,7 @@ class BtcTransaction {
     } else {
       int index = txIndex;
       List<int> indexBytes = List<int>.filled(4, 0);
-      writeUint32LE(index, indexBytes);
+      BinaryOps.writeUint32LE(index, indexBytes);
       txForSign.add(indexBytes);
     }
     if (sighashSingle) {
@@ -433,7 +430,7 @@ class BtcTransaction {
           [leafVar, ...IntUtils.prependVarint(script?.toBytes() ?? <int>[])]);
       txForSign.add(taggedHash(leafVarBytes, "TapLeaf"));
       txForSign.add([0]);
-      txForSign.add(List<int>.filled(4, mask8));
+      txForSign.add(List<int>.filled(4, BinaryOps.mask8));
     }
     final bytes = txForSign.toBytes();
 

--- a/packages/crypto_wallet_util/lib/src/forked_lib/bitcoin_base_hd/src/bitcoin/script/witness.dart
+++ b/packages/crypto_wallet_util/lib/src/forked_lib/bitcoin_base_hd/src/bitcoin/script/witness.dart
@@ -1,5 +1,4 @@
-import 'package:blockchain_utils/binary/utils.dart';
-import 'package:blockchain_utils/numbers/int_utils.dart';
+import 'package:blockchain_utils/blockchain_utils.dart';
 
 /// A list of the witness items required to satisfy the locking conditions of a segwit input (aka witness stack).
 ///

--- a/packages/crypto_wallet_util/lib/src/forked_lib/bitcoin_base_hd/src/bytes_utils/dynamic_byte.dart
+++ b/packages/crypto_wallet_util/lib/src/forked_lib/bitcoin_base_hd/src/bytes_utils/dynamic_byte.dart
@@ -1,4 +1,4 @@
-import 'package:blockchain_utils/binary/binary_operation.dart';
+import 'package:blockchain_utils/blockchain_utils.dart';
 
 class DynamicByteTracker {
   final List<int> _buffer = List<int>.empty(growable: true);
@@ -9,7 +9,7 @@ class DynamicByteTracker {
 
   void add(List<int> chunk) {
     for (int i in chunk) {
-      _buffer.add(i & mask8);
+      _buffer.add(i & BinaryOps.mask8);
     }
   }
 }

--- a/packages/crypto_wallet_util/lib/src/forked_lib/bitcoin_base_hd/src/crypto/keypair/ec_private.dart
+++ b/packages/crypto_wallet_util/lib/src/forked_lib/bitcoin_base_hd/src/crypto/keypair/ec_private.dart
@@ -22,7 +22,7 @@ class ECPrivate {
   factory ECPrivate.fromWif(String wif, {required List<int>? netVersion}) {
     final decode = WifDecoder.decode(wif,
         netVer: netVersion ?? BitcoinNetwork.mainnet.wifNetVer);
-    return ECPrivate.fromBytes(decode.item1);
+    return ECPrivate.fromBytes(decode.$1);
   }
 
   /// returns as WIFC (compressed) or WIF format (string)
@@ -49,16 +49,18 @@ class ECPrivate {
   /// Returns a Bitcoin compact signature in hex
   String signMessage(List<int> message,
       {String messagePrefix = '\x18Bitcoin Signed Message:\n'}) {
-    final btcSigner = BitcoinSigner.fromKeyBytes(toBytes());
-    final signature = btcSigner.signMessage(message, messagePrefix);
-    return BytesUtils.toHexString(signature);
+    final btcSigner = BitcoinKeySigner.fromKeyBytes(toBytes());
+    final signature =
+        btcSigner.signMessageConst(message: message, messagePrefix: messagePrefix);
+    // 6.x prepends a 1-byte recovery header; drop it to match pre-upgrade output.
+    return BytesUtils.toHexString(signature.sublist(1));
   }
 
   /// sign transaction digest  and returns the signature.
   String signInput(List<int> txDigest,
       {int sigHash = BitcoinOpCodeConst.SIGHASH_ALL}) {
-    final btcSigner = BitcoinSigner.fromKeyBytes(toBytes());
-    List<int> signature = btcSigner.signTransaction(txDigest);
+    final btcSigner = BitcoinKeySigner.fromKeyBytes(toBytes());
+    List<int> signature = btcSigner.signECDSADerConst(txDigest);
     signature = <int>[...signature, sigHash];
     return BytesUtils.toHexString(signature);
   }
@@ -75,12 +77,16 @@ class ECPrivate {
       return true;
     }(),
         "When the tweak is false, the `tapScripts` are ignored, to use the tap script path, you need to consider the tweak value to be true.");
-    final tapScriptBytes = !tweak
-        ? []
+    final tapScriptBytes = (!tweak || tapScripts.isEmpty)
+        ? null
         : tapScripts.map((e) => e.map((e) => e.toBytes()).toList()).toList();
-    final btcSigner = BitcoinSigner.fromKeyBytes(toBytes());
-    List<int> signatur = btcSigner.signSchnorrTransaction(txDigest,
-        tapScripts: tapScriptBytes, tweak: tweak);
+    final btcSigner = BitcoinKeySigner.fromKeyBytes(toBytes());
+    final pubPoint = getPublic().publicKey.point as ProjectiveECCPoint;
+    List<int> signatur = btcSigner.signBip340Const(
+      digest: txDigest,
+      tapTweakHash:
+          tweak ? P2TRUtils.calculateTweek(pubPoint, script: tapScriptBytes) : null,
+    );
     if (sighash != BitcoinOpCodeConst.TAPROOT_SIGHASH_ALL) {
       signatur = <int>[...signatur, sighash];
     }

--- a/packages/crypto_wallet_util/lib/src/forked_lib/bitcoin_base_hd/src/crypto/keypair/ec_public.dart
+++ b/packages/crypto_wallet_util/lib/src/forked_lib/bitcoin_base_hd/src/crypto/keypair/ec_public.dart
@@ -160,7 +160,8 @@ class ECPublic {
         publicKey.point as ProjectiveECCPoint,
         script: scriptBytes);
     return BytesUtils.toHexString(
-        BigintUtils.toBytes(pubKey.x, length: publicKey.point.curve.baselen));
+        BigintUtils.toBytes(pubKey.x,
+        length: (publicKey.point as ProjectiveECCPoint).curve.baselen));
   }
 
   /// toXOnlyHex extracts and returns the x-coordinate (first 32 bytes) of the ECPublic key
@@ -172,21 +173,28 @@ class ECPublic {
   /// returns true if the message was signed with this public key's
   bool verify(List<int> message, List<int> signature,
       {String messagePrefix = '\x18Bitcoin Signed Message:\n'}) {
-    final verifyKey = BitcoinVerifier.fromKeyBytes(toBytes());
-    return verifyKey.verifyMessage(message, messagePrefix, signature);
+    final verifyKey = BitcoinSignatureVerifier.fromKeyBytes(toBytes());
+    return verifyKey.verifyMessageSignature(
+        message: message, messagePrefix: messagePrefix, signature: signature);
   }
 
   /// returns true if the message was signed with this public key's
   bool verifyTransactionSignature(List<int> message, List<int> signature) {
-    final verifyKey = BitcoinVerifier.fromKeyBytes(toBytes());
-    return verifyKey.verifyTransaction(message, signature);
+    final verifyKey = BitcoinSignatureVerifier.fromKeyBytes(toBytes());
+    return verifyKey.verifyECDSADerSignature(
+        digest: message, signature: signature);
   }
 
   /// returns true if the message was signed with this public key's
   bool verifySchnorrTransactionSignature(List<int> message, List<int> signature,
       {List<dynamic>? tapleafScripts, bool isTweak = true}) {
-    final verifyKey = BitcoinVerifier.fromKeyBytes(toBytes());
-    return verifyKey.verifySchnorr(message, signature,
-        tapleafScripts: tapleafScripts, isTweak: isTweak);
+    final verifyKey = BitcoinSignatureVerifier.fromKeyBytes(toBytes());
+    final pubPoint = publicKey.point as ProjectiveECCPoint;
+    return verifyKey.verifyBip340Signature(
+        digest: message,
+        signature: signature,
+        tapTweakHash: isTweak
+            ? P2TRUtils.calculateTweek(pubPoint, script: tapleafScripts)
+            : null);
   }
 }

--- a/packages/crypto_wallet_util/lib/src/forked_lib/bitcoin_base_hd/src/models/network.dart
+++ b/packages/crypto_wallet_util/lib/src/forked_lib/bitcoin_base_hd/src/models/network.dart
@@ -1,5 +1,4 @@
-import 'package:blockchain_utils/bip/coin_conf/coin_conf.dart';
-import 'package:blockchain_utils/bip/coin_conf/coins_conf.dart';
+import 'package:blockchain_utils/blockchain_utils.dart';
 
 import '../../bitcoin_base.dart';
 import '../utils/enumerate.dart';

--- a/packages/crypto_wallet_util/lib/src/forked_lib/bitcoin_base_hd/src/provider/transaction_builder/bch_transaction_builder.dart
+++ b/packages/crypto_wallet_util/lib/src/forked_lib/bitcoin_base_hd/src/provider/transaction_builder/bch_transaction_builder.dart
@@ -1,6 +1,6 @@
 import 'dart:convert';
 import '../../../bitcoin_base.dart';
-import 'package:blockchain_utils/binary/utils.dart';
+import 'package:blockchain_utils/blockchain_utils.dart';
 
 class BCHTransactionBuilder {
   final List<BitcoinOutput> outPuts;

--- a/packages/crypto_wallet_util/lib/src/forked_lib/bitcoin_base_hd/src/provider/transaction_builder/transaction_builder.dart
+++ b/packages/crypto_wallet_util/lib/src/forked_lib/bitcoin_base_hd/src/provider/transaction_builder/transaction_builder.dart
@@ -1,6 +1,6 @@
 import 'dart:convert';
 import '../../../bitcoin_base.dart';
-import 'package:blockchain_utils/binary/utils.dart';
+import 'package:blockchain_utils/blockchain_utils.dart';
 
 typedef BitcoinSignerCallBack = String Function(
     List<int> trDigest, UtxoWithAddress utxo, String publicKey, int sighash);

--- a/packages/crypto_wallet_util/lib/src/forked_lib/bitcoin_base_hd/src/utils/btc_utils.dart
+++ b/packages/crypto_wallet_util/lib/src/forked_lib/bitcoin_base_hd/src/utils/btc_utils.dart
@@ -1,4 +1,4 @@
-import 'package:blockchain_utils/numbers/big_rational.dart';
+import 'package:blockchain_utils/blockchain_utils.dart';
 
 class BtcUtils {
   static BigInt toSatoshi(String dec) {

--- a/packages/crypto_wallet_util/lib/src/forked_lib/tweetnacl-dart/src/tweetnacl_base.dart
+++ b/packages/crypto_wallet_util/lib/src/forked_lib/tweetnacl-dart/src/tweetnacl_base.dart
@@ -651,7 +651,7 @@ class Signature {
     for (int i = 0; i < signatureLength; i++) sm[i] = signature[i];
     for (int i = 0; i < message.length; i++)
       sm[i + signatureLength] = message[i];
-    return (TweetNaclFast.crypto_sign_open(m, -1, sm, 0, sm.length, _theirPublicKey!) >= 0);
+    return (TweetNaclFast.crypto_sign_open(m, -1, sm, 0, sm.length, _theirPublicKey) >= 0);
   }
 
   /*

--- a/packages/crypto_wallet_util/lib/src/forked_lib/xrpl_dart/src/keypair/xrpl_private_key.dart
+++ b/packages/crypto_wallet_util/lib/src/forked_lib/xrpl_dart/src/keypair/xrpl_private_key.dart
@@ -36,7 +36,7 @@ class XrpSeedUtils {
   /// This method takes a seed as input and applies the SHA-512 hash function to it
   /// to derive an ED25519 key. It returns the derived key as a list of integers.
   static List<int> deriveED25519(List<int> seed) {
-    return QuickCrypto.sha512HashHalves(seed).item1;
+    return QuickCrypto.sha512HashHalves(seed).$1;
   }
 
   /// Derives a key pair from the given seed using a multi-step process.
@@ -60,7 +60,8 @@ class XrpSeedUtils {
     final BigInt finalPair = (root + mid) % order;
 
     // Convert the final key pair value to a byte array representation with a specific length.
-    return BigintUtils.toBytes(finalPair, length: BigintUtils.orderLen(order));
+    return BigintUtils.toBytes(finalPair,
+        length: BigintUtils.bitlengthInBytes(order));
   }
 
   /// Calculates the secret value from the given data using an iterative process.
@@ -70,7 +71,7 @@ class XrpSeedUtils {
   static BigInt _getSecret(List<int> data, {bool isMid = false}) {
     const int sqSize = 4;
     final BigInt sqMax = BigInt.from(256) << (sqSize * 8);
-    final BigInt bigMask8 = BigInt.from(mask8);
+    final BigInt bigMask8 = BigInt.from(BinaryOps.mask8);
     for (BigInt rawRoot = BigInt.zero;
         rawRoot < sqMax;
         rawRoot += BigInt.zero) {
@@ -89,7 +90,7 @@ class XrpSeedUtils {
         combine = [...data, ...root];
       }
       final hash = QuickCrypto.sha512Hash(combine).sublist(0, 32);
-      if (Secp256k1PrivateKeyEcdsa.isValidBytes(hash)) {
+      if (Secp256k1PrivateKey.isValidBytes(hash)) {
         return BigintUtils.fromBytes(hash);
       }
     }
@@ -138,7 +139,7 @@ class XrpSeedUtils {
         Base58Decoder.checkDecode(b58String, Base58Alphabets.ripple);
 
     /// Check if the decoded bytes match the provided prefix.
-    if (!bytesEqual(decoded.sublist(0, prefixLength), prefix)) {
+    if (!BytesUtils.bytesEqual(decoded.sublist(0, prefixLength), prefix)) {
       /// Throw an exception if the prefix does not match, indicating an incorrect prefix.
       throw const XRPLAddressCodecException('Provided prefix is incorrect');
     }
@@ -163,14 +164,14 @@ class XrpSeedUtils {
   }
 
   /// This method decodes a Ripple address (seed) into its corresponding entropy and encoding algorithm.
-  static Tuple<List<int>, XRPKeyAlgorithm> decodeSeed(String seed,
+  static (List<int>, XRPKeyAlgorithm) decodeSeed(String seed,
       [XRPKeyAlgorithm? algorithm]) {
     if (algorithm != null) {
       /// If a specific algorithm is provided, attempt to decode with that algorithm's prefix.
       for (final prefix in _algorithmSeedPrefix[algorithm]!) {
         try {
           final decodedResult = _decode(seed, prefix);
-          return Tuple(decodedResult, algorithm);
+          return (decodedResult, algorithm);
         } catch (e) {
           /// Prefix is incorrect, continue to the next prefix.
           continue;
@@ -185,7 +186,7 @@ class XrpSeedUtils {
       final prefix = _algorithmSeedPrefix[algorithm]![0];
       try {
         final decodedResult = _decode(seed, prefix);
-        return Tuple(decodedResult, algorithm);
+        return (decodedResult, algorithm);
       } catch (e) {
         /// Prefix is incorrect, continue to the next algorithm.
         continue;
@@ -227,7 +228,7 @@ class XRPPrivateKey {
     switch (algorithm) {
       case XRPKeyAlgorithm.secp256k1:
         final derive = XrpSeedUtils.deriveKeyPair(entropyBytes);
-        final privateKey = Secp256k1PrivateKeyEcdsa.fromBytes(derive);
+        final privateKey = Secp256k1PrivateKey.fromBytes(derive);
         return XRPPrivateKey._(privateKey, algorithm);
       default:
         final privateBytes = XrpSeedUtils.deriveED25519(entropyBytes);
@@ -244,8 +245,8 @@ class XRPPrivateKey {
     final entropy = XrpSeedUtils.decodeSeed(seed);
 
     /// Create an XRPPrivateKey from the entropy and specified algorithm
-    return XRPPrivateKey.fromEntropy(BytesUtils.toHexString(entropy.item1),
-        algorithm: entropy.item2);
+    return XRPPrivateKey.fromEntropy(BytesUtils.toHexString(entropy.$1),
+        algorithm: entropy.$2);
   }
 
   /// Factory constructor for creating an XRP private key from a hexadecimal representation.
@@ -275,9 +276,9 @@ class XRPPrivateKey {
   static XRPKeyAlgorithm findAlgorithm(List<int> keyBytes) {
     if (keyBytes.length == XrpKeyConst.privateKeyWithPrefix) {
       final keyPrefix = keyBytes.sublist(0, 1);
-      if (bytesEqual(keyPrefix, XrpKeyConst.secpPrivateKey)) {
+      if (BytesUtils.bytesEqual(keyPrefix, XrpKeyConst.secpPrivateKey)) {
         return XRPKeyAlgorithm.secp256k1;
-      } else if (bytesEqual(keyPrefix, XrpKeyConst.ed255PrivateKeyPrefix)) {
+      } else if (BytesUtils.bytesEqual(keyPrefix, XrpKeyConst.ed255PrivateKeyPrefix)) {
         return XRPKeyAlgorithm.ed25519;
       }
     }

--- a/packages/crypto_wallet_util/lib/src/forked_lib/xrpl_dart/src/keypair/xrpl_public_key.dart
+++ b/packages/crypto_wallet_util/lib/src/forked_lib/xrpl_dart/src/keypair/xrpl_public_key.dart
@@ -27,11 +27,11 @@ class XRPPublicKey {
     }
     if (keyBytes.length == RippleKeyConst.publicKeyLength) {
       final prefix = keyBytes.sublist(0, 1);
-      if (bytesEqual(prefix, Ed25519KeysConst.xrpPubKeyPrefix) ||
-          bytesEqual(prefix, Ed25519KeysConst.pubKeyPrefix)) {
+      if (BytesUtils.bytesEqual(prefix, Ed25519KeysConst.xrpPubKeyPrefix) ||
+          BytesUtils.bytesEqual(prefix, Ed25519KeysConst.pubKeyPrefix)) {
         return XRPKeyAlgorithm.ed25519;
       }
-      if (Secp256k1PublicKeyEcdsa.isValidBytes(keyBytes)) {
+      if (Secp256k1PublicKey.isValidBytes(keyBytes)) {
         return XRPKeyAlgorithm.secp256k1;
       }
     }

--- a/packages/crypto_wallet_util/lib/src/forked_lib/xrpl_dart/src/keypair/xrpl_public_key.dart
+++ b/packages/crypto_wallet_util/lib/src/forked_lib/xrpl_dart/src/keypair/xrpl_public_key.dart
@@ -1,4 +1,3 @@
-import 'package:blockchain_utils/bip/address/p2pkh_addr.dart';
 import 'package:blockchain_utils/blockchain_utils.dart';
 import '../xrpl/address/xrpl.dart';
 

--- a/packages/crypto_wallet_util/lib/src/forked_lib/xrpl_dart/src/rpc/provider/provider.dart
+++ b/packages/crypto_wallet_util/lib/src/forked_lib/xrpl_dart/src/rpc/provider/provider.dart
@@ -1,5 +1,5 @@
 import 'dart:async';
-import 'package:blockchain_utils/blockchain_utils.dart';
+import 'package:blockchain_utils/blockchain_utils.dart' hide RPCError;
 import 'package:crypto_wallet_util/src/forked_lib/xrpl_dart/xrpl_dart.dart';
 
 typedef OnGenerateRpc = Future<RpcService> Function(

--- a/packages/crypto_wallet_util/lib/src/forked_lib/xrpl_dart/src/utility/fulfillment/ans1_raw_encoder.dart
+++ b/packages/crypto_wallet_util/lib/src/forked_lib/xrpl_dart/src/utility/fulfillment/ans1_raw_encoder.dart
@@ -81,7 +81,7 @@ class ASN1RawEncoder {
     for (int i = 0; i < buf.length; i++) {
       int shift = 7 * (buf.length - i - 1);
       int mask = 0x7F << shift;
-      buf[i] = ((tag & mask) >> shift) & mask8;
+      buf[i] = ((tag & mask) >> shift) & BinaryOps.mask8;
       // Only the last byte is not marked with 0x80
       if (i != buf.length - 1) {
         buf[i] |= 0x80;
@@ -103,8 +103,8 @@ class ASN1RawEncoder {
 
     for (int i = 0; i < buf.length; i++) {
       int shift = (buf.length - i - 1) * 8;
-      int mask = mask8 << shift;
-      buf[i] = ((mask & length) >> shift) & mask8;
+      int mask = BinaryOps.mask8 << shift;
+      buf[i] = ((mask & length) >> shift) & BinaryOps.mask8;
     }
 
     // Ignore leading zeros
@@ -135,7 +135,7 @@ class ASN1RawEncoder {
 
     // Encode value
     for (int i = byteCount - 1; i >= 0; i--) {
-      encoded.add((value >> (8 * i)) & mask8);
+      encoded.add((value >> (8 * i)) & BinaryOps.mask8);
     }
     // If the first bit of the first byte is 1 (negative number), prepend a zero byte
     if ((encoded[0] & 0x80) != 0) {

--- a/packages/crypto_wallet_util/lib/src/forked_lib/xrpl_dart/src/xrpl/address/xrpl.dart
+++ b/packages/crypto_wallet_util/lib/src/forked_lib/xrpl_dart/src/xrpl/address/xrpl.dart
@@ -1,4 +1,3 @@
-import 'package:blockchain_utils/bip/coin_conf/coins_conf.dart';
 import 'package:blockchain_utils/blockchain_utils.dart';
 import 'package:crypto_wallet_util/src/forked_lib/xrpl_dart/src/keypair/xrpl_private_key.dart';
 
@@ -11,7 +10,7 @@ class XRPAddress {
   factory XRPAddress.fromPublicKeyBytes(
       List<int> bytes, XRPKeyAlgorithm algorithm) {
     return XRPAddress._(
-        XrpAddrEncoder().encodeKey(bytes, {"curve_type": algorithm.curveType}),
+        XrpAddrEncoder().encodeKey(bytes, pubKeyType: algorithm.curveType),
         null);
   }
 
@@ -21,8 +20,8 @@ class XRPAddress {
         ? CoinsConf.rippleTestNet.params.addrNetVer!
         : CoinsConf.ripple.params.addrNetVer!;
     final decodeXAddress = XRPAddressUtils.decodeXAddress(xAddress, addrNetVar);
-    final toClassic = XRPAddressUtils.hashToAddress(decodeXAddress.item1);
-    return XRPAddress._(toClassic, decodeXAddress.item2);
+    final toClassic = XRPAddressUtils.hashToAddress(decodeXAddress.bytes);
+    return XRPAddress._(toClassic, decodeXAddress.tag);
   }
 
   /// Converts the XRP address to an X-Address.

--- a/packages/crypto_wallet_util/lib/src/forked_lib/xrpl_dart/src/xrpl/bytes/binery_serializer/binary_parser.dart
+++ b/packages/crypto_wallet_util/lib/src/forked_lib/xrpl_dart/src/xrpl/bytes/binery_serializer/binary_parser.dart
@@ -205,9 +205,9 @@ class BinaryParser {
   }
 
   /// Read both a field and its value
-  Tuple<FieldInstance, SerializedType> readFieldAndValue() {
+  (FieldInstance, SerializedType) readFieldAndValue() {
     final field = readField();
     final value = readFieldValue(field);
-    return Tuple(field, value);
+    return (field, value);
   }
 }

--- a/packages/crypto_wallet_util/lib/src/forked_lib/xrpl_dart/src/xrpl/bytes/binery_serializer/binary_serializer.dart
+++ b/packages/crypto_wallet_util/lib/src/forked_lib/xrpl_dart/src/xrpl/bytes/binery_serializer/binary_serializer.dart
@@ -41,7 +41,7 @@ OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
   OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-import 'package:blockchain_utils/binary/binary.dart';
+import 'package:blockchain_utils/blockchain_utils.dart';
 import 'package:crypto_wallet_util/src/forked_lib/xrpl_dart/src/xrpl/bytes/definations/field.dart';
 
 /// Constants for binary serializer
@@ -108,15 +108,15 @@ class BinarySerializer {
       length -= _BinerySerializerConst._maxSingleByteLength + 1;
       final byte1 =
           ((_BinerySerializerConst._maxSingleByteLength + 1) + (length >> 8));
-      final byte2 = (length & mask8);
+      final byte2 = (length & BinaryOps.mask8);
       return [byte1, byte2];
     }
     if (length <= _BinerySerializerConst._maxLengthValue) {
       length -= _BinerySerializerConst._maxDoubleByteLength;
       final byte1 =
           ((_BinerySerializerConst._maxSecondByteValue + 1) + (length >> 16));
-      final byte2 = ((length >> 8) & mask8);
-      final byte3 = (length & mask8);
+      final byte2 = ((length >> 8) & BinaryOps.mask8);
+      final byte3 = (length & BinaryOps.mask8);
       return [byte1, byte2, byte3];
     }
 

--- a/packages/crypto_wallet_util/lib/src/forked_lib/xrpl_dart/src/xrpl/bytes/types/currency.dart
+++ b/packages/crypto_wallet_util/lib/src/forked_lib/xrpl_dart/src/xrpl/bytes/types/currency.dart
@@ -32,7 +32,7 @@ class _CurrencyUtils {
     if (bytes == null) return null;
     if (bytes[0] != 0) {
       return null;
-    } else if (bytesEqual(bytes, xrpIsoBytes)) {
+    } else if (BytesUtils.bytesEqual(bytes, xrpIsoBytes)) {
       return xrpIsoName;
     } else {
       return _isoNameFromBytes(bytes.sublist(12, 15));

--- a/packages/crypto_wallet_util/lib/src/forked_lib/xrpl_dart/src/xrpl/bytes/types/hash.dart
+++ b/packages/crypto_wallet_util/lib/src/forked_lib/xrpl_dart/src/xrpl/bytes/types/hash.dart
@@ -15,7 +15,7 @@ abstract class Hash extends SerializedType {
     if (identical(this, other)) return true;
     return other is Hash &&
         runtimeType == other.runtimeType &&
-        bytesEqual(_buffer, other._buffer);
+        BytesUtils.bytesEqual(_buffer, other._buffer);
   }
 
   @override

--- a/packages/crypto_wallet_util/lib/src/forked_lib/xrpl_dart/src/xrpl/bytes/types/st_object.dart
+++ b/packages/crypto_wallet_util/lib/src/forked_lib/xrpl_dart/src/xrpl/bytes/types/st_object.dart
@@ -13,8 +13,8 @@ class _StObjectUtils {
   static Map<String, dynamic> _handleXAddress(String field, String xaddress) {
     final classicAddressTag = XRPAddressUtils.decodeXAddress(xaddress, null);
     final classicAddress =
-        XRPAddressUtils.hashToAddress(classicAddressTag.item1);
-    final tag = classicAddressTag.item2;
+        XRPAddressUtils.hashToAddress(classicAddressTag.bytes);
+    final tag = classicAddressTag.tag;
     String? tagFieldName;
     if (field == _destination) {
       tagFieldName = _destTag;

--- a/packages/crypto_wallet_util/lib/src/forked_lib/xrpl_dart/src/xrpl/bytes/types/xchain_bridge.dart
+++ b/packages/crypto_wallet_util/lib/src/forked_lib/xrpl_dart/src/xrpl/bytes/types/xchain_bridge.dart
@@ -18,15 +18,15 @@ class _XChainBridgeConst {
     }
   }
 
-  static Tuple<int?, SerializedType> fromParser(String key, BinaryParser parser,
+  static (int?, SerializedType) fromParser(String key, BinaryParser parser,
       [int? lengthHint]) {
     switch (key) {
       case "LockingChainIssue":
       case "IssuingChainIssue":
-        return Tuple(null, Issue.fromParser(parser, lengthHint));
+        return (null, Issue.fromParser(parser, lengthHint));
       default:
         parser.skip(1);
-        return Tuple(0x14, AccountID.fromParser(parser, lengthHint));
+        return (0x14, AccountID.fromParser(parser, lengthHint));
     }
   }
 }
@@ -35,7 +35,7 @@ class XChainBridge extends SerializedType {
   XChainBridge([super.buffer]);
   @override
   factory XChainBridge.fromValue(Map value) {
-    if (iterableIsEqual(value.keys, _XChainBridgeConst.keys)) {
+    if (CompareUtils.iterableIsEqual(value.keys, _XChainBridgeConst.keys)) {
       final bytes = DynamicByteTracker();
       for (final i in _XChainBridgeConst.keys) {
         final buffer = _XChainBridgeConst.toBytesFromType(i, value[i]);
@@ -51,10 +51,10 @@ class XChainBridge extends SerializedType {
     final bytes = DynamicByteTracker();
     for (final i in _XChainBridgeConst.keys) {
       final buffer = _XChainBridgeConst.fromParser(i, parser, lengthHint);
-      if (buffer.item1 != null) {
-        bytes.add([buffer.item1!]);
+      if (buffer.$1 != null) {
+        bytes.add([buffer.$1!]);
       }
-      bytes.add(buffer.item2.toBytes());
+      bytes.add(buffer.$2.toBytes());
     }
     return XChainBridge(bytes.toBytes());
   }
@@ -65,7 +65,7 @@ class XChainBridge extends SerializedType {
     final Map<String, String> toJson = {};
     for (final i in _XChainBridgeConst.keys) {
       final buffer = _XChainBridgeConst.fromParser(i, parser);
-      toJson[i] = buffer.item2.toJson();
+      toJson[i] = buffer.$2.toJson();
     }
     return toJson;
   }

--- a/packages/crypto_wallet_util/lib/src/forked_lib/xrpl_dart/src/xrpl/exception/exceptions.dart
+++ b/packages/crypto_wallet_util/lib/src/forked_lib/xrpl_dart/src/xrpl/exception/exceptions.dart
@@ -1,4 +1,4 @@
-import 'package:blockchain_utils/exception/exception.dart';
+import 'package:blockchain_utils/blockchain_utils.dart';
 
 /// Exception thrown when an error occurs during XRPL binary encoding or decoding.
 class XRPLBinaryCodecException implements BlockchainUtilsException {
@@ -7,6 +7,9 @@ class XRPLBinaryCodecException implements BlockchainUtilsException {
 
   /// Constructor for XRPLBinaryCodecException
   const XRPLBinaryCodecException(this.message);
+
+  @override
+  Map<String, dynamic>? get details => null;
 
   @override
   String toString() => message;
@@ -19,6 +22,10 @@ class XRPLAddressCodecException implements BlockchainUtilsException {
 
   /// Constructor for XRPLAddressCodecException
   const XRPLAddressCodecException(this.message);
+
+  @override
+  Map<String, dynamic>? get details => null;
+
   @override
   String toString() => message;
 }

--- a/packages/crypto_wallet_util/lib/src/utils/address.dart
+++ b/packages/crypto_wallet_util/lib/src/utils/address.dart
@@ -48,8 +48,6 @@ class AddressUtils {
         return RegExp(conf.regExp).hasMatch(address);
       case AddressType.NONE:
         return RegExp(COMMON_REG).hasMatch(address);
-      default:
-        return RegExp(COMMON_REG).hasMatch(address);
     }
   }
 

--- a/packages/crypto_wallet_util/lib/src/utils/bech32/bech32.dart
+++ b/packages/crypto_wallet_util/lib/src/utils/bech32/bech32.dart
@@ -70,7 +70,7 @@ class Bech32Decoder extends Converter<String, Bech32> with Bech32Validations {
 }
 
 /// Generic validations for Bech32 standard.
-class Bech32Validations {
+mixin Bech32Validations {
   static const int maxInputLength = 90;
   static const checksumLength = 6;
 

--- a/packages/crypto_wallet_util/lib/src/utils/bech32/segwit.dart
+++ b/packages/crypto_wallet_util/lib/src/utils/bech32/segwit.dart
@@ -71,7 +71,7 @@ class SegwitDecoder extends Converter<SegwitInput, Segwit> with SegwitValidation
 }
 
 /// Generic validations for a Segwit class.
-class SegwitValidations {
+mixin SegwitValidations {
   bool isInvalidHrp(String hrp, String validHrp) => hrp != validHrp;
 
   bool isEmptyProgram(List<int> data) => data.isEmpty;

--- a/packages/crypto_wallet_util/pubspec.yaml
+++ b/packages/crypto_wallet_util/pubspec.yaml
@@ -1,10 +1,10 @@
 name: crypto_wallet_util
 description: A collection of utility functions for cryptocurrencies.
-version: 1.2.6
+version: 2.0.0
 homepage: https://github.com/fxwalletOfficial/fx-wallet-packages/tree/main/packages/wallet_crypto_util
 
 environment:
-  sdk: '>=2.17.0 <4.0.0'
+  sdk: '>=3.7.0 <4.0.0'
 
 dependency_overrides:
   pointycastle: ^4.0.0
@@ -31,7 +31,7 @@ dependencies:
   buffer: ^1.2.3
   bech32m_i: ^0.2.2
   decimal: ^3.2.4
-  blockchain_utils: ^1.4.1
+  blockchain_utils: ^6.0.0
   wasm_run: ^0.1.0+2
 
 dev_dependencies:

--- a/packages/crypto_wallet_util/test/forked_lib/MIGRATION_COVERAGE_BASELINE.md
+++ b/packages/crypto_wallet_util/test/forked_lib/MIGRATION_COVERAGE_BASELINE.md
@@ -1,0 +1,78 @@
+# blockchain_utils 1.6.0 → 6.0.0 升级：覆盖率与风险基线
+
+> 阶段 0.5「覆盖审计闸门」产出物。重构前固化，重构后用于对照。
+> 数据采集于 blockchain_utils **1.6.0**（升级前），分支 `feature/upgrade-blockchain-utils-v6`。
+
+## 1. 影响面
+
+`blockchain_utils` 仅被两个 vendored fork 使用，项目自有代码 **0** 处直接依赖：
+
+| fork | 文件数 | 用途 |
+|------|------:|------|
+| `lib/src/forked_lib/bitcoin_base_hd` | 19（引用 blockchain_utils 的） | BTC/LTC/BCH 钱包 **仅用 `ECPrivate`** |
+| `lib/src/forked_lib/xrpl_dart` | 16（引用 blockchain_utils 的） | XRP |
+
+把约束改成 `^6.0.0` 后 `dart analyze` 报 **211 error，全部在这两个 fork 内**，自有代码 0。
+
+## 2. 升级前覆盖率（含被排除的 fork）
+
+> 注意：仓库现有 `generate_coverage.sh` 用 `--ignore-files` 把这两个 fork **排除**在覆盖率外，
+> 即对本次要改的代码原本零可见性。下表是去掉该排除后的真实数据。
+
+| 范围 | 升级前 | 闸门后 |
+|------|------:|------:|
+| `bitcoin_base_hd` 整体 | 1.6% (26/1588) | 1.6%（见 §4，多为运行时死代码） |
+| `xrpl_dart` 整体 | 16.7% (521/3111) | **19.3% (600/3111)** |
+| `xrpl_private_key.dart`（含 orderLen） | 26.3% | **88.9%** |
+| `xrpl/address/xrpl.dart`（X-address） | 27.3% | **77.3%** |
+| 测试总数 | 771 | **779** |
+
+## 3. 「编译可达」≠「运行时执行」
+
+入口 `ec_private.dart` 顺着 barrel 把整个 `bitcoin_base_hd` import 进来，所以**全部文件都必须能编译过 6.x**（211 个报错都要修，不能简单删）。
+但**运行时真正被测试执行**的只有一小撮：
+
+- BTC/LTC/BCH：只用 `ECPrivate`（`signInput` / `signTapRoot` / `signMessage` 均已被 btc + taproot 测试命中）。
+- XRP：`fromHex` + secp256k1 签名（xrp_test 用 golden `signedBlob` 锁定 payment / token / trust_set 三类）、公钥→地址、ed25519 派生。
+
+其余（tx-builder、script、address 类、provider/RPC、binary_parser 解码、xchain、fulfillment）**运行时 0% 执行**——这是 1.6% 的根因，不是测试缺失，而是 crypto_wallet_util 根本不调用。
+
+## 4. 待改文件风险分层
+
+| 层级 | 处理策略 | 文件 |
+|------|----------|------|
+| 🟢 运行时死代码（仅需编译过 6.x） | 机械修复，无需补测 | bitcoin_base_hd 的 tx-builder/script/address/provider；xrpl 的 binary_parser(解码)/xchain_bridge/ans1_raw_encoder/rpc provider |
+| 🟡 活码·已被现有测试覆盖 | 现有 golden 兜底，可安全改 | xrpl_public_key、currency、binary_serializer(序列化)、st_object(序列化)、ec_private/ec_public sign、地址 encodeKey |
+| 🔴 活码/半活·低覆盖·有语义改动 | **已在本闸门补特征测试** | xrpl_private_key（orderLen）、X-address 转换 |
+
+## 5. 本闸门新增的特征测试（pin 升级前行为）
+
+1. `test/forked_lib/xrpl_dart/keypair/xrpl_seed_characterization_test.dart`
+   - secp256k1 家族种子派生（`deriveKeyPair` → **`orderLen` line 63，升级前命中=0**）。
+   - 用 XRPL 官方主种子向量 `snoPBrXtMeMyMHUVTgbuqAfg1SUTb → rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh` 交叉验证。
+   - 覆盖 ed25519 派生（`sha512HashHalves().item1` → 6.x record）、secp256k1 签名往返。
+2. `test/forked_lib/xrpl_dart/address/xaddress_characterization_test.dart`
+   - classic ↔ X-address（`decodeXAddress` 的 `.item1/.item2` Tuple→record；`encodeKey` 签名变化）。
+   - 用官方向量 `rHb9… ↔ XVPcpSm47b1CZkf5AkKM9a84dQHe3m4sBhsrA4XtnBECTAc` 交叉验证。
+
+> 这些路径**运行时未被 XrpCoin 调用**，但升级会改动它们，故以特征测试 pin 住，确保字节不变。
+
+## 6. 死代码处理建议（任务 #22）
+
+`ec_private.dart` 实际只从 barrel 用到 `ECPublic / BitcoinSigner / Script / BitcoinNetwork / BitcoinOpCodeConst`，
+**不**用 tx-builder / provider。理论上可切断 barrel→删死代码，但 `Script` 的传递依赖需要谨慎解耦。
+
+**建议**：本升级 PR **不**删死代码，只「修到能编译」（原子、可回退、聚焦）。
+死代码移除作为**独立后续 PR**（纯重构，可单独验证；且 1.6% 覆盖下本就该先补特征测试）。
+
+## 7. 复现命令
+
+```bash
+cd packages/crypto_wallet_util
+dart run wasm_run:setup           # 否则 SC(Sia) 用例假失败
+dart test --coverage=coverage
+dart pub global run coverage:format_coverage \
+  --lcov --in=coverage --out=coverage/lcov_full.info \
+  --report-on=lib --packages=.dart_tool/package_config.json
+# 注意：不要沿用 generate_coverage.sh 的 --ignore-files，否则看不到这两个 fork
+```

--- a/packages/crypto_wallet_util/test/forked_lib/bitcoin_base_hd/keypair/ec_private_characterization_test.dart
+++ b/packages/crypto_wallet_util/test/forked_lib/bitcoin_base_hd/keypair/ec_private_characterization_test.dart
@@ -1,0 +1,51 @@
+import 'package:test/test.dart';
+
+import 'package:blockchain_utils/blockchain_utils.dart';
+import 'package:crypto_wallet_util/src/forked_lib/bitcoin_base_hd/src/crypto/keypair/ec_private.dart';
+
+/// Characterization tests for ECPrivate signing (bitcoin_base_hd fork).
+///
+/// 背景：BTC/LTC/BCH 钱包的 sign() 走 ECPrivate.signInput / signTapRoot，但
+/// 各币种 WalletType.verify 目前是 `return true` 桩实现，wallet_test 的 sign+verify
+/// 并未对签名输出做 golden 比对。而 blockchain_utils 1.x→6.x 升级重写了这些方法体
+/// (BitcoinSigner→BitcoinKeySigner: signTransaction→signECDSADerConst,
+///  signSchnorrTransaction→signBip340Const+P2TRUtils.calculateTweek,
+///  signMessage→signMessageConst().sublist(1))。
+///
+/// 下列 golden 采自升级前(blockchain_utils 1.6.0)并经升级前后逐字节比对确认一致，
+/// 用以锁定这条活跃签名路径，防止后续改动产生回归。
+void main() {
+  final priv = BytesUtils.fromHexString(
+    '3c9229289a6125f7fdf1885a77bb12c37a8d3b4962d936f7e3084dece32a3ca1',
+  );
+  final digest = BytesUtils.fromHexString(
+    'deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef',
+  );
+
+  group('ECPrivate signing (pins pre-upgrade bytes)', () {
+    test('signInput (ECDSA DER + sighash)', () {
+      expect(
+        ECPrivate.fromBytes(priv).signInput(digest),
+        '30440220547b70c9e3862a339fa6c0aed6c6cb86df4a202e87f6bd33082ebdb5bfc'
+        '9049f02200f366449e8ffd33be92676634a716b2077027b11dc76b33ecae62a6ddf'
+        'fe21e201',
+      );
+    });
+
+    test('signTapRoot (key-path, tweak=true)', () {
+      expect(
+        ECPrivate.fromBytes(priv).signTapRoot(digest),
+        '603892c5f393edb586604f09d91b944ab6a62f7991c14c98af0a319674dd1459c1'
+        'af08f3b8a648442e893166d47a208a716d697a415179fb49f3d4b23d557fb4',
+      );
+    });
+
+    test('signMessage (compact, recovery byte stripped)', () {
+      expect(
+        ECPrivate.fromBytes(priv).signMessage(digest),
+        '561fe99047a805b001da87f8730291706eddb48aa2b2a6d80f129cc95a04eae53b'
+        '0d637c3057d0a3eab2bdec5cca058651b9fa100dc5d1c8e177fca9976a9c34',
+      );
+    });
+  });
+}

--- a/packages/crypto_wallet_util/test/forked_lib/xrpl_dart/address/xaddress_characterization_test.dart
+++ b/packages/crypto_wallet_util/test/forked_lib/xrpl_dart/address/xaddress_characterization_test.dart
@@ -1,0 +1,39 @@
+import 'package:test/test.dart';
+
+import 'package:crypto_wallet_util/src/forked_lib/xrpl_dart/src/xrpl/address/xrpl.dart';
+
+/// Characterization tests for XRPL classic <-> X-address conversion.
+///
+/// 这条路径(XRPAddress.toXAddress / fromXAddress)运行时未被 crypto_wallet_util 调用，
+/// 但 blockchain_utils 1.x→6.x 升级会改动它：
+///   * fromXAddress 里 decodeXAddress 返回的 `.item1/.item2` (Tuple→record)
+///   * fromPublicKeyBytes 里 `encodeKey` 的参数签名变化
+/// golden 用 XRPL 官方 X-address 文档向量交叉验证，确保升级后字节不变。
+void main() {
+  // XRPL 官方文档向量：经典地址 rHb9... 对应的 X-address。
+  const classic = 'rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh';
+  const xMainnet = 'XVPcpSm47b1CZkf5AkKM9a84dQHe3m4sBhsrA4XtnBECTAc';
+  const xMainnetTag12345 = 'XVPcpSm47b1CZkf5AkKM9a84dQHe3mTAxgxfLw2qYoe7Boa';
+
+  group('XRPL X-address conversion (pins pre-upgrade behavior)', () {
+    test('classic -> X-address (no tag)', () {
+      expect(XRPAddress(classic).toXAddress(), xMainnet);
+    });
+
+    test('classic -> X-address (with destination tag)', () {
+      expect(XRPAddress(classic).toXAddress(tag: 12345), xMainnetTag12345);
+    });
+
+    test('X-address -> classic (no tag)', () {
+      final back = XRPAddress.fromXAddress(xMainnet);
+      expect(back.address, classic);
+      expect(back.tag, isNull);
+    });
+
+    test('X-address -> classic (with tag) preserves tag', () {
+      final back = XRPAddress.fromXAddress(xMainnetTag12345);
+      expect(back.address, classic);
+      expect(back.tag, 12345);
+    });
+  });
+}

--- a/packages/crypto_wallet_util/test/forked_lib/xrpl_dart/keypair/xrpl_seed_characterization_test.dart
+++ b/packages/crypto_wallet_util/test/forked_lib/xrpl_dart/keypair/xrpl_seed_characterization_test.dart
@@ -1,0 +1,68 @@
+import 'package:test/test.dart';
+
+import 'package:crypto_wallet_util/src/forked_lib/xrpl_dart/src/keypair/xrpl_private_key.dart';
+
+/// Characterization tests for the XRPL *family-seed* key derivation.
+///
+/// 背景：crypto_wallet_util 的 XrpCoin 走 bip32 + XRPPrivateKey.fromHex，
+/// 不经过这里的 family-seed 派生(deriveKeyPair / deriveED25519 / decodeSeed)。
+/// 因此这条路径运行时 0% 覆盖——而 blockchain_utils 1.x→6.x 升级恰好要改动它：
+///   * deriveKeyPair 里的 `BigintUtils.orderLen(order)` (6.x 已移除/改名)
+///   * deriveED25519 里 `sha512HashHalves(seed).item1` (6.x 改为 record .$1)
+///   * decodeSeed 返回的 `Tuple` (6.x 改为 record)
+///   * `bytesEqual` / `Secp256k1PrivateKeyEcdsa` 等改名
+///
+/// 这些 golden 值采自升级前(blockchain_utils 1.6.0)，并用 XRPL 官方主种子
+/// 向量交叉验证(snoPBrXtMeMyMHUVTgbuqAfg1SUTb → rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh)，
+/// 确保升级后这些字节逐一不变。任何漂移都会让本测试失败。
+void main() {
+  group('XRPL family-seed derivation (pins pre-upgrade behavior)', () {
+    // ---- secp256k1：覆盖 orderLen / deriveKeyPair / _getSecret ----
+    test('secp256k1 fromSeed (canonical XRPL master seed)', () {
+      const masterSeed = 'snoPBrXtMeMyMHUVTgbuqAfg1SUTb';
+      final pk = XRPPrivateKey.fromSeed(masterSeed);
+      final pub = pk.getPublic();
+
+      expect(pk.algorithm.prefix, 0x00, reason: 'secp256k1 prefix');
+      expect(pk.toHex(),
+          '001ACAAEDECE405B2A958212629E16F2EB46B153EEE94CDD350FDEFF52795525B7');
+      expect(pub.toHex(),
+          '0330E7FC9D56BB25D6893BA3F317AE5BCF33B3291BD63DB32654A313222F7FD020');
+      // XRPL 官方已知向量，交叉验证派生正确性
+      expect(pub.toAddress().toString(), 'rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh');
+    });
+
+    test('secp256k1 fromEntropy (== decoded master seed entropy)', () {
+      const entropyHex = 'DEDCE9CE67B451D852FD4E846FCDE31C';
+      final pk = XRPPrivateKey.fromEntropy(entropyHex,
+          algorithm: XRPKeyAlgorithm.secp256k1);
+
+      expect(pk.toHex(),
+          '001ACAAEDECE405B2A958212629E16F2EB46B153EEE94CDD350FDEFF52795525B7');
+      expect(pk.getPublic().toAddress().toString(),
+          'rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh');
+    });
+
+    // ---- ed25519：覆盖 deriveED25519 的 sha512HashHalves().item1 ----
+    test('ed25519 fromEntropy', () {
+      const entropyHex = '4C3A1D213FBDFB14C056C8B6E6E07A4C';
+      final pk = XRPPrivateKey.fromEntropy(entropyHex,
+          algorithm: XRPKeyAlgorithm.ed25519);
+
+      expect(pk.algorithm.prefix, 0xED, reason: 'ed25519 prefix');
+      expect(pk.toHex(),
+          'ED20737253887BDBECD50DE917352142D4A1E1BDF034EC9AF9EEF5FC228FCB0E0A');
+      expect(pk.getPublic().toAddress().toString(),
+          'rhW2hRNo2sz4HfgYspzrwgeSiMi59HaQ87');
+    });
+
+    // ---- 签名往返：覆盖 secp256k1 sign + 公钥验签(活路径再加一层保险) ----
+    test('secp256k1 sign & verify round-trip', () {
+      final pk = XRPPrivateKey.fromSeed('snoPBrXtMeMyMHUVTgbuqAfg1SUTb');
+      const message = 'deadbeefdeadbeefdeadbeefdeadbeef';
+      final sig = pk.sign(message);
+      expect(sig, isNotEmpty);
+      expect(pk.getPublic().verifySignature(message, sig), isTrue);
+    });
+  });
+}


### PR DESCRIPTION
## 背景

修复 #20：`crypto_wallet_util` 的 `blockchain_utils` 卡在 `^1.4.1`，而上游 `bitcoin_base 7.x` / `xrpl_dart 7.x` 已依赖 `blockchain_utils ^6.0.0`，导致下游无法同时使用。本 PR 将依赖升至 `^6.0.0`。

## ⚠️ BREAKING

- `blockchain_utils` `^1.4.1` → `^6.0.0`
- 最低 Dart SDK `2.17` → `3.7`（6.0.0 硬性要求）
- 包版本 `1.2.6` → `2.0.0`

## 影响面

`blockchain_utils` 仅被两个 vendored fork（`bitcoin_base_hd`、`xrpl_dart`）使用，**项目自有代码 0 处直接依赖**。本 PR 把这两个 fork 迁移到 6.x API：

- 工具类 import 统一走 barrel；`coin_conf` 新路径
- `Tuple` / `.item1,.item2` → Dart records（`$1`,`$2`）
- `mask8/16/32`、`writeUintXLE`、`readUintXLE` → `BinaryOps.*`
- `bytesEqual` → `BytesUtils.bytesEqual`；`iterableIsEqual` → `CompareUtils.iterableIsEqual`
- `Secp256k1{Public,Private}KeyEcdsa` → `Secp256k1{Public,Private}Key`
- `BitcoinSigner`/`BitcoinVerifier` → `BitcoinKeySigner`/`BitcoinSignatureVerifier`
- `BigintUtils.orderLen` → `BigintUtils.bitlengthInBytes`
- `decodeXAddress` 返回类型 → `XRPXAddressDecodeResult`（`.bytes`/`.tag`）
- `BlockchainUtilsException` 新增抽象 `details` getter（已实现）
- `Bech32Validations`/`SegwitValidations` 改 `mixin`（Dart 3 规则）
- `DynamicByteTracker` / `RPCError` 命名冲突用 `hide` 消解

## 验证（回归安全网）

- `dart analyze`：**0 error / 0 warning**
- `dart test`：**782 个用例全绿**
- **ECDSA / Taproot / message 三类签名输出经升级前后逐字节比对，完全一致**，并新增特征测试锁定
- XRP secp256k1 家族种子派生（`orderLen` 路径，升级前 0 覆盖）与 classic↔X-address 转换均用官方向量做特征测试
- 覆盖率审计基线见 `test/forked_lib/MIGRATION_COVERAGE_BASELINE.md`

## CI

- `setup-dart` `3.3.4` → `3.8.0`（否则无法解析 SDK ≥3.7 的包）
- 测试前新增 `dart run wasm_run:setup`（否则 SC/Sia 的 WASM 用例假失败）

## 说明 / 待确认

- 死代码（`bitcoin_base_hd` 的 tx-builder/script/provider 运行时未被调用）本 PR **仅修到可编译**，删除留作后续独立 PR。
- 升到 Dart 3.7 后 `dart format` 会切到新的 "tall" 风格；本 PR 未做仓库级重格式化（属独立的全仓库迁移）。当前 CI 的 `format` 步骤为 `dart format .`（不带 `--set-exit-if-changed`），不会因此失败。

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)