### PR TITLE
chore(crypto_wallet_util): drop redundant pointycastle dependency_override

### DIFF
--- a/packages/crypto_wallet_util/pubspec.yaml
+++ b/packages/crypto_wallet_util/pubspec.yaml
@@ -6,9 +6,6 @@ homepage: https://github.com/fxwalletOfficial/fx-wallet-packages/tree/main/packa
 environment:
   sdk: '>=3.7.0 <4.0.0'
 
-dependency_overrides:
-  pointycastle: ^4.0.0
-
 dependencies:
   bip340: ^0.3.1
   collection: ^1.19.1


### PR DESCRIPTION
## 背景

发布前清理：`crypto_wallet_util/pubspec.yaml` 里的 `dependency_overrides: pointycastle: ^4.0.0` 在 blockchain_utils 升到 6.x 后已经**多余**。

- blockchain_utils 6.0.0 和本包都直接要求 `pointycastle: ^4.0.0`，去掉 override 后解析照样落到 **4.0.0**（已验证）。
- `dependency_overrides` **不会对已发布包的使用方生效**，所以删掉它能让发布包的解析更忠实，并消除 `dart pub publish` 关于"覆盖非 dev 依赖"的 hint。

## 验证

- `dart pub get`：pointycastle 仍解析为 4.0.0
- `dart analyze`：0 error / 0 warning
- `dart test`：782 全绿
- `dart pub publish --dry-run`：override 的 hint 已消失

无行为变化。为发布 2.0.0 做准备。

🤖 Generated with [Claude Code](https://claude.com/claude-code)