### PR TITLE
ci: upgrade actions/checkout to v5 (Node 24)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Setup Dart
       uses: dart-lang/setup-dart@v1


### PR DESCRIPTION
`actions/checkout@v4` runs on Node.js 20 — GitHub force-migrates Node 20 actions to Node 24 on **2026-06-16** and removes Node 20 from runners on 2026-09-16 (the CI run already surfaces this as an annotation). Bumps to `v5` (Node 24).

`dart-lang/setup-dart@v1` and `subosito/flutter-action@v2` are floating major tags and weren't flagged, so they're left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)