### PR TITLE
Clean-room aleo_ffi Group 3: programs/proofs/transactions (31/31, testnet-verified)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,33 @@
+name: Rust (aleo_ffi)
+
+# Builds and unit-tests the clean-room aleo_ffi crate. Path-filtered so it does
+# not run on (and slow down) Dart-only PRs; the snarkVM build is heavy and is
+# cached between runs.
+on:
+  push:
+    branches: [ main, 'epic/**' ]
+    paths: [ 'rust/**', '.github/workflows/rust.yml' ]
+  pull_request:
+    branches: [ main, 'epic/**' ]
+    paths: [ 'rust/**', '.github/workflows/rust.yml' ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      # Installs the toolchain pinned by rust/rust-toolchain.toml.
+      - name: Install Rust toolchain
+        working-directory: rust/aleo_ffi
+        run: rustup show
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: rust/aleo_ffi
+
+      # Offline unit tests only; the recursive-import test is #[ignore]d as it
+      # needs a live node.
+      - name: Test
+        working-directory: rust/aleo_ffi
+        run: cargo test --lib

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -27,7 +27,36 @@ jobs:
           workspaces: rust/aleo_ffi
 
       # Offline unit tests only; the recursive-import test is #[ignore]d as it
-      # needs a live node.
+      # needs a live node. Includes an FFI smoke test that calls the exported
+      # functions (and free_string) through their C signatures.
       - name: Test
         working-directory: rust/aleo_ffi
         run: cargo test --lib
+
+      # Build the actual deliverable — the release cdylib — and verify its
+      # exported C ABI, so a green run means the library Dart loads is buildable
+      # and complete (not just that the rlib test harness compiles).
+      - name: Build release cdylib
+        working-directory: rust/aleo_ffi
+        run: cargo build --release
+
+      - name: Verify exported FFI symbols
+        working-directory: rust/aleo_ffi
+        run: |
+          lib=target/release/libaleo_rust.so
+          test -f "$lib" || { echo "release cdylib not found"; exit 1; }
+          syms=$(nm -D --defined-only "$lib")
+          missing=0
+          for f in numbers_add seed_to_private_key private_key_to_address \
+                   private_key_to_view_key view_key_to_address sign_message verify \
+                   get_token_owner_hash is_owner decrypt_cipher_text \
+                   serial_number_string encrypt_private_key decrypt_to_private_key \
+                   decrypt_sender_ciphertext build_transaction_offline \
+                   execution_authorization execute_proof execution_fee_authorization \
+                   execute_fee_proof get_base_fee broadcast build_transaction \
+                   try_transfer join_authorization try_join execute_program \
+                   execute_program_proof contract_execution contract_fee_execution \
+                   upgrade_authorization build_upgrade_transaction_offline free_string; do
+            echo "$syms" | grep -qw "$f" || { echo "MISSING SYMBOL: $f"; missing=1; }
+          done
+          test "$missing" -eq 0 && echo "all 31 FFI functions + free_string exported"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,15 +1,16 @@
 name: Rust (aleo_ffi)
 
-# Builds and unit-tests the clean-room aleo_ffi crate. Path-filtered so it does
-# not run on (and slow down) Dart-only PRs; the snarkVM build is heavy and is
-# cached between runs.
+# Builds and unit-tests the clean-room aleo_ffi crate, then runs the Dart
+# wrapper's FFI-backed tests against the built cdylib. Path-filtered to the
+# crate and its Dart wrapper so it does not run on (and slow down) unrelated
+# Dart-only PRs; the snarkVM build is heavy and is cached between runs.
 on:
   push:
     branches: [ main, 'epic/**' ]
-    paths: [ 'rust/**', '.github/workflows/rust.yml' ]
+    paths: [ 'rust/**', 'packages/aleo_dart/**', '.github/workflows/rust.yml' ]
   pull_request:
     branches: [ main, 'epic/**' ]
-    paths: [ 'rust/**', '.github/workflows/rust.yml' ]
+    paths: [ 'rust/**', 'packages/aleo_dart/**', '.github/workflows/rust.yml' ]
 
 jobs:
   test:
@@ -60,3 +61,19 @@ jobs:
             echo "$syms" | grep -qw "$f" || { echo "MISSING SYMBOL: $f"; missing=1; }
           done
           test "$missing" -eq 0 && echo "all 31 FFI functions + free_string exported"
+
+      # Run the Dart wrapper's FFI-backed tests against the cdylib built above,
+      # so Dart/Rust signature mismatches, string-ownership bugs and wrapper
+      # regressions fail CI instead of being skipped for want of a library.
+      - name: Setup Dart
+        uses: dart-lang/setup-dart@v1
+        with:
+          sdk: '3.8.0'
+
+      - name: Dart FFI integration tests
+        working-directory: packages/aleo_dart
+        env:
+          ALEO_NEW_LIB: ${{ github.workspace }}/rust/aleo_ffi/target/release/libaleo_rust.so
+        run: |
+          dart pub get
+          dart test

--- a/packages/aleo_dart/lib/src/aleo_account.dart
+++ b/packages/aleo_dart/lib/src/aleo_account.dart
@@ -12,11 +12,8 @@ const ALEO_PATH = "m/44/0/0/0";
 
 class AleoAccount {
   late AccountRustFFI accountRustFFI;
-  // Long-lived: the network pointer is held for the object's lifetime and
-  // passed to every call, so it is not freed per-call.
-  AleoAccount(dyLib, [network_raw = 'testnet']) {
-    final network = dartStrToC(network_raw);
-    this.accountRustFFI = AccountRustFFI(dyLib, network);
+  AleoAccount(dyLib, [String network_raw = 'testnet']) {
+    this.accountRustFFI = AccountRustFFI(dyLib, network_raw);
   }
 
   int testRustFFi(int a, int b) {

--- a/packages/aleo_dart/lib/src/aleo_account.dart
+++ b/packages/aleo_dart/lib/src/aleo_account.dart
@@ -27,10 +27,12 @@ class AleoAccount {
 
   String seedToPrivateKey(Uint8List seedRaw) {
     final seed = dartListToC(seedRaw);
-    final result = accountRustFFI.seedToPrivateKey(seed);
-    final privateKey = takeNativeString(accountRustFFI.dyLib, result);
-    calloc.free(seed);
-    return privateKey;
+    try {
+      final result = accountRustFFI.seedToPrivateKey(seed);
+      return takeNativeString(accountRustFFI.dyLib, result);
+    } finally {
+      calloc.free(seed);
+    }
   }
 
   String mnemonicToPrivateKey(String mnemonic) {
@@ -41,10 +43,12 @@ class AleoAccount {
   String privateKeyToAddress(String privateKeyRaw) {
     AleoUtils.checkPrivateKey(privateKeyRaw);
     final privateKey = dartStrToC(privateKeyRaw);
-    final result = accountRustFFI.privateKeyToAddress(privateKey);
-    final address = takeNativeString(accountRustFFI.dyLib, result);
-    malloc.free(privateKey);
-    return address;
+    try {
+      final result = accountRustFFI.privateKeyToAddress(privateKey);
+      return takeNativeString(accountRustFFI.dyLib, result);
+    } finally {
+      malloc.free(privateKey);
+    }
   }
 
   String mnemonicToAddress(String mnemonic) {
@@ -56,39 +60,42 @@ class AleoAccount {
   String privateKeyToViewKey(String privateKeyRaw) {
     AleoUtils.checkPrivateKey(privateKeyRaw);
     final privateKey = dartStrToC(privateKeyRaw);
-    final result = accountRustFFI.privateKeyToViewKey(privateKey);
-    final viewKey = takeNativeString(accountRustFFI.dyLib, result);
-    malloc.free(privateKey);
-    return viewKey;
+    try {
+      final result = accountRustFFI.privateKeyToViewKey(privateKey);
+      return takeNativeString(accountRustFFI.dyLib, result);
+    } finally {
+      malloc.free(privateKey);
+    }
   }
 
   String mnemonicToViewKey(String mnemonic) {
     final seed = mnemonicToSeed(mnemonic);
     final privateKeyRaw = seedToPrivateKey(seed);
-    final privateKey = dartStrToC(privateKeyRaw);
-    final result = accountRustFFI.privateKeyToViewKey(privateKey);
-    final viewKey = takeNativeString(accountRustFFI.dyLib, result);
-    malloc.free(privateKey);
-    return viewKey;
+    return privateKeyToViewKey(privateKeyRaw);
   }
 
   String viewKeyToAddress(String viewKeyRaw) {
     AleoUtils.checkViewKey(viewKeyRaw);
     final viewKey = dartStrToC(viewKeyRaw);
-    final result = accountRustFFI.viewKeyToAddress(viewKey);
-    final address = takeNativeString(accountRustFFI.dyLib, result);
-    malloc.free(viewKey);
-    return address;
+    try {
+      final result = accountRustFFI.viewKeyToAddress(viewKey);
+      return takeNativeString(accountRustFFI.dyLib, result);
+    } finally {
+      malloc.free(viewKey);
+    }
   }
 
   String sign(String privateKeyRaw, Uint8List messageRaw) {
     final privateKey = dartStrToC(privateKeyRaw);
     final message = dartListToC(messageRaw);
-    final result = accountRustFFI.sign(privateKey, message, messageRaw.length);
-    final signature = takeNativeString(accountRustFFI.dyLib, result);
-    malloc.free(privateKey);
-    calloc.free(message);
-    return signature;
+    try {
+      final result =
+          accountRustFFI.sign(privateKey, message, messageRaw.length);
+      return takeNativeString(accountRustFFI.dyLib, result);
+    } finally {
+      malloc.free(privateKey);
+      calloc.free(message);
+    }
   }
 
   bool isValidSignature(
@@ -96,21 +103,25 @@ class AleoAccount {
     final address = dartStrToC(addressRaw);
     final signature = dartStrToC(signatureRaw);
     final message = dartListToC(messageRaw);
-    final valid = accountRustFFI.isValidSignature(
-        address, signature, message, messageRaw.length);
-    malloc.free(address);
-    malloc.free(signature);
-    calloc.free(message);
-    return valid;
+    try {
+      return accountRustFFI.isValidSignature(
+          address, signature, message, messageRaw.length);
+    } finally {
+      malloc.free(address);
+      malloc.free(signature);
+      calloc.free(message);
+    }
   }
 
   String getTokenOwnerHash(String addressRaw, String tokenIdRaw) {
     final address = dartStrToC(addressRaw);
     final tokenId = dartStrToC(tokenIdRaw);
-    final result = accountRustFFI.getTokenOwnerHash(address, tokenId);
-    final tokenOwnerHash = takeNativeString(accountRustFFI.dyLib, result);
-    malloc.free(address);
-    malloc.free(tokenId);
-    return tokenOwnerHash;
+    try {
+      final result = accountRustFFI.getTokenOwnerHash(address, tokenId);
+      return takeNativeString(accountRustFFI.dyLib, result);
+    } finally {
+      malloc.free(address);
+      malloc.free(tokenId);
+    }
   }
 }

--- a/packages/aleo_dart/lib/src/aleo_account.dart
+++ b/packages/aleo_dart/lib/src/aleo_account.dart
@@ -1,6 +1,7 @@
 import 'dart:typed_data';
 
 import 'package:bip39/bip39.dart' as bip39;
+import 'package:ffi/ffi.dart';
 
 import 'package:aleo_dart/src/rust_lib/account_rust_ffi.dart';
 import 'package:aleo_dart/src/aleo_hd_key.dart';
@@ -11,6 +12,8 @@ const ALEO_PATH = "m/44/0/0/0";
 
 class AleoAccount {
   late AccountRustFFI accountRustFFI;
+  // Long-lived: the network pointer is held for the object's lifetime and
+  // passed to every call, so it is not freed per-call.
   AleoAccount(dyLib, [network_raw = 'testnet']) {
     final network = dartStrToC(network_raw);
     this.accountRustFFI = AccountRustFFI(dyLib, network);
@@ -27,8 +30,10 @@ class AleoAccount {
 
   String seedToPrivateKey(Uint8List seedRaw) {
     final seed = dartListToC(seedRaw);
-    final privateKey = accountRustFFI.seedToPrivateKey(seed);
-    return cStrToDart(privateKey);
+    final result = accountRustFFI.seedToPrivateKey(seed);
+    final privateKey = takeNativeString(accountRustFFI.dyLib, result);
+    calloc.free(seed);
+    return privateKey;
   }
 
   String mnemonicToPrivateKey(String mnemonic) {
@@ -39,8 +44,10 @@ class AleoAccount {
   String privateKeyToAddress(String privateKeyRaw) {
     AleoUtils.checkPrivateKey(privateKeyRaw);
     final privateKey = dartStrToC(privateKeyRaw);
-    final address = accountRustFFI.privateKeyToAddress(privateKey);
-    return cStrToDart(address);
+    final result = accountRustFFI.privateKeyToAddress(privateKey);
+    final address = takeNativeString(accountRustFFI.dyLib, result);
+    malloc.free(privateKey);
+    return address;
   }
 
   String mnemonicToAddress(String mnemonic) {
@@ -52,31 +59,39 @@ class AleoAccount {
   String privateKeyToViewKey(String privateKeyRaw) {
     AleoUtils.checkPrivateKey(privateKeyRaw);
     final privateKey = dartStrToC(privateKeyRaw);
-    final viewKey = accountRustFFI.privateKeyToViewKey(privateKey);
-    return cStrToDart(viewKey);
+    final result = accountRustFFI.privateKeyToViewKey(privateKey);
+    final viewKey = takeNativeString(accountRustFFI.dyLib, result);
+    malloc.free(privateKey);
+    return viewKey;
   }
 
   String mnemonicToViewKey(String mnemonic) {
     final seed = mnemonicToSeed(mnemonic);
     final privateKeyRaw = seedToPrivateKey(seed);
     final privateKey = dartStrToC(privateKeyRaw);
-    final viewKey = accountRustFFI.privateKeyToViewKey(privateKey);
-    return cStrToDart(viewKey);
+    final result = accountRustFFI.privateKeyToViewKey(privateKey);
+    final viewKey = takeNativeString(accountRustFFI.dyLib, result);
+    malloc.free(privateKey);
+    return viewKey;
   }
 
   String viewKeyToAddress(String viewKeyRaw) {
     AleoUtils.checkViewKey(viewKeyRaw);
     final viewKey = dartStrToC(viewKeyRaw);
-    final address = accountRustFFI.viewKeyToAddress(viewKey);
-    return cStrToDart(address);
+    final result = accountRustFFI.viewKeyToAddress(viewKey);
+    final address = takeNativeString(accountRustFFI.dyLib, result);
+    malloc.free(viewKey);
+    return address;
   }
 
   String sign(String privateKeyRaw, Uint8List messageRaw) {
     final privateKey = dartStrToC(privateKeyRaw);
     final message = dartListToC(messageRaw);
-    final signature =
-        accountRustFFI.sign(privateKey, message, messageRaw.length);
-    return cStrToDart(signature);
+    final result = accountRustFFI.sign(privateKey, message, messageRaw.length);
+    final signature = takeNativeString(accountRustFFI.dyLib, result);
+    malloc.free(privateKey);
+    calloc.free(message);
+    return signature;
   }
 
   bool isValidSignature(
@@ -84,14 +99,21 @@ class AleoAccount {
     final address = dartStrToC(addressRaw);
     final signature = dartStrToC(signatureRaw);
     final message = dartListToC(messageRaw);
-    return accountRustFFI.isValidSignature(
+    final valid = accountRustFFI.isValidSignature(
         address, signature, message, messageRaw.length);
+    malloc.free(address);
+    malloc.free(signature);
+    calloc.free(message);
+    return valid;
   }
 
   String getTokenOwnerHash(String addressRaw, String tokenIdRaw) {
     final address = dartStrToC(addressRaw);
     final tokenId = dartStrToC(tokenIdRaw);
-    final tokenOwnerHash = accountRustFFI.getTokenOwnerHash(address, tokenId);
-    return cStrToDart(tokenOwnerHash);
+    final result = accountRustFFI.getTokenOwnerHash(address, tokenId);
+    final tokenOwnerHash = takeNativeString(accountRustFFI.dyLib, result);
+    malloc.free(address);
+    malloc.free(tokenId);
+    return tokenOwnerHash;
   }
 }

--- a/packages/aleo_dart/lib/src/aleo_programs.dart
+++ b/packages/aleo_dart/lib/src/aleo_programs.dart
@@ -9,11 +9,8 @@ import 'package:aleo_dart/src/rust_lib/utils.dart';
 class AleoProgram {
   late ProgramsRustFFI programsRustFFI;
 
-  // Long-lived: the network pointer is held for the object's lifetime and
-  // passed to every call, so it is not freed per-call.
-  AleoProgram(dyLib, [network_raw = 'testnet']) {
-    final network = dartStrToC(network_raw);
-    this.programsRustFFI = ProgramsRustFFI(dyLib, network);
+  AleoProgram(dyLib, [String network_raw = 'testnet']) {
+    this.programsRustFFI = ProgramsRustFFI(dyLib, network_raw);
   }
 
   Future<String> tryTransfer(

--- a/packages/aleo_dart/lib/src/aleo_programs.dart
+++ b/packages/aleo_dart/lib/src/aleo_programs.dart
@@ -5,6 +5,7 @@ import 'package:path/path.dart' as path;
 
 import 'package:aleo_dart/src/rust_lib/programs_rust_ffi.dart';
 import 'package:aleo_dart/src/rust_lib/utils.dart';
+import 'package:aleo_dart/src/aleo_utils.dart';
 
 class AleoProgram {
   late ProgramsRustFFI programsRustFFI;
@@ -23,6 +24,8 @@ class AleoProgram {
     String amount_record_raw,
     String fee_record_raw,
   ) async {
+    AleoUtils.checkAmount(amount_credits, 'amount');
+    AleoUtils.checkAmount(fee_credits, 'fee');
     final private_key = dartStrToC(private_key_raw);
     final transfer_type = dartStrToC(transfer_type_raw);
     final recipient = dartStrToC(recipient_raw);
@@ -60,6 +63,7 @@ class AleoProgram {
     String fee_record_raw,
     String url_raw,
   ) async {
+    AleoUtils.checkAmount(fee_credits, 'fee');
     final private_key = dartStrToC(private_key_raw);
     final record_1 = dartStrToC(record_1_raw);
     final record_2 = dartStrToC(record_2_raw);
@@ -120,6 +124,8 @@ class AleoProgram {
     String amount_record_raw,
     String fee_record_raw,
   ) async {
+    AleoUtils.checkAmount(amount_credits, 'amount');
+    AleoUtils.checkAmount(fee_credits, 'fee');
     final private_key = dartStrToC(private_key_raw);
     final transfer_type = dartStrToC(transfer_type_raw);
     final recipient = dartStrToC(recipient_raw);
@@ -174,6 +180,7 @@ class AleoProgram {
     String url_raw,
     String amount_record_raw,
   ) async {
+    AleoUtils.checkAmount(amount_credits, 'amount');
     final private_key = dartStrToC(private_key_raw);
     final transfer_type = dartStrToC(transfer_type_raw);
     final recipient = dartStrToC(recipient_raw);
@@ -195,6 +202,7 @@ class AleoProgram {
       String url_raw,
       String fee_record_raw,
       String execution_raw) async {
+    AleoUtils.checkAmount(fee_credits, 'fee');
     final private_key = dartStrToC(private_key_raw);
     final transfer_type = dartStrToC(transfer_type_raw);
     final url = dartStrToC(url_raw);
@@ -340,6 +348,7 @@ class AleoProgram {
     int fee,
     String url_raw,
   ) async {
+    AleoUtils.checkAmount(fee, 'fee');
     final private_key = dartStrToC(private_key_raw);
     final program_id = dartStrToC(program_id_raw);
     final function_name = dartStrToC(function_name_raw);
@@ -361,6 +370,7 @@ class AleoProgram {
     String program_id_raw,
     String url_raw,
   ) async {
+    AleoUtils.checkAmount(fee, 'fee');
     final private_key = dartStrToC(private_key_raw);
     final execution = dartStrToC(execution_raw);
     final program_id = dartStrToC(program_id_raw);

--- a/packages/aleo_dart/lib/src/aleo_programs.dart
+++ b/packages/aleo_dart/lib/src/aleo_programs.dart
@@ -29,25 +29,27 @@ class AleoProgram {
     final url = dartStrToC(url_raw);
     final amount_record = dartStrToC(amount_record_raw);
     final fee_record = dartStrToC(fee_record_raw);
-    final result = await programsRustFFI.transfer(
+    try {
+      final result = await programsRustFFI.transfer(
+          private_key,
+          recipient,
+          transfer_type,
+          amount_credits,
+          fee_credits,
+          url,
+          amount_record,
+          fee_record);
+      return takeNativeString(programsRustFFI.dyLib, result);
+    } finally {
+      freeAll([
         private_key,
-        recipient,
         transfer_type,
-        amount_credits,
-        fee_credits,
+        recipient,
         url,
         amount_record,
-        fee_record);
-    final out = takeNativeString(programsRustFFI.dyLib, result);
-    freeAll([
-      private_key,
-      transfer_type,
-      recipient,
-      url,
-      amount_record,
-      fee_record
-    ]);
-    return out;
+        fee_record
+      ]);
+    }
   }
 
   Future<String> tryJoin(
@@ -63,11 +65,13 @@ class AleoProgram {
     final record_2 = dartStrToC(record_2_raw);
     final fee_record = dartStrToC(fee_record_raw);
     final url = dartStrToC(url_raw);
-    final result = await programsRustFFI.join(
-        private_key, record_1, record_2, fee_credits, fee_record, url);
-    final out = takeNativeString(programsRustFFI.dyLib, result);
-    freeAll([private_key, record_1, record_2, fee_record, url]);
-    return out;
+    try {
+      final result = await programsRustFFI.join(
+          private_key, record_1, record_2, fee_credits, fee_record, url);
+      return takeNativeString(programsRustFFI.dyLib, result);
+    } finally {
+      freeAll([private_key, record_1, record_2, fee_record, url]);
+    }
   }
 
   Future<String> joinAuthorization(
@@ -80,11 +84,13 @@ class AleoProgram {
     final record_1 = dartStrToC(record_1_raw);
     final record_2 = dartStrToC(record_2_raw);
     final url = dartStrToC(url_raw);
-    final result = await programsRustFFI.joinAuthorization(
-        private_key, record_1, record_2, url);
-    final out = takeNativeString(programsRustFFI.dyLib, result);
-    freeAll([private_key, record_1, record_2, url]);
-    return out;
+    try {
+      final result = await programsRustFFI.joinAuthorization(
+          private_key, record_1, record_2, url);
+      return takeNativeString(programsRustFFI.dyLib, result);
+    } finally {
+      freeAll([private_key, record_1, record_2, url]);
+    }
   }
 
   Future<String> upgradeAuthorization(
@@ -95,11 +101,13 @@ class AleoProgram {
     final private_key = dartStrToC(private_key_raw);
     final record = dartStrToC(record_raw);
     final url = dartStrToC(url_raw);
-    final result =
-        await programsRustFFI.upgradeAuthorization(private_key, record, url);
-    final out = takeNativeString(programsRustFFI.dyLib, result);
-    freeAll([private_key, record, url]);
-    return out;
+    try {
+      final result =
+          await programsRustFFI.upgradeAuthorization(private_key, record, url);
+      return takeNativeString(programsRustFFI.dyLib, result);
+    } finally {
+      freeAll([private_key, record, url]);
+    }
   }
 
   Future<String> buildTransaction(
@@ -118,26 +126,27 @@ class AleoProgram {
     final url = dartStrToC(url_raw);
     final amount_record = dartStrToC(amount_record_raw);
     final fee_record = dartStrToC(fee_record_raw);
-
-    final result = await programsRustFFI.buildTransaction(
+    try {
+      final result = await programsRustFFI.buildTransaction(
+          private_key,
+          recipient,
+          transfer_type,
+          amount_credits,
+          fee_credits,
+          url,
+          amount_record,
+          fee_record);
+      return takeNativeString(programsRustFFI.dyLib, result);
+    } finally {
+      freeAll([
         private_key,
-        recipient,
         transfer_type,
-        amount_credits,
-        fee_credits,
+        recipient,
         url,
         amount_record,
-        fee_record);
-    final out = takeNativeString(programsRustFFI.dyLib, result);
-    freeAll([
-      private_key,
-      transfer_type,
-      recipient,
-      url,
-      amount_record,
-      fee_record
-    ]);
-    return out;
+        fee_record
+      ]);
+    }
   }
 
   Future<String> broadcast(
@@ -148,12 +157,13 @@ class AleoProgram {
     final transaction = dartStrToC(transaction_raw);
     final url = dartStrToC(url_raw);
     final transfer_type = dartStrToC(transfer_type_raw);
-
-    final result =
-        await programsRustFFI.broadcast(transaction, url, transfer_type);
-    final out = takeNativeString(programsRustFFI.dyLib, result);
-    freeAll([transaction, url, transfer_type]);
-    return out;
+    try {
+      final result =
+          await programsRustFFI.broadcast(transaction, url, transfer_type);
+      return takeNativeString(programsRustFFI.dyLib, result);
+    } finally {
+      freeAll([transaction, url, transfer_type]);
+    }
   }
 
   Future<String> executionAuthorization(
@@ -169,12 +179,13 @@ class AleoProgram {
     final recipient = dartStrToC(recipient_raw);
     final url = dartStrToC(url_raw);
     final amount_record = dartStrToC(amount_record_raw);
-
-    final result = await programsRustFFI.executionAuthorization(private_key,
-        recipient, transfer_type, amount_credits, url, amount_record);
-    final out = takeNativeString(programsRustFFI.dyLib, result);
-    freeAll([private_key, transfer_type, recipient, url, amount_record]);
-    return out;
+    try {
+      final result = await programsRustFFI.executionAuthorization(private_key,
+          recipient, transfer_type, amount_credits, url, amount_record);
+      return takeNativeString(programsRustFFI.dyLib, result);
+    } finally {
+      freeAll([private_key, transfer_type, recipient, url, amount_record]);
+    }
   }
 
   Future<String> executionFeeAuthorization(
@@ -189,21 +200,24 @@ class AleoProgram {
     final url = dartStrToC(url_raw);
     final fee_record = dartStrToC(fee_record_raw);
     final execution = dartStrToC(execution_raw);
-
-    final result = await programsRustFFI.executionFeeAuthorization(
-        private_key, transfer_type, fee_credits, url, fee_record, execution);
-    final out = takeNativeString(programsRustFFI.dyLib, result);
-    freeAll([private_key, transfer_type, url, fee_record, execution]);
-    return out;
+    try {
+      final result = await programsRustFFI.executionFeeAuthorization(
+          private_key, transfer_type, fee_credits, url, fee_record, execution);
+      return takeNativeString(programsRustFFI.dyLib, result);
+    } finally {
+      freeAll([private_key, transfer_type, url, fee_record, execution]);
+    }
   }
 
   Future<String> executeProof(String url_raw, String authorization_raw) async {
     final url = dartStrToC(url_raw);
     final authorization = dartStrToC(authorization_raw);
-    final result = await programsRustFFI.executeProof(url, authorization);
-    final out = takeNativeString(programsRustFFI.dyLib, result);
-    freeAll([url, authorization]);
-    return out;
+    try {
+      final result = await programsRustFFI.executeProof(url, authorization);
+      return takeNativeString(programsRustFFI.dyLib, result);
+    } finally {
+      freeAll([url, authorization]);
+    }
   }
 
   Future<String> executeProgramProof(String url_raw, String authorization_raw,
@@ -211,11 +225,13 @@ class AleoProgram {
     final url = dartStrToC(url_raw);
     final authorization = dartStrToC(authorization_raw);
     final program_id = dartStrToC(program_id_raw);
-    final result = await programsRustFFI.executeProgramProof(
-        url, authorization, program_id);
-    final out = takeNativeString(programsRustFFI.dyLib, result);
-    freeAll([url, authorization, program_id]);
-    return out;
+    try {
+      final result = await programsRustFFI.executeProgramProof(
+          url, authorization, program_id);
+      return takeNativeString(programsRustFFI.dyLib, result);
+    } finally {
+      freeAll([url, authorization, program_id]);
+    }
   }
 
   Future<String> executeFeeProof(
@@ -224,10 +240,12 @@ class AleoProgram {
   ) async {
     final url = dartStrToC(url_raw);
     final authorization = dartStrToC(authorization_raw);
-    final result = await programsRustFFI.executeFeeProof(url, authorization);
-    final out = takeNativeString(programsRustFFI.dyLib, result);
-    freeAll([url, authorization]);
-    return out;
+    try {
+      final result = await programsRustFFI.executeFeeProof(url, authorization);
+      return takeNativeString(programsRustFFI.dyLib, result);
+    } finally {
+      freeAll([url, authorization]);
+    }
   }
 
   Future<String> buildTransactionOffline(
@@ -236,22 +254,26 @@ class AleoProgram {
   ) async {
     final execution = dartStrToC(execution_raw);
     final fee = dartStrToC(fee_raw);
-    final result =
-        await programsRustFFI.buildTransactionOffline(execution, fee);
-    final out = takeNativeString(programsRustFFI.dyLib, result);
-    freeAll([execution, fee]);
-    return out;
+    try {
+      final result =
+          await programsRustFFI.buildTransactionOffline(execution, fee);
+      return takeNativeString(programsRustFFI.dyLib, result);
+    } finally {
+      freeAll([execution, fee]);
+    }
   }
 
   Future<String> buildUpgradeTransactionOffline(
     String execution_raw,
   ) async {
     final execution = dartStrToC(execution_raw);
-    final result =
-        await programsRustFFI.buildUpgradeTransactionOffline(execution);
-    final out = takeNativeString(programsRustFFI.dyLib, result);
-    freeAll([execution]);
-    return out;
+    try {
+      final result =
+          await programsRustFFI.buildUpgradeTransactionOffline(execution);
+      return takeNativeString(programsRustFFI.dyLib, result);
+    } finally {
+      freeAll([execution]);
+    }
   }
 
   Future<int> getBaseFee(
@@ -260,9 +282,11 @@ class AleoProgram {
   ) async {
     final execution = dartStrToC(execution_raw);
     final url = dartStrToC(url_raw);
-    final result = await programsRustFFI.getBaseFee(url, execution);
-    freeAll([execution, url]);
-    return result;
+    try {
+      return await programsRustFFI.getBaseFee(url, execution);
+    } finally {
+      freeAll([execution, url]);
+    }
   }
 
   Future<void> downloadProvingKey({updateKey = false}) async {
@@ -299,11 +323,13 @@ class AleoProgram {
     final function_name = dartStrToC(function_name_raw);
     final arguments = dartStrToC(arguments_raw);
     final url = dartStrToC(url_raw);
-    final result = await programsRustFFI.contractExecution(
-        private_key, program_id, function_name, arguments, url);
-    final out = takeNativeString(programsRustFFI.dyLib, result);
-    freeAll([private_key, program_id, function_name, arguments, url]);
-    return out;
+    try {
+      final result = await programsRustFFI.contractExecution(
+          private_key, program_id, function_name, arguments, url);
+      return takeNativeString(programsRustFFI.dyLib, result);
+    } finally {
+      freeAll([private_key, program_id, function_name, arguments, url]);
+    }
   }
 
   Future<String> executeProgram(
@@ -319,11 +345,13 @@ class AleoProgram {
     final function_name = dartStrToC(function_name_raw);
     final arguments = dartStrToC(arguments_raw);
     final url = dartStrToC(url_raw);
-    final result = await programsRustFFI.executeProgram(
-        private_key, program_id, function_name, arguments, fee, url);
-    final out = takeNativeString(programsRustFFI.dyLib, result);
-    freeAll([private_key, program_id, function_name, arguments, url]);
-    return out;
+    try {
+      final result = await programsRustFFI.executeProgram(
+          private_key, program_id, function_name, arguments, fee, url);
+      return takeNativeString(programsRustFFI.dyLib, result);
+    } finally {
+      freeAll([private_key, program_id, function_name, arguments, url]);
+    }
   }
 
   Future<String> contractFeeExecution(
@@ -337,11 +365,13 @@ class AleoProgram {
     final execution = dartStrToC(execution_raw);
     final program_id = dartStrToC(program_id_raw);
     final url = dartStrToC(url_raw);
-    final result = await programsRustFFI.contractFeeExecution(
-        private_key, fee, execution, program_id, url);
-    final out = takeNativeString(programsRustFFI.dyLib, result);
-    freeAll([private_key, execution, program_id, url]);
-    return out;
+    try {
+      final result = await programsRustFFI.contractFeeExecution(
+          private_key, fee, execution, program_id, url);
+      return takeNativeString(programsRustFFI.dyLib, result);
+    } finally {
+      freeAll([private_key, execution, program_id, url]);
+    }
   }
 
   String modifyAuthorization(

--- a/packages/aleo_dart/lib/src/aleo_programs.dart
+++ b/packages/aleo_dart/lib/src/aleo_programs.dart
@@ -1,7 +1,6 @@
 import 'dart:io';
 import 'dart:convert';
 
-import 'package:ffi/ffi.dart';
 import 'package:path/path.dart' as path;
 
 import 'package:aleo_dart/src/rust_lib/programs_rust_ffi.dart';
@@ -10,6 +9,8 @@ import 'package:aleo_dart/src/rust_lib/utils.dart';
 class AleoProgram {
   late ProgramsRustFFI programsRustFFI;
 
+  // Long-lived: the network pointer is held for the object's lifetime and
+  // passed to every call, so it is not freed per-call.
   AleoProgram(dyLib, [network_raw = 'testnet']) {
     final network = dartStrToC(network_raw);
     this.programsRustFFI = ProgramsRustFFI(dyLib, network);
@@ -40,7 +41,16 @@ class AleoProgram {
         url,
         amount_record,
         fee_record);
-    return result.toDartString();
+    final out = takeNativeString(programsRustFFI.dyLib, result);
+    freeAll([
+      private_key,
+      transfer_type,
+      recipient,
+      url,
+      amount_record,
+      fee_record
+    ]);
+    return out;
   }
 
   Future<String> tryJoin(
@@ -58,7 +68,9 @@ class AleoProgram {
     final url = dartStrToC(url_raw);
     final result = await programsRustFFI.join(
         private_key, record_1, record_2, fee_credits, fee_record, url);
-    return result.toDartString();
+    final out = takeNativeString(programsRustFFI.dyLib, result);
+    freeAll([private_key, record_1, record_2, fee_record, url]);
+    return out;
   }
 
   Future<String> joinAuthorization(
@@ -73,7 +85,9 @@ class AleoProgram {
     final url = dartStrToC(url_raw);
     final result = await programsRustFFI.joinAuthorization(
         private_key, record_1, record_2, url);
-    return result.toDartString();
+    final out = takeNativeString(programsRustFFI.dyLib, result);
+    freeAll([private_key, record_1, record_2, url]);
+    return out;
   }
 
   Future<String> upgradeAuthorization(
@@ -86,7 +100,9 @@ class AleoProgram {
     final url = dartStrToC(url_raw);
     final result =
         await programsRustFFI.upgradeAuthorization(private_key, record, url);
-    return result.toDartString();
+    final out = takeNativeString(programsRustFFI.dyLib, result);
+    freeAll([private_key, record, url]);
+    return out;
   }
 
   Future<String> buildTransaction(
@@ -115,7 +131,16 @@ class AleoProgram {
         url,
         amount_record,
         fee_record);
-    return result.toDartString();
+    final out = takeNativeString(programsRustFFI.dyLib, result);
+    freeAll([
+      private_key,
+      transfer_type,
+      recipient,
+      url,
+      amount_record,
+      fee_record
+    ]);
+    return out;
   }
 
   Future<String> broadcast(
@@ -129,7 +154,9 @@ class AleoProgram {
 
     final result =
         await programsRustFFI.broadcast(transaction, url, transfer_type);
-    return result.toDartString();
+    final out = takeNativeString(programsRustFFI.dyLib, result);
+    freeAll([transaction, url, transfer_type]);
+    return out;
   }
 
   Future<String> executionAuthorization(
@@ -148,7 +175,9 @@ class AleoProgram {
 
     final result = await programsRustFFI.executionAuthorization(private_key,
         recipient, transfer_type, amount_credits, url, amount_record);
-    return result.toDartString();
+    final out = takeNativeString(programsRustFFI.dyLib, result);
+    freeAll([private_key, transfer_type, recipient, url, amount_record]);
+    return out;
   }
 
   Future<String> executionFeeAuthorization(
@@ -166,14 +195,18 @@ class AleoProgram {
 
     final result = await programsRustFFI.executionFeeAuthorization(
         private_key, transfer_type, fee_credits, url, fee_record, execution);
-    return result.toDartString();
+    final out = takeNativeString(programsRustFFI.dyLib, result);
+    freeAll([private_key, transfer_type, url, fee_record, execution]);
+    return out;
   }
 
   Future<String> executeProof(String url_raw, String authorization_raw) async {
     final url = dartStrToC(url_raw);
     final authorization = dartStrToC(authorization_raw);
     final result = await programsRustFFI.executeProof(url, authorization);
-    return result.toDartString();
+    final out = takeNativeString(programsRustFFI.dyLib, result);
+    freeAll([url, authorization]);
+    return out;
   }
 
   Future<String> executeProgramProof(String url_raw, String authorization_raw,
@@ -183,7 +216,9 @@ class AleoProgram {
     final program_id = dartStrToC(program_id_raw);
     final result = await programsRustFFI.executeProgramProof(
         url, authorization, program_id);
-    return result.toDartString();
+    final out = takeNativeString(programsRustFFI.dyLib, result);
+    freeAll([url, authorization, program_id]);
+    return out;
   }
 
   Future<String> executeFeeProof(
@@ -193,7 +228,9 @@ class AleoProgram {
     final url = dartStrToC(url_raw);
     final authorization = dartStrToC(authorization_raw);
     final result = await programsRustFFI.executeFeeProof(url, authorization);
-    return result.toDartString();
+    final out = takeNativeString(programsRustFFI.dyLib, result);
+    freeAll([url, authorization]);
+    return out;
   }
 
   Future<String> buildTransactionOffline(
@@ -204,15 +241,20 @@ class AleoProgram {
     final fee = dartStrToC(fee_raw);
     final result =
         await programsRustFFI.buildTransactionOffline(execution, fee);
-    return result.toDartString();
+    final out = takeNativeString(programsRustFFI.dyLib, result);
+    freeAll([execution, fee]);
+    return out;
   }
 
   Future<String> buildUpgradeTransactionOffline(
     String execution_raw,
   ) async {
     final execution = dartStrToC(execution_raw);
-    final result = await programsRustFFI.buildUpgradeTransactionOffline(execution);
-    return result.toDartString();
+    final result =
+        await programsRustFFI.buildUpgradeTransactionOffline(execution);
+    final out = takeNativeString(programsRustFFI.dyLib, result);
+    freeAll([execution]);
+    return out;
   }
 
   Future<int> getBaseFee(
@@ -222,6 +264,7 @@ class AleoProgram {
     final execution = dartStrToC(execution_raw);
     final url = dartStrToC(url_raw);
     final result = await programsRustFFI.getBaseFee(url, execution);
+    freeAll([execution, url]);
     return result;
   }
 
@@ -261,7 +304,9 @@ class AleoProgram {
     final url = dartStrToC(url_raw);
     final result = await programsRustFFI.contractExecution(
         private_key, program_id, function_name, arguments, url);
-    return result.toDartString();
+    final out = takeNativeString(programsRustFFI.dyLib, result);
+    freeAll([private_key, program_id, function_name, arguments, url]);
+    return out;
   }
 
   Future<String> executeProgram(
@@ -279,7 +324,9 @@ class AleoProgram {
     final url = dartStrToC(url_raw);
     final result = await programsRustFFI.executeProgram(
         private_key, program_id, function_name, arguments, fee, url);
-    return result.toDartString();
+    final out = takeNativeString(programsRustFFI.dyLib, result);
+    freeAll([private_key, program_id, function_name, arguments, url]);
+    return out;
   }
 
   Future<String> contractFeeExecution(
@@ -295,7 +342,9 @@ class AleoProgram {
     final url = dartStrToC(url_raw);
     final result = await programsRustFFI.contractFeeExecution(
         private_key, fee, execution, program_id, url);
-    return result.toDartString();
+    final out = takeNativeString(programsRustFFI.dyLib, result);
+    freeAll([private_key, execution, program_id, url]);
+    return out;
   }
 
   String modifyAuthorization(

--- a/packages/aleo_dart/lib/src/aleo_record.dart
+++ b/packages/aleo_dart/lib/src/aleo_record.dart
@@ -19,27 +19,25 @@ class AleoRecord {
     AleoUtils.checkPrivateKey(privateKeyRaw);
     final privateKey = dartStrToC(privateKeyRaw);
     final secret = dartStrToC(secretRaw);
-    final ciphertext = recordRustFFI.encryptPrivateKey(privateKey, secret);
-    return ciphertext.toDartString();
+    final result = recordRustFFI.encryptPrivateKey(privateKey, secret);
+    final ciphertext = takeNativeString(recordRustFFI.dyLib, result);
+    malloc.free(privateKey);
+    malloc.free(secret);
+    return ciphertext;
   }
 
   String decryptToPrivateKey(ciphertextRaw, secretRaw) {
     final ciphertext = dartStrToC(ciphertextRaw);
     final secret = dartStrToC(secretRaw);
-    final privateKey = recordRustFFI.decryptToPrivateKey(ciphertext, secret);
-    return privateKey.toDartString();
+    final result = recordRustFFI.decryptToPrivateKey(ciphertext, secret);
+    final privateKey = takeNativeString(recordRustFFI.dyLib, result);
+    malloc.free(ciphertext);
+    malloc.free(secret);
+    return privateKey;
   }
 
   RecordPlainText decryptCipherText(String record, String viewKey) {
-    AleoUtils.checkRecord(record);
-    AleoUtils.checkViewKey(viewKey);
-    final flag = isOwner(record, viewKey);
-    if (!flag) {
-      throw Exception('Record is not owned by the view key');
-    }
-    final result = recordRustFFI.decryptCipherText(
-        dartStrToC(record), dartStrToC(viewKey));
-    return processRecord(result.toDartString());
+    return processRecord(decryptCipherTextRaw(record, viewKey));
   }
 
   String decryptCipherTextRaw(String record, String viewKey) {
@@ -49,15 +47,24 @@ class AleoRecord {
     if (!flag) {
       throw Exception('Record is not owned by the view key');
     }
-    final result = recordRustFFI.decryptCipherText(
-        dartStrToC(record), dartStrToC(viewKey));
-    return result.toDartString();
+    final recordPtr = dartStrToC(record);
+    final viewKeyPtr = dartStrToC(viewKey);
+    final result = recordRustFFI.decryptCipherText(recordPtr, viewKeyPtr);
+    final plaintext = takeNativeString(recordRustFFI.dyLib, result);
+    malloc.free(recordPtr);
+    malloc.free(viewKeyPtr);
+    return plaintext;
   }
 
   bool isOwner(String record, String viewKey) {
     AleoUtils.checkRecord(record);
     AleoUtils.checkViewKey(viewKey);
-    return recordRustFFI.isOwner(dartStrToC(record), dartStrToC(viewKey));
+    final recordPtr = dartStrToC(record);
+    final viewKeyPtr = dartStrToC(viewKey);
+    final owned = recordRustFFI.isOwner(recordPtr, viewKeyPtr);
+    malloc.free(recordPtr);
+    malloc.free(viewKeyPtr);
+    return owned;
   }
 
   /// 解密 sender_ciphertext 字段，获取发送方地址
@@ -80,11 +87,15 @@ class AleoRecord {
     }
 
     // 调用 Rust FFI 解密 sender_ciphertext
+    final recordPtr = dartStrToC(record);
+    final viewKeyPtr = dartStrToC(viewKey);
+    final senderCiphertextPtr = dartStrToC(senderCiphertext);
     final result = recordRustFFI.decryptSenderCiphertext(
-        dartStrToC(record), dartStrToC(viewKey), dartStrToC(senderCiphertext));
-
-    final senderInfo = result.toDartString();
-
+        recordPtr, viewKeyPtr, senderCiphertextPtr);
+    final senderInfo = takeNativeString(recordRustFFI.dyLib, result);
+    malloc.free(recordPtr);
+    malloc.free(viewKeyPtr);
+    malloc.free(senderCiphertextPtr);
     return senderInfo;
   }
 
@@ -99,7 +110,12 @@ class AleoRecord {
     final recordName = dartStrToC(recordNameRaw);
     final result = recordRustFFI.serialNumberString(
         recordPlainText, privateKey, programId, recordName);
-    return result.toDartString();
+    final serialNumber = takeNativeString(recordRustFFI.dyLib, result);
+    malloc.free(recordPlainText);
+    malloc.free(privateKey);
+    malloc.free(programId);
+    malloc.free(recordName);
+    return serialNumber;
   }
 
   List<String> serialNumberStrings(

--- a/packages/aleo_dart/lib/src/aleo_record.dart
+++ b/packages/aleo_dart/lib/src/aleo_record.dart
@@ -1,7 +1,5 @@
 import 'dart:math';
 
-import 'package:ffi/ffi.dart';
-
 import 'package:aleo_dart/src/rust_lib/record_rust_ffi.dart';
 import 'package:aleo_dart/src/rust_lib/utils.dart';
 import 'package:aleo_dart/src/aleo_utils.dart';
@@ -18,21 +16,23 @@ class AleoRecord {
     AleoUtils.checkPrivateKey(privateKeyRaw);
     final privateKey = dartStrToC(privateKeyRaw);
     final secret = dartStrToC(secretRaw);
-    final result = recordRustFFI.encryptPrivateKey(privateKey, secret);
-    final ciphertext = takeNativeString(recordRustFFI.dyLib, result);
-    malloc.free(privateKey);
-    malloc.free(secret);
-    return ciphertext;
+    try {
+      final result = recordRustFFI.encryptPrivateKey(privateKey, secret);
+      return takeNativeString(recordRustFFI.dyLib, result);
+    } finally {
+      freeAll([privateKey, secret]);
+    }
   }
 
   String decryptToPrivateKey(ciphertextRaw, secretRaw) {
     final ciphertext = dartStrToC(ciphertextRaw);
     final secret = dartStrToC(secretRaw);
-    final result = recordRustFFI.decryptToPrivateKey(ciphertext, secret);
-    final privateKey = takeNativeString(recordRustFFI.dyLib, result);
-    malloc.free(ciphertext);
-    malloc.free(secret);
-    return privateKey;
+    try {
+      final result = recordRustFFI.decryptToPrivateKey(ciphertext, secret);
+      return takeNativeString(recordRustFFI.dyLib, result);
+    } finally {
+      freeAll([ciphertext, secret]);
+    }
   }
 
   RecordPlainText decryptCipherText(String record, String viewKey) {
@@ -48,11 +48,12 @@ class AleoRecord {
     }
     final recordPtr = dartStrToC(record);
     final viewKeyPtr = dartStrToC(viewKey);
-    final result = recordRustFFI.decryptCipherText(recordPtr, viewKeyPtr);
-    final plaintext = takeNativeString(recordRustFFI.dyLib, result);
-    malloc.free(recordPtr);
-    malloc.free(viewKeyPtr);
-    return plaintext;
+    try {
+      final result = recordRustFFI.decryptCipherText(recordPtr, viewKeyPtr);
+      return takeNativeString(recordRustFFI.dyLib, result);
+    } finally {
+      freeAll([recordPtr, viewKeyPtr]);
+    }
   }
 
   bool isOwner(String record, String viewKey) {
@@ -60,10 +61,11 @@ class AleoRecord {
     AleoUtils.checkViewKey(viewKey);
     final recordPtr = dartStrToC(record);
     final viewKeyPtr = dartStrToC(viewKey);
-    final owned = recordRustFFI.isOwner(recordPtr, viewKeyPtr);
-    malloc.free(recordPtr);
-    malloc.free(viewKeyPtr);
-    return owned;
+    try {
+      return recordRustFFI.isOwner(recordPtr, viewKeyPtr);
+    } finally {
+      freeAll([recordPtr, viewKeyPtr]);
+    }
   }
 
   /// 解密 sender_ciphertext 字段，获取发送方地址
@@ -89,13 +91,13 @@ class AleoRecord {
     final recordPtr = dartStrToC(record);
     final viewKeyPtr = dartStrToC(viewKey);
     final senderCiphertextPtr = dartStrToC(senderCiphertext);
-    final result = recordRustFFI.decryptSenderCiphertext(
-        recordPtr, viewKeyPtr, senderCiphertextPtr);
-    final senderInfo = takeNativeString(recordRustFFI.dyLib, result);
-    malloc.free(recordPtr);
-    malloc.free(viewKeyPtr);
-    malloc.free(senderCiphertextPtr);
-    return senderInfo;
+    try {
+      final result = recordRustFFI.decryptSenderCiphertext(
+          recordPtr, viewKeyPtr, senderCiphertextPtr);
+      return takeNativeString(recordRustFFI.dyLib, result);
+    } finally {
+      freeAll([recordPtr, viewKeyPtr, senderCiphertextPtr]);
+    }
   }
 
   String serialNumberString(String recordCipherTextRaw, String privateKeyRaw,
@@ -107,14 +109,13 @@ class AleoRecord {
     final privateKey = dartStrToC(privateKeyRaw);
     final programId = dartStrToC(programIdRaw);
     final recordName = dartStrToC(recordNameRaw);
-    final result = recordRustFFI.serialNumberString(
-        recordPlainText, privateKey, programId, recordName);
-    final serialNumber = takeNativeString(recordRustFFI.dyLib, result);
-    malloc.free(recordPlainText);
-    malloc.free(privateKey);
-    malloc.free(programId);
-    malloc.free(recordName);
-    return serialNumber;
+    try {
+      final result = recordRustFFI.serialNumberString(
+          recordPlainText, privateKey, programId, recordName);
+      return takeNativeString(recordRustFFI.dyLib, result);
+    } finally {
+      freeAll([recordPlainText, privateKey, programId, recordName]);
+    }
   }
 
   List<String> serialNumberStrings(

--- a/packages/aleo_dart/lib/src/aleo_record.dart
+++ b/packages/aleo_dart/lib/src/aleo_record.dart
@@ -10,9 +10,8 @@ class AleoRecord {
   late RecordRustFFI recordRustFFI;
   int decimal = 6;
 
-  AleoRecord(dyLib, [network_raw = 'testnet']) {
-    final network = dartStrToC(network_raw);
-    this.recordRustFFI = RecordRustFFI(dyLib, network);
+  AleoRecord(dyLib, [String network_raw = 'testnet']) {
+    this.recordRustFFI = RecordRustFFI(dyLib, network_raw);
   }
 
   String encryptPrivateKey(privateKeyRaw, secretRaw) {

--- a/packages/aleo_dart/lib/src/aleo_utils.dart
+++ b/packages/aleo_dart/lib/src/aleo_utils.dart
@@ -25,4 +25,12 @@ class AleoUtils {
       throw Exception('Invalid record prefix');
     }
   }
+
+  /// Amounts and fees cross the FFI boundary as unsigned 64-bit microcredits;
+  /// a negative Dart int would wrap to an enormous u64.
+  static checkAmount(int value, String name) {
+    if (value < 0) {
+      throw Exception('Invalid $name: must not be negative ($value)');
+    }
+  }
 }

--- a/packages/aleo_dart/lib/src/rust_lib/account_rust_ffi.dart
+++ b/packages/aleo_dart/lib/src/rust_lib/account_rust_ffi.dart
@@ -26,7 +26,7 @@ typedef TypeGetTokenOwnerHashInDart = ffi.Pointer<Utf8> Function(
 
 class AccountRustFFI {
   final ffi.DynamicLibrary dyLib;
-  final network;
+  final String network;
 
   AccountRustFFI(this.dyLib, this.network);
 

--- a/packages/aleo_dart/lib/src/rust_lib/programs_rust_ffi.dart
+++ b/packages/aleo_dart/lib/src/rust_lib/programs_rust_ffi.dart
@@ -4,12 +4,14 @@ import 'package:ffi/ffi.dart';
 typedef TypeTestInRust = ffi.Int Function(ffi.Int, ffi.Int);
 typedef TypeTestInDart = int Function(int, int);
 
+// Amounts and fees cross the ABI as unsigned 64-bit microcredits (snarkVM's
+// fee/amount type); 32-bit types cannot express the legal range.
 typedef TypeTransferInRust = ffi.Pointer<Utf8> Function(
     ffi.Pointer<Utf8>,
     ffi.Pointer<Utf8>,
     ffi.Pointer<Utf8>,
-    ffi.Int,
-    ffi.Int,
+    ffi.Uint64,
+    ffi.Uint64,
     ffi.Pointer<Utf8>,
     ffi.Pointer<Utf8>,
     ffi.Pointer<Utf8>,
@@ -33,7 +35,7 @@ typedef TypeAuthorizationInRust = ffi.Pointer<Utf8> Function(
     ffi.Pointer<Utf8>,
     ffi.Pointer<Utf8>,
     ffi.Pointer<Utf8>,
-    ffi.Int,
+    ffi.Uint64,
     ffi.Pointer<Utf8>,
     ffi.Pointer<Utf8>,
     ffi.Pointer<Utf8>);
@@ -66,7 +68,7 @@ typedef TypeJoinInRust = ffi.Pointer<Utf8> Function(
     ffi.Pointer<Utf8>,
     ffi.Pointer<Utf8>,
     ffi.Pointer<Utf8>,
-    ffi.Int,
+    ffi.Uint64,
     ffi.Pointer<Utf8>,
     ffi.Pointer<Utf8>,
     ffi.Pointer<Utf8>);
@@ -83,7 +85,7 @@ typedef TypeJoinInDart = ffi.Pointer<Utf8> Function(
 typedef TypeJoinAuthorization = ffi.Pointer<Utf8> Function(ffi.Pointer<Utf8>,
     ffi.Pointer<Utf8>, ffi.Pointer<Utf8>, ffi.Pointer<Utf8>, ffi.Pointer<Utf8>);
 
-typedef TypeGetBaseFeeInRust = ffi.Int Function(
+typedef TypeGetBaseFeeInRust = ffi.Uint64 Function(
   ffi.Pointer<Utf8>,
   ffi.Pointer<Utf8>,
   ffi.Pointer<Utf8>,
@@ -116,7 +118,7 @@ typedef TypeExecuteProgramInRust = ffi.Pointer<Utf8> Function(
     ffi.Pointer<Utf8>,
     ffi.Pointer<Utf8>,
     ffi.Pointer<Utf8>,
-    ffi.Int,
+    ffi.Uint64,
     ffi.Pointer<Utf8>,
     ffi.Pointer<Utf8>);
 
@@ -131,7 +133,7 @@ typedef TypeExecuteProgramInDart = ffi.Pointer<Utf8> Function(
 
 typedef TypeContractFeeExecutionInRust = ffi.Pointer<Utf8> Function(
     ffi.Pointer<Utf8>,
-    ffi.Int,
+    ffi.Uint64,
     ffi.Pointer<Utf8>,
     ffi.Pointer<Utf8>,
     ffi.Pointer<Utf8>,

--- a/packages/aleo_dart/lib/src/rust_lib/programs_rust_ffi.dart
+++ b/packages/aleo_dart/lib/src/rust_lib/programs_rust_ffi.dart
@@ -147,9 +147,21 @@ typedef TypeContractFeeExecutionInDart = ffi.Pointer<Utf8> Function(
 
 class ProgramsRustFFI {
   final ffi.DynamicLibrary dyLib;
-  final network;
+  final String network;
 
   ProgramsRustFFI(this.dyLib, this.network);
+
+  /// Allocates a native copy of [network] for the duration of [action] and
+  /// frees it afterwards. The native functions copy the string during the
+  /// call, so no allocation needs to outlive it.
+  T _withNetwork<T>(T Function(ffi.Pointer<Utf8> network) action) {
+    final networkPtr = network.toNativeUtf8();
+    try {
+      return action(networkPtr);
+    } finally {
+      malloc.free(networkPtr);
+    }
+  }
 
   Future<ffi.Pointer<Utf8>> transfer(
     ffi.Pointer<Utf8> private_key,
@@ -164,8 +176,16 @@ class ProgramsRustFFI {
     final rustFunction = dyLib
         .lookupFunction<TypeTransferInRust, TypeTransferInDart>('try_transfer');
 
-    return rustFunction(private_key, recipient, transfer_type, amount_credits,
-        fee_credits, url, amount_record, fee_record, this.network);
+    return _withNetwork((network) => rustFunction(
+        private_key,
+        recipient,
+        transfer_type,
+        amount_credits,
+        fee_credits,
+        url,
+        amount_record,
+        fee_record,
+        network));
   }
 
   Future<ffi.Pointer<Utf8>> join(
@@ -179,8 +199,8 @@ class ProgramsRustFFI {
     final rustFunction =
         dyLib.lookupFunction<TypeJoinInRust, TypeJoinInDart>('try_join');
 
-    return rustFunction(private_key, record_1, record_2, fee_credits,
-        fee_record, url, this.network);
+    return _withNetwork((network) => rustFunction(private_key, record_1,
+        record_2, fee_credits, fee_record, url, network));
   }
 
   Future<ffi.Pointer<Utf8>> joinAuthorization(
@@ -193,7 +213,8 @@ class ProgramsRustFFI {
         dyLib.lookupFunction<TypeJoinAuthorization, TypeJoinAuthorization>(
             'join_authorization');
 
-    return rustFunction(private_key, record_1, record_2, url, this.network);
+    return _withNetwork((network) =>
+        rustFunction(private_key, record_1, record_2, url, network));
   }
 
   Future<ffi.Pointer<Utf8>> upgradeAuthorization(
@@ -204,7 +225,8 @@ class ProgramsRustFFI {
     final rustFunction = dyLib.lookupFunction<TypeUpgradeAuthorization,
         TypeUpgradeAuthorization>('upgrade_authorization');
 
-    return rustFunction(private_key, record, url, this.network);
+    return _withNetwork(
+        (network) => rustFunction(private_key, record, url, network));
   }
 
   Future<ffi.Pointer<Utf8>> buildTransaction(
@@ -221,8 +243,16 @@ class ProgramsRustFFI {
         dyLib.lookupFunction<TypeTransferInRust, TypeTransferInDart>(
             'build_transaction');
 
-    return rustFunction(private_key, recipient, transfer_type, amount_credits,
-        fee_credits, url, amount_record, fee_record, this.network);
+    return _withNetwork((network) => rustFunction(
+        private_key,
+        recipient,
+        transfer_type,
+        amount_credits,
+        fee_credits,
+        url,
+        amount_record,
+        fee_record,
+        network));
   }
 
   Future<ffi.Pointer<Utf8>> broadcast(
@@ -233,7 +263,8 @@ class ProgramsRustFFI {
     final rustFunction =
         dyLib.lookupFunction<TypeBroadcast, TypeBroadcast>('broadcast');
 
-    return rustFunction(transaction, url, transfer_type, this.network);
+    return _withNetwork(
+        (network) => rustFunction(transaction, url, transfer_type, network));
   }
 
   Future<ffi.Pointer<Utf8>> executionAuthorization(
@@ -248,8 +279,8 @@ class ProgramsRustFFI {
         dyLib.lookupFunction<TypeAuthorizationInRust, TypeAuthorizationInDart>(
             'execution_authorization');
 
-    return rustFunction(private_key, recipient, transfer_type, amount_credits,
-        url, amount_record, this.network);
+    return _withNetwork((network) => rustFunction(private_key, recipient,
+        transfer_type, amount_credits, url, amount_record, network));
   }
 
   Future<ffi.Pointer<Utf8>> executionFeeAuthorization(
@@ -264,8 +295,8 @@ class ProgramsRustFFI {
         dyLib.lookupFunction<TypeAuthorizationInRust, TypeAuthorizationInDart>(
             'execution_fee_authorization');
 
-    return rustFunction(private_key, transfer_type, url, fee_credits,
-        fee_record, execution, this.network);
+    return _withNetwork((network) => rustFunction(private_key, transfer_type,
+        url, fee_credits, fee_record, execution, network));
   }
 
   Future<ffi.Pointer<Utf8>> executeProof(
@@ -275,7 +306,7 @@ class ProgramsRustFFI {
     final rustFunction = dyLib
         .lookupFunction<TypeExecuteProof, TypeExecuteProof>('execute_proof');
 
-    return rustFunction(url, authorization, this.network);
+    return _withNetwork((network) => rustFunction(url, authorization, network));
   }
 
   Future<ffi.Pointer<Utf8>> executeProgramProof(
@@ -287,7 +318,8 @@ class ProgramsRustFFI {
         dyLib.lookupFunction<TypeExecuteProgramProof, TypeExecuteProgramProof>(
             'execute_program_proof');
 
-    return rustFunction(url, authorization, this.network, program_id);
+    return _withNetwork(
+        (network) => rustFunction(url, authorization, network, program_id));
   }
 
   Future<ffi.Pointer<Utf8>> executeFeeProof(
@@ -297,7 +329,7 @@ class ProgramsRustFFI {
     final rustFunction =
         dyLib.lookupFunction<TypeProof, TypeProof>('execute_fee_proof');
 
-    return rustFunction(url, authorization, this.network);
+    return _withNetwork((network) => rustFunction(url, authorization, network));
   }
 
   Future<ffi.Pointer<Utf8>> buildTransactionOffline(
@@ -306,7 +338,7 @@ class ProgramsRustFFI {
   ) async {
     final rustFunction =
         dyLib.lookupFunction<TypeProof, TypeProof>('build_transaction_offline');
-    return rustFunction(execution, fee, this.network);
+    return _withNetwork((network) => rustFunction(execution, fee, network));
   }
 
   Future<ffi.Pointer<Utf8>> buildUpgradeTransactionOffline(
@@ -314,7 +346,7 @@ class ProgramsRustFFI {
   ) async {
     final rustFunction = dyLib.lookupFunction<TypeUpgradeTransactionOffline,
         TypeUpgradeTransactionOffline>('build_upgrade_transaction_offline');
-    return rustFunction(execution, this.network);
+    return _withNetwork((network) => rustFunction(execution, network));
   }
 
   Future<int> getBaseFee(
@@ -324,7 +356,7 @@ class ProgramsRustFFI {
     final rustFunction =
         dyLib.lookupFunction<TypeGetBaseFeeInRust, TypeGetBaseFeeInDart>(
             'get_base_fee');
-    return rustFunction(url, execution, this.network);
+    return _withNetwork((network) => rustFunction(url, execution, network));
   }
 
   Future<ffi.Pointer<Utf8>> executeProgram(
@@ -338,8 +370,8 @@ class ProgramsRustFFI {
     final rustFunction = dyLib.lookupFunction<TypeExecuteProgramInRust,
         TypeExecuteProgramInDart>('execute_program');
 
-    return rustFunction(private_key, program_id, function_name, arguments, fee,
-        url, this.network);
+    return _withNetwork((network) => rustFunction(
+        private_key, program_id, function_name, arguments, fee, url, network));
   }
 
   Future<ffi.Pointer<Utf8>> contractExecution(
@@ -351,8 +383,8 @@ class ProgramsRustFFI {
   ) async {
     final rustFunction = dyLib.lookupFunction<TypeContractExecutionInRust,
         TypeContractExecutionInDart>('contract_execution');
-    return rustFunction(
-        private_key, program_id, function_name, arguments, url, this.network);
+    return _withNetwork((network) => rustFunction(
+        private_key, program_id, function_name, arguments, url, network));
   }
 
   Future<ffi.Pointer<Utf8>> contractFeeExecution(
@@ -364,7 +396,7 @@ class ProgramsRustFFI {
   ) async {
     final rustFunction = dyLib.lookupFunction<TypeContractFeeExecutionInRust,
         TypeContractFeeExecutionInDart>('contract_fee_execution');
-    return rustFunction(
-        private_key, fee, execution, program_id, url, this.network);
+    return _withNetwork((network) =>
+        rustFunction(private_key, fee, execution, program_id, url, network));
   }
 }

--- a/packages/aleo_dart/lib/src/rust_lib/record_rust_ffi.dart
+++ b/packages/aleo_dart/lib/src/rust_lib/record_rust_ffi.dart
@@ -17,7 +17,7 @@ typedef TypeStr2ToBoolInDart = int Function(
 
 class RecordRustFFI {
   final ffi.DynamicLibrary dyLib;
-  final network;
+  final String network;
 
   RecordRustFFI(this.dyLib, this.network);
 
@@ -30,8 +30,8 @@ class RecordRustFFI {
 
   ffi.Pointer<Utf8> decryptToPrivateKey(
       ffi.Pointer<Utf8> ciphertext, ffi.Pointer<Utf8> secret) {
-    final decryptToPrivateKey =
-        dyLib.lookupFunction<TypeStr2To1, TypeStr2To1>('decrypt_to_private_key');
+    final decryptToPrivateKey = dyLib
+        .lookupFunction<TypeStr2To1, TypeStr2To1>('decrypt_to_private_key');
     return decryptToPrivateKey(ciphertext, secret);
   }
 
@@ -59,12 +59,10 @@ class RecordRustFFI {
         recordCipherText, privateKey, programId, recordName);
   }
 
-  ffi.Pointer<Utf8> decryptSenderCiphertext(
-      ffi.Pointer<Utf8> recordCipherText, 
-      ffi.Pointer<Utf8> viewKey, 
-      ffi.Pointer<Utf8> senderCiphertext) {
-    final decryptSenderCiphertext =
-        dyLib.lookupFunction<TypeStr3To1, TypeStr3To1>('decrypt_sender_ciphertext');
+  ffi.Pointer<Utf8> decryptSenderCiphertext(ffi.Pointer<Utf8> recordCipherText,
+      ffi.Pointer<Utf8> viewKey, ffi.Pointer<Utf8> senderCiphertext) {
+    final decryptSenderCiphertext = dyLib
+        .lookupFunction<TypeStr3To1, TypeStr3To1>('decrypt_sender_ciphertext');
     return decryptSenderCiphertext(recordCipherText, viewKey, senderCiphertext);
   }
 }

--- a/packages/aleo_dart/lib/src/rust_lib/utils.dart
+++ b/packages/aleo_dart/lib/src/rust_lib/utils.dart
@@ -17,3 +17,34 @@ ffi.Pointer<Utf8> dartStrToC(String string) {
 String cStrToDart(ffi.Pointer<Utf8> charPointer) {
   return charPointer.toDartString();
 }
+
+typedef _FreeStringC = ffi.Void Function(ffi.Pointer<Utf8>);
+typedef _FreeStringDart = void Function(ffi.Pointer<Utf8>);
+
+/// Frees a string returned by the native library. Returned pointers are
+/// allocated by Rust (`CString::into_raw`), so they must be released through
+/// Rust's `free_string`, not the C allocator. If the loaded library predates
+/// `free_string` (the older GPL build), this degrades to the previous
+/// behaviour — the buffer is not freed — rather than throwing.
+void freeNativeString(ffi.DynamicLibrary dyLib, ffi.Pointer<Utf8> ptr) {
+  try {
+    dyLib.lookupFunction<_FreeStringC, _FreeStringDart>('free_string')(ptr);
+  } catch (_) {
+    // Library has no free_string: fall back to leaking, as before.
+  }
+}
+
+/// Copies a Rust-returned C string into a Dart string and frees the native
+/// buffer. Use for every `Pointer<Utf8>` returned by the library.
+String takeNativeString(ffi.DynamicLibrary dyLib, ffi.Pointer<Utf8> ptr) {
+  final value = ptr.toDartString();
+  freeNativeString(dyLib, ptr);
+  return value;
+}
+
+/// Frees Dart-allocated input string pointers (from [dartStrToC]).
+void freeAll(Iterable<ffi.Pointer<Utf8>> pointers) {
+  for (final pointer in pointers) {
+    malloc.free(pointer);
+  }
+}

--- a/packages/aleo_dart/lib/src/rust_lib/utils.dart
+++ b/packages/aleo_dart/lib/src/rust_lib/utils.dart
@@ -35,11 +35,14 @@ void freeNativeString(ffi.DynamicLibrary dyLib, ffi.Pointer<Utf8> ptr) {
 }
 
 /// Copies a Rust-returned C string into a Dart string and frees the native
-/// buffer. Use for every `Pointer<Utf8>` returned by the library.
+/// buffer (even when the conversion throws). Use for every `Pointer<Utf8>`
+/// returned by the library.
 String takeNativeString(ffi.DynamicLibrary dyLib, ffi.Pointer<Utf8> ptr) {
-  final value = ptr.toDartString();
-  freeNativeString(dyLib, ptr);
-  return value;
+  try {
+    return ptr.toDartString();
+  } finally {
+    freeNativeString(dyLib, ptr);
+  }
 }
 
 /// Frees Dart-allocated input string pointers (from [dartStrToC]).

--- a/packages/aleo_dart/test/amount_units_test.dart
+++ b/packages/aleo_dart/test/amount_units_test.dart
@@ -1,0 +1,40 @@
+// Guards the transfer amount/fee unit contract: the FFI integer is passed
+// straight through to credits.aleo as microcredits (`{amount}u64`), with no
+// credits->microcredits scaling. This matches the reference implementation and
+// the caller is responsible for supplying microcredits.
+//
+// Run against a built library:
+//   ALEO_NEW_LIB=/abs/path/libaleo_rust.dylib flutter test test/amount_units_test.dart
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:aleo_dart/aleo.dart';
+import 'package:test/test.dart';
+
+void main() {
+  final libPath = Platform.environment['ALEO_NEW_LIB'];
+  if (libPath == null) {
+    test('amount units', () {},
+        skip: 'set ALEO_NEW_LIB to a libaleo_rust build');
+    return;
+  }
+
+  final dy = DyLib.getDyLibByPosition(libPath);
+  final program = AleoProgram(dy);
+  final account = AleoAccount(dy);
+  const privateKey =
+      'APrivateKey1zkpC2CbihCvUyg8zcNXTngzGpmCzKTF8uZP4jfyu3LdfT8v';
+  final recipient = account.privateKeyToAddress(privateKey);
+
+  test('transfer amount is encoded as microcredits without scaling', () async {
+    for (final amount in <int>[1, 5, 1000000, 2000000000]) {
+      final auth = await program.executionAuthorization(
+          privateKey, recipient, 'transfer_public', amount, '', '');
+      expect(auth, isNotEmpty);
+      final inputs =
+          (json.decode(auth)['requests'] as List).first['inputs'] as List;
+      expect(inputs, contains('${amount}u64'),
+          reason: 'amount $amount should pass through as ${amount}u64');
+    }
+  });
+}

--- a/packages/aleo_dart/test/amount_units_test.dart
+++ b/packages/aleo_dart/test/amount_units_test.dart
@@ -4,22 +4,21 @@
 // the caller is responsible for supplying microcredits.
 //
 // Run against a built library:
-//   ALEO_NEW_LIB=/abs/path/libaleo_rust.dylib flutter test test/amount_units_test.dart
+//   ALEO_NEW_LIB=/abs/path/libaleo_rust.dylib dart test test/amount_units_test.dart
 import 'dart:convert';
-import 'dart:io';
 
 import 'package:aleo_dart/aleo.dart';
 import 'package:test/test.dart';
 
+import 'support/test_dylib.dart';
+
 void main() {
-  final libPath = Platform.environment['ALEO_NEW_LIB'];
-  if (libPath == null) {
-    test('amount units', () {},
-        skip: 'set ALEO_NEW_LIB to a libaleo_rust build');
+  final dy = tryLoadAleoLib();
+  if (dy == null) {
+    test('amount units', () {}, skip: nativeLibMissingReason);
     return;
   }
 
-  final dy = DyLib.getDyLibByPosition(libPath);
   final program = AleoProgram(dy);
   final account = AleoAccount(dy);
   const privateKey =

--- a/packages/aleo_dart/test/amount_units_test.dart
+++ b/packages/aleo_dart/test/amount_units_test.dart
@@ -26,7 +26,17 @@ void main() {
   final recipient = account.privateKeyToAddress(privateKey);
 
   test('transfer amount is encoded as microcredits without scaling', () async {
-    for (final amount in <int>[1, 5, 1000000, 2000000000]) {
+    // Includes values past i32 (2^31, 2^32) and the total-supply order of
+    // magnitude (10^15): the ABI is u64 end to end, so none may truncate.
+    for (final amount in <int>[
+      1,
+      5,
+      1000000,
+      2000000000,
+      2147483648,
+      4294967296,
+      1000000000000000,
+    ]) {
       final auth = await program.executionAuthorization(
           privateKey, recipient, 'transfer_public', amount, '', '');
       expect(auth, isNotEmpty);
@@ -35,5 +45,17 @@ void main() {
       expect(inputs, contains('${amount}u64'),
           reason: 'amount $amount should pass through as ${amount}u64');
     }
+  });
+
+  test('negative amounts and fees are rejected before reaching the FFI', () {
+    // A negative Dart int would wrap to an enormous u64 across the ABI.
+    expect(
+        () => program.executionAuthorization(
+            privateKey, recipient, 'transfer_public', -1, '', ''),
+        throwsException);
+    expect(
+        () => program.executionFeeAuthorization(
+            privateKey, 'transfer_public', -1, '', '', '{}'),
+        throwsException);
   });
 }

--- a/packages/aleo_dart/test/support/test_dylib.dart
+++ b/packages/aleo_dart/test/support/test_dylib.dart
@@ -1,4 +1,5 @@
 import 'dart:ffi';
+import 'dart:io';
 
 import 'package:aleo_dart/aleo.dart';
 
@@ -6,15 +7,23 @@ import 'package:aleo_dart/aleo.dart';
 /// `aleo_rust` library could not be loaded (e.g. on CI where it is neither
 /// prebuilt nor compiled from source).
 const nativeLibMissingReason =
-    'native libaleo_rust not available; fetch a prebuilt copy with '
-    '`dart run aleo_dart:setup` (loaded via DyLib.getDyLibFromGit)';
+    'native libaleo_rust not available; set ALEO_NEW_LIB to a built library, '
+    'or fetch a prebuilt copy with `dart run aleo_dart:setup` '
+    '(loaded via DyLib.getDyLibFromGit)';
 
 /// Attempts to load the native `aleo_rust` dynamic library for tests.
 ///
-/// Tries the local cargo build first, then a prebuilt copy fetched by
-/// `dart run aleo_dart:setup`. Returns `null` when none is available so that
-/// suites can [skip] gracefully instead of crashing at load time.
+/// An `ALEO_NEW_LIB` path takes priority and fails loudly when unloadable (CI
+/// sets it to the freshly built cdylib, and a typo there should not silently
+/// skip the suite). Otherwise tries the local cargo build, then a prebuilt
+/// copy fetched by `dart run aleo_dart:setup`, and returns `null` when none
+/// is available so that suites can [skip] gracefully instead of crashing at
+/// load time.
 DynamicLibrary? tryLoadAleoLib() {
+  final override = Platform.environment['ALEO_NEW_LIB'];
+  if (override != null && override.isNotEmpty) {
+    return DynamicLibrary.open(override);
+  }
   for (final loader in <DynamicLibrary Function()>[
     DyLib.getDyLibFromCargo,
     DyLib.getDyLibFromGit,

--- a/rust/aleo_ffi/Cargo.lock
+++ b/rust/aleo_ffi/Cargo.lock
@@ -80,6 +80,7 @@ dependencies = [
  "aleo-std-storage",
  "anyhow",
  "rand",
+ "serde",
  "serde_json",
  "snarkvm-console",
  "snarkvm-ledger-block",

--- a/rust/aleo_ffi/Cargo.lock
+++ b/rust/aleo_ffi/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aleo-std"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -71,10 +77,16 @@ checksum = "12aca1021aef2c476bad30d2f681e891b2be4f07dbc230a96df09cb693bfb3cb"
 name = "aleo_ffi"
 version = "0.1.0"
 dependencies = [
+ "aleo-std-storage",
+ "anyhow",
  "rand",
  "serde_json",
  "snarkvm-console",
  "snarkvm-ledger-block",
+ "snarkvm-ledger-query",
+ "snarkvm-ledger-store",
+ "snarkvm-synthesizer",
+ "ureq 2.12.1",
 ]
 
 [[package]]
@@ -102,6 +114,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.45",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -112,6 +135,12 @@ name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bech32"
@@ -222,12 +251,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
+name = "cookie"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
+dependencies = [
+ "percent-encoding",
+ "time",
+ "version_check",
+]
+
+[[package]]
+name = "cookie_store"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b2c103cf610ec6cae3da84a766285b42fd16aad564758459e6ecf128c75206"
+dependencies = [
+ "cookie",
+ "document-features",
+ "idna",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "time",
+ "url",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -324,6 +391,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -353,6 +429,26 @@ dependencies = [
  "libc",
  "redox_users",
  "winapi",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.45",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
 ]
 
 [[package]]
@@ -467,6 +563,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -477,6 +583,15 @@ name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
 
 [[package]]
 name = "fxhash"
@@ -589,10 +704,129 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "indexmap"
@@ -680,6 +914,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -716,6 +962,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -734,6 +990,12 @@ dependencies = [
  "num-integer",
  "num-traits",
 ]
+
+[[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-derive"
@@ -828,6 +1090,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -838,6 +1106,21 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -978,6 +1261,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -997,6 +1294,41 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+dependencies = [
+ "log",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -1118,6 +1450,12 @@ dependencies = [
  "digest",
  "rand_core",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "smallvec"
@@ -1744,6 +2082,72 @@ dependencies = [
 ]
 
 [[package]]
+name = "snarkvm-ledger-puzzle-epoch"
+version = "4.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcb9278a74ef96adecd302979d43f01bb1fda9dab01af8586426eab0be916f07"
+dependencies = [
+ "aleo-std",
+ "anyhow",
+ "colored",
+ "indexmap",
+ "lru",
+ "parking_lot",
+ "rand",
+ "rand_chacha",
+ "rayon",
+ "snarkvm-circuit",
+ "snarkvm-console",
+ "snarkvm-ledger-puzzle",
+ "snarkvm-synthesizer-process",
+ "snarkvm-synthesizer-program",
+ "snarkvm-utilities",
+]
+
+[[package]]
+name = "snarkvm-ledger-query"
+version = "4.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03f55770a9b2aabc103b658e681346f62eb4e00b98293d185e04d654edf1ab31"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "serde",
+ "serde_json",
+ "snarkvm-console",
+ "snarkvm-ledger-block",
+ "snarkvm-ledger-store",
+ "snarkvm-synthesizer-program",
+ "ureq 3.3.0",
+]
+
+[[package]]
+name = "snarkvm-ledger-store"
+version = "4.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17f71a9d7badda594dc9dd75f6dd31a08b282d4e5cc2cb679d3802d396506387"
+dependencies = [
+ "aleo-std-storage",
+ "anyhow",
+ "bincode",
+ "indexmap",
+ "parking_lot",
+ "rayon",
+ "serde",
+ "serde_json",
+ "snarkvm-console",
+ "snarkvm-ledger-authority",
+ "snarkvm-ledger-block",
+ "snarkvm-ledger-committee",
+ "snarkvm-ledger-narwhal-batch-certificate",
+ "snarkvm-ledger-puzzle",
+ "snarkvm-synthesizer-program",
+ "snarkvm-synthesizer-snark",
+ "snarkvm-utilities",
+ "tracing",
+]
+
+[[package]]
 name = "snarkvm-parameters"
 version = "4.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1764,6 +2168,62 @@ dependencies = [
  "snarkvm-curves",
  "snarkvm-utilities",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "snarkvm-synthesizer"
+version = "4.5.0"
+dependencies = [
+ "aleo-std",
+ "anyhow",
+ "indexmap",
+ "itertools",
+ "lru",
+ "parking_lot",
+ "rand",
+ "rayon",
+ "serde_json",
+ "snarkvm-algorithms",
+ "snarkvm-circuit",
+ "snarkvm-console",
+ "snarkvm-ledger-block",
+ "snarkvm-ledger-committee",
+ "snarkvm-ledger-narwhal-data",
+ "snarkvm-ledger-puzzle",
+ "snarkvm-ledger-puzzle-epoch",
+ "snarkvm-ledger-query",
+ "snarkvm-ledger-store",
+ "snarkvm-synthesizer-process",
+ "snarkvm-synthesizer-program",
+ "snarkvm-synthesizer-snark",
+ "snarkvm-utilities",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "snarkvm-synthesizer-process"
+version = "4.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73e2a61297295cd9a8ed0e509c14170bd1e4338eeefba1224302e7a6aea451d7"
+dependencies = [
+ "aleo-std",
+ "colored",
+ "indexmap",
+ "parking_lot",
+ "rand",
+ "rand_chacha",
+ "rayon",
+ "serde_json",
+ "snarkvm-algorithms",
+ "snarkvm-circuit",
+ "snarkvm-console",
+ "snarkvm-ledger-block",
+ "snarkvm-ledger-query",
+ "snarkvm-ledger-store",
+ "snarkvm-synthesizer-program",
+ "snarkvm-synthesizer-snark",
+ "snarkvm-utilities",
 ]
 
 [[package]]
@@ -1846,6 +2306,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1891,6 +2357,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
 dependencies = [
  "unicode-xid 0.0.4",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.45",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1947,12 +2424,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
 name = "tiny-keccak"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
 dependencies = [
  "crunchy",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
 ]
 
 [[package]]
@@ -1969,6 +2487,15 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tokio"
+version = "1.52.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+dependencies = [
+ "pin-project-lite",
+]
 
 [[package]]
 name = "tracing"
@@ -2024,6 +2551,86 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "ureq"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+dependencies = [
+ "base64",
+ "flate2",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "url",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "ureq"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
+dependencies = [
+ "base64",
+ "cookie_store",
+ "flate2",
+ "log",
+ "percent-encoding",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "ureq-proto",
+ "utf8-zero",
+ "webpki-roots 1.0.7",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
+dependencies = [
+ "base64",
+ "http",
+ "httparse",
+ "log",
+]
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8-zero"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "vcpkg"
@@ -2106,6 +2713,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.7",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2141,6 +2766,15 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
 
 [[package]]
 name = "windows-sys"
@@ -2319,6 +2953,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "yoke"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.45",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2339,6 +3002,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.45",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
 name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2352,6 +3036,39 @@ name = "zeroize_derive"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.45",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote 1.0.45",

--- a/rust/aleo_ffi/Cargo.toml
+++ b/rust/aleo_ffi/Cargo.toml
@@ -13,5 +13,16 @@ crate-type = ["cdylib"]
 [dependencies]
 snarkvm-console = "=4.5.0"
 snarkvm-ledger-block = "=4.5.0"
+snarkvm-ledger-store = "=4.5.0"
+snarkvm-ledger-query = "=4.5.0"
+snarkvm-synthesizer = "=4.5.0"
+aleo-std-storage = "=1.0.3"
+anyhow = "1"
 rand = "0.8.5"
 serde_json = "1"
+ureq = { version = "2.7.1", features = ["json"] }
+
+# Expose VM::execute_authorization_raw / execute_fee_authorization_raw (private
+# upstream) for the split-proof flow. Apache-2.0; verbatim + a 2-line pub patch.
+[patch.crates-io]
+snarkvm-synthesizer = { path = "../vendor/snarkvm-synthesizer-4.5.0" }

--- a/rust/aleo_ffi/Cargo.toml
+++ b/rust/aleo_ffi/Cargo.toml
@@ -19,6 +19,7 @@ snarkvm-synthesizer = "=4.5.0"
 aleo-std-storage = "=1.0.3"
 anyhow = "1"
 rand = "0.8.5"
+serde = "1"
 serde_json = "1"
 ureq = { version = "2.7.1", features = ["json"] }
 

--- a/rust/aleo_ffi/Cargo.toml
+++ b/rust/aleo_ffi/Cargo.toml
@@ -8,7 +8,8 @@ edition = "2021"
 
 [lib]
 name = "aleo_rust"
-crate-type = ["cdylib"]
+# rlib in addition to cdylib so `cargo test` can build a unit-test harness.
+crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 snarkvm-console = "=4.5.0"

--- a/rust/aleo_ffi/docs/network-io-to-dart.md
+++ b/rust/aleo_ffi/docs/network-io-to-dart.md
@@ -87,6 +87,20 @@ for the consensus version, so it cannot be omitted:
 - `execution_fee_authorization(private_key, execution, fee_credits, fee_record, height)`
   — base fee derived from `height`, pure.
 
+**Phase-1 symbol names — these cannot reuse the old symbols.** `execute_proof`,
+`execute_fee_proof`, `execute_program_proof` already exist as exports with the
+*old* parameter lists and Dart looks them up by exactly those names; a cdylib
+cannot export two different ABIs under one symbol, and silently replacing them
+would feed old callers into native code with the wrong signature. So phase 1
+ships the new functions under **distinct symbols** — `execute_proof_static`,
+`execute_fee_proof_static`, `execute_program_proof_static`,
+`get_base_fee_static`, `execution_fee_authorization_static` — alongside the
+untouched old exports. Only in phase 3, once Dart no longer looks up the old
+names, are the old exports deleted (and the `_static` names optionally renamed to
+the canonical ones in lockstep with the Dart `lookupFunction` calls, since a
+rename is itself an ABI change). The names above are the *target* shapes; read
+them with the `_static` suffix until phase 3.
+
 **Root handling (no protocol parsing in Dart).** Dart has no `StatePath`
 parser, and Rust parses the paths anyway, so Rust — not Dart — derives the root:
 
@@ -100,6 +114,22 @@ parser, and Rust parses the paths anyway, so Rust — not Dart — derives the r
 So Dart only ever passes through opaque strings it got from the node: the path
 strings from `statePaths`, or the root string from `latest/stateRoot`. It never
 parses snarkVM types.
+
+**`state_paths_json` is untrusted node input too — budget + exact-match it.**
+A malicious node can return a huge array or huge path strings to exhaust Dart's
+response buffer or Rust's serde. Bounds, both sides:
+
+- *Dart (fetch side):* cap the `statePaths` response bytes and entry count
+  before buffering the whole body.
+- *Rust (parse side):* check the raw `state_paths_json` byte length and entry
+  count **before** deserializing, then require the parsed paths' commitment set
+  to **exactly equal `required_commitments(authorization)`** — no extra, no
+  missing. This is both a correctness check (you prove inclusion for exactly the
+  records being spent) and a tight, protocol-grounded count bound: the required
+  commitments are bounded by the execution's inputs (`MAX_INPUTS` per transition
+  × `MAX_TRANSITIONS`), so a node cannot inflate the path count beyond what the
+  transaction actually needs. `public_state_root` is similarly length-checked
+  before parsing.
 
 `program_sources_json`: a JSON array of `{id, edition, source}` the caller has
 already fetched (closure included, any order). Rust validates ids, loads
@@ -152,13 +182,15 @@ strings only:
 **Height vs the snapshot — not automatically harmless.** `height` selects the
 consensus version, which changes at specific upgrade heights. If `height` and
 the root/paths straddle such an upgrade height, proving applies the wrong rules
-and fails. So height is not "a block of slack for free": the caller must ensure
-`height` maps to the **same consensus version** as the snapshot. Practical rule
-for `AleoNode`: read height, take the snapshot, re-read height; if
-`CONSENSUS_VERSION(h_before) != CONSENSUS_VERSION(h_after)` an upgrade landed
-mid-snapshot — retry. A `consensus_version_for(height) -> u16` helper (pure,
-wrapping `Net::CONSENSUS_VERSION`) lets Dart make this check without hardcoding
-upgrade heights.
+and fails. So height is not "a block of slack for free": the caller pins one
+`height`/`version` for the **whole** transaction and verifies it is unchanged
+after the snapshots. A `consensus_version_for(height) -> u16` helper (pure,
+wrapping `Net::CONSENSUS_VERSION`) lets Dart check without hardcoding upgrade
+heights. Because a transaction takes two snapshots (execution and a private
+fee), the response to a mid-flow version change is **not** to re-snapshot one
+piece — every authorization and proof already generated was bound to the old
+version and must be discarded, and the whole flow restarts (see the orchestration
+steps, "Consistency gate").
 
 ## Dart responsibilities (new)
 
@@ -178,10 +210,15 @@ dependency of `aleo_dart`):
 The existing `AleoProgram` Dart methods keep their signatures where possible by
 orchestrating internally. The full flow has two independent inclusion snapshots
 — one for the execution, one for the fee — because a **private fee spends its
-own record**, so its proof needs its own state paths. `tryTransfer(...)` becomes:
+own record**, so its proof needs its own state paths. One height/consensus
+version is pinned for the **whole** transaction; the execution proof and the fee
+proof and the fee authorization are all bound to it, so a consensus upgrade
+landing mid-flow invalidates *everything* generated so far, not just the next
+snapshot. `tryTransfer(...)` becomes (with the whole thing wrapped in a
+bounded retry):
 
-1. `height = node.height()` (up front — every proof needs it; re-checked for
-   consensus-version stability per the snapshot contract).
+1. `height = node.height()`; `version = consensus_version_for(height)` — pinned
+   for the whole transaction.
 2. `exec = executionAuthorization(...)`.
 3. `execPaths = node.statePaths(required_commitments(exec))` — empty for a
    public transfer.
@@ -192,8 +229,15 @@ own record**, so its proof needs its own state paths. `tryTransfer(...)` becomes
    when the fee is private** (spends a fee record), empty for a public fee.
 7. `feeProof = executeFeeProof(feeAuth, height, feePaths, feePublicRoot)` with
    `feePublicRoot = feePaths.isEmpty ? node.stateRoot() : ""`.
-8. `tx = buildTransactionOffline(executionProof, feeProof)`.
-9. `node.broadcast(tx)`.
+8. **Consistency gate:** `consensus_version_for(node.height()) == version`?
+   If not, an upgrade landed mid-flow — **discard `exec`, `executionProof`,
+   `feeAuth`, `feeProof` and restart from step 1.** Re-snapshotting only the fee
+   while keeping the old `height`/`executionProof` would prove against a stale
+   version. (Each snapshot's paths are also self-consistent via the root
+   derivation, but only an all-or-nothing version pin keeps the two snapshots
+   *and* the pinned height mutually consistent.)
+9. `tx = buildTransactionOffline(executionProof, feeProof)`.
+10. `node.broadcast(tx)`.
 
 Steps 3–4 and 6–7 are the same snapshot contract applied twice, to two
 different commitment sets. So app-facing call sites change little, but the
@@ -236,13 +280,16 @@ rustls needed; see the GPL-removal plan).
 
 ## Migration plan (phased, each independently shippable)
 
-1. **Add pure primitives + helpers alongside the existing functions** (no
-   removals). New exports: `required_commitments`, `required_imports`,
-   `state_root_from_paths`, `consensus_version_for(height)`, the height-taking
-   proving variants (`execute_proof`/`execute_fee_proof`/`execute_program_proof`
-   with the `height, state_paths_json, public_state_root` shape), and a
-   `program_sources_json` parser carrying the count/byte budget. CI keeps the
-   old path green.
+1. **Add pure primitives + helpers under new symbol names, alongside the
+   existing functions** (no removals, no symbol reuse — see "Phase-1 symbol
+   names"). New exports: `required_commitments`, `required_imports`,
+   `state_root_from_paths`, `consensus_version_for(height)`, and the
+   `*_static` proving/fee variants (`execute_proof_static`,
+   `execute_fee_proof_static`, `execute_program_proof_static`,
+   `get_base_fee_static`, `execution_fee_authorization_static`) carrying the
+   `height, state_paths_json, public_state_root` shape and the program/path
+   resource budgets. The old `execute_proof` etc. stay exactly as they are, so
+   CI and current Dart keep working.
 2. **Move orchestration to Dart**: implement `AleoNode` + rewrite `AleoProgram`
    orchestration onto the pure primitives; keep method signatures stable.
    Parity-test new Dart pipeline vs the old FFI one against testnet.
@@ -266,11 +313,11 @@ rustls needed; see the GPL-removal plan).
   their own inclusion snapshot (different commitment sets). The orchestration
   must not share one snapshot across both — pinned by a private-fee parity test.
 - **Resource budget parity**: the count/byte budget must reject the same
-  oversized closures Dart's walk does; tested on both sides against a synthetic
-  oversized set.
-- **API churn**: app code calling the one-call functions directly (not via the
-  Dart wrapper) would change. Mitigated by keeping `AleoProgram` method
-  signatures stable in step 2.
+  oversized closures Dart's walk does, and the `state_paths_json` parser must
+  reject path sets that don't exactly match `required_commitments`; tested on
+  both sides against synthetic oversized/mismatched inputs.
+- **Consensus-version pin**: a parity/regression test that a version change
+  between the two snapshots restarts the whole flow rather than mixing versions.
 - **Effort**: ~12 FFI functions resigned, an `AleoNode` Dart class, and a
   parity pass. Bounded, but a real piece of work — hence its own phased PR set,
   not a rider on #51.

--- a/rust/aleo_ffi/docs/network-io-to-dart.md
+++ b/rust/aleo_ffi/docs/network-io-to-dart.md
@@ -63,25 +63,33 @@ StaticQuery::new(block_height: u32,
                  state_paths: HashMap<Field<N>, StatePath<N>>)
 ```
 
-`execute_authorization_raw` / `execute_fee_authorization_raw` only call
-`current_state_root` and `get_state_paths_for_commitments` on the query, both of
-which `StaticQuery` answers from its preloaded data. So proving is fully offline
-once the caller supplies `{height, state_root, state_paths}`.
+`execute_authorization_raw` / `execute_fee_authorization_raw` call
+`current_state_root`, `get_state_paths_for_commitments`, **and
+`current_block_height`** on the query (height selects the consensus version and
+feeds inclusion `prepare`), all of which `StaticQuery` answers from its
+preloaded data. So proving is fully offline once the caller supplies
+`{height, state_root, state_paths}` — note `height` is required, not optional:
+`StaticQuery::new` takes it as its first argument and a wrong/absent height
+yields an invalid query.
 
 ## New FFI shape
 
 ### Pure primitives (replace `url`/`network` with pre-fetched data)
 
-- `execute_proof(authorization, state_root, state_paths_json)` — build a
-  `StaticQuery` from the inputs; no HTTP.
-- `execute_fee_proof(authorization, state_root, state_paths_json)`.
-- `execute_program_proof(authorization, program_sources_json, state_root, state_paths_json)`.
+Every proving primitive takes `height` — proving reads `current_block_height`
+for the consensus version, so it cannot be omitted:
+
+- `execute_proof(authorization, height, state_root, state_paths_json)` — build a
+  `StaticQuery::new(height, state_root, paths)` from the inputs; no HTTP.
+- `execute_fee_proof(authorization, height, state_root, state_paths_json)`.
+- `execute_program_proof(authorization, program_sources_json, height, state_root, state_paths_json)`.
 - `get_base_fee(execution, height)` — height in, fee out, pure.
 - `execution_fee_authorization(private_key, execution, fee_credits, fee_record, height)`
   — base fee derived from `height`, pure.
 
 `state_paths_json`: a JSON array of snarkVM state-path strings; Rust parses each,
-keys it by its commitment, and assembles the `HashMap`. Empty for public flows.
+keys it by its commitment, and assembles the `HashMap`. Empty for public flows
+(see the state-root snapshot contract below for how `state_root` relates to it).
 
 `program_sources_json`: a JSON array of `{id, edition, source}` the caller has
 already fetched (closure included, topologically any order — Rust still
@@ -107,14 +115,42 @@ from Rust and **re-implemented in Dart** as compositions of the pure primitives
 `contract_fee_execution` likewise become Dart compositions over the program-proof
 primitives. `broadcast` is deleted (Dart does the POST).
 
+## State-root snapshot contract
+
+`statePaths?commitments=…` returns paths only, **not** the latest state root, so
+a separately-fetched `latest/stateRoot` can come from a different block than the
+paths. To keep one consistent snapshot, the root is sourced differently per flow
+and Rust verifies it:
+
+- **Private flows (≥1 commitment):** do **not** fetch `latest/stateRoot`. Every
+  returned `StatePath` carries a `global_state_root()`; they must all agree
+  (snarkVM's inclusion prepare already enforces this). Dart derives the snapshot
+  root from the paths and passes it as `state_root`; Rust **rejects** the call
+  if any supplied path's `global_state_root` differs from `state_root` or from
+  the others. This makes the root and the paths a single verified snapshot.
+- **Public flows (no commitments → no paths):** there is no path to derive from,
+  so Dart fetches `latest/stateRoot` and passes it; `state_paths_json` is empty.
+  Inclusion proving uses this root directly (snarkVM falls back to
+  `current_state_root` when there are no paths).
+
+`height` is fetched once alongside, and may lag the root by a block without harm
+(it only selects the consensus version); the root↔paths consistency above is the
+part that must be atomic.
+
 ## Dart responsibilities (new)
 
-A small `AleoNode` Dart class owns all node I/O with `dio`/`http`:
+A small `AleoNode` Dart class owns all node I/O with **`dio`** (already a
+dependency of `aleo_dart`):
 
 - `latestHeight()`, `latestStateRoot()`, `statePaths(commitments)`,
   `programSource(id)` (+ closure walk via `required_imports`), `broadcast(tx)`.
-- Real timeouts / retries / cancellation via `Future.timeout`, `CancelToken` —
-  where they are natural and correct.
+- **Real cancellation, not just `Future.timeout`.** `Future.timeout` only stops
+  *awaiting* — the underlying socket keeps running, which would recreate the
+  abandoned-worker resource leak we are leaving Rust to escape. So every request
+  carries a `dio` `CancelToken`; on timeout we `cancelToken.cancel()` (which
+  aborts the HTTP request), and `dio`'s own `connectTimeout` / `receiveTimeout`
+  bound the connect and read phases. `Future.timeout` is at most a belt-and-
+  suspenders outer guard, never described as the cancellation mechanism.
 
 The existing `AleoProgram` Dart methods keep their signatures where possible by
 orchestrating internally: e.g. `tryTransfer(...)` becomes
@@ -150,12 +186,12 @@ rustls needed; see the GPL-removal plan).
 
 ## Open questions / risks
 
-- **State-path correctness across blocks**: Dart must fetch state root + all
-  state paths atomically (one batch `statePaths?commitments=`, as the in-Rust
-  fix already does) so every path shares one global root. The
-  `required_commitments` helper must return *exactly* the set snarkVM will ask
-  for during proving — to be pinned by a parity test against the current
-  `NodeQuery` path before deleting it.
+- **State-path correctness across blocks**: handled by the state-root snapshot
+  contract above (derive the root from the batch `statePaths` response for
+  private flows; fetch it separately only for public ones; Rust verifies the
+  paths agree). The `required_commitments` helper must return *exactly* the set
+  snarkVM will ask for during proving — to be pinned by a parity test against
+  the current `NodeQuery` path before deleting it.
 - **API churn**: app code calling the one-call functions directly (not via the
   Dart wrapper) would change. Mitigated by keeping `AleoProgram` method
   signatures stable in step 2.

--- a/rust/aleo_ffi/docs/network-io-to-dart.md
+++ b/rust/aleo_ffi/docs/network-io-to-dart.md
@@ -79,32 +79,48 @@ yields an invalid query.
 Every proving primitive takes `height` — proving reads `current_block_height`
 for the consensus version, so it cannot be omitted:
 
-- `execute_proof(authorization, height, state_root, state_paths_json)` — build a
-  `StaticQuery::new(height, state_root, paths)` from the inputs; no HTTP.
-- `execute_fee_proof(authorization, height, state_root, state_paths_json)`.
-- `execute_program_proof(authorization, program_sources_json, height, state_root, state_paths_json)`.
+- `execute_proof(authorization, height, state_paths_json, public_state_root)`
+  — builds the `StaticQuery` and proves; no HTTP.
+- `execute_fee_proof(authorization, height, state_paths_json, public_state_root)`.
+- `execute_program_proof(authorization, program_sources_json, height, state_paths_json, public_state_root)`.
 - `get_base_fee(execution, height)` — height in, fee out, pure.
 - `execution_fee_authorization(private_key, execution, fee_credits, fee_record, height)`
   — base fee derived from `height`, pure.
 
-`state_paths_json`: a JSON array of snarkVM state-path strings; Rust parses each,
-keys it by its commitment, and assembles the `HashMap`. Empty for public flows
-(see the state-root snapshot contract below for how `state_root` relates to it).
+**Root handling (no protocol parsing in Dart).** Dart has no `StatePath`
+parser, and Rust parses the paths anyway, so Rust — not Dart — derives the root:
+
+- `state_paths_json` non-empty (private flows): Rust parses each path, verifies
+  they all carry the same `global_state_root`, and builds
+  `StaticQuery::new(height, that_root, map)`. `public_state_root` must be empty
+  (or, if supplied, must equal the derived root) — Rust rejects a mismatch.
+- `state_paths_json` empty (public flows): Rust builds the query from
+  `public_state_root` (the opaque `latest/stateRoot` string Dart fetched).
+
+So Dart only ever passes through opaque strings it got from the node: the path
+strings from `statePaths`, or the root string from `latest/stateRoot`. It never
+parses snarkVM types.
 
 `program_sources_json`: a JSON array of `{id, edition, source}` the caller has
-already fetched (closure included, topologically any order — Rust still
-validates ids and loads imports-before-importers from the supplied set, with the
-existing cycle / id-mismatch / `MAX_PROGRAM_SIZE` checks, now over an in-memory
-set rather than the network).
+already fetched (closure included, any order). Rust validates ids, loads
+imports-before-importers from the supplied set, and applies the existing cycle /
+id-mismatch / `MAX_PROGRAM_SIZE` checks **plus a program-count and total-byte
+budget** (see "Resource budgets survive the move" below) — now over an in-memory
+set rather than the network.
 
 ### New pure helpers (so Dart knows what to fetch)
 
 - `required_commitments(authorization_json) -> JSON [field]` — the input-record
   commitments whose state paths the caller must fetch before proving. Empty for
-  public transfers.
+  public transfers. **Called once per authorization** — both the execution
+  authorization and (separately) the fee authorization, since a private fee
+  spends its own record (see the example flow).
 - `required_imports(program_source) -> JSON [program_id]` — direct imports of a
   program, so Dart can walk the closure it must fetch. (Dart recurses; Rust
   stays a pure per-program function.)
+- `state_root_from_paths(state_paths_json) -> field` — optional convenience if
+  Dart needs the snapshot root for logging/caching; not required for proving
+  (the proving primitives derive it themselves, above).
 
 ### Removed exports
 
@@ -119,23 +135,30 @@ primitives. `broadcast` is deleted (Dart does the POST).
 
 `statePaths?commitments=…` returns paths only, **not** the latest state root, so
 a separately-fetched `latest/stateRoot` can come from a different block than the
-paths. To keep one consistent snapshot, the root is sourced differently per flow
-and Rust verifies it:
+paths. To keep one consistent snapshot, the root is sourced differently per flow,
+and (per finding above) Rust derives and verifies it — Dart passes opaque
+strings only:
 
 - **Private flows (≥1 commitment):** do **not** fetch `latest/stateRoot`. Every
-  returned `StatePath` carries a `global_state_root()`; they must all agree
-  (snarkVM's inclusion prepare already enforces this). Dart derives the snapshot
-  root from the paths and passes it as `state_root`; Rust **rejects** the call
-  if any supplied path's `global_state_root` differs from `state_root` or from
-  the others. This makes the root and the paths a single verified snapshot.
+  returned `StatePath` carries a `global_state_root`; Rust parses the paths,
+  **rejects** the call unless they all agree, and uses that shared root. The
+  root and the paths are thus one verified snapshot with no second fetch to
+  straddle a block.
 - **Public flows (no commitments → no paths):** there is no path to derive from,
-  so Dart fetches `latest/stateRoot` and passes it; `state_paths_json` is empty.
-  Inclusion proving uses this root directly (snarkVM falls back to
-  `current_state_root` when there are no paths).
+  so Dart fetches `latest/stateRoot` and passes it as `public_state_root`;
+  `state_paths_json` is empty. Inclusion proving uses this root directly
+  (snarkVM falls back to `current_state_root` when there are no paths).
 
-`height` is fetched once alongside, and may lag the root by a block without harm
-(it only selects the consensus version); the root↔paths consistency above is the
-part that must be atomic.
+**Height vs the snapshot — not automatically harmless.** `height` selects the
+consensus version, which changes at specific upgrade heights. If `height` and
+the root/paths straddle such an upgrade height, proving applies the wrong rules
+and fails. So height is not "a block of slack for free": the caller must ensure
+`height` maps to the **same consensus version** as the snapshot. Practical rule
+for `AleoNode`: read height, take the snapshot, re-read height; if
+`CONSENSUS_VERSION(h_before) != CONSENSUS_VERSION(h_after)` an upgrade landed
+mid-snapshot — retry. A `consensus_version_for(height) -> u16` helper (pure,
+wrapping `Net::CONSENSUS_VERSION`) lets Dart make this check without hardcoding
+upgrade heights.
 
 ## Dart responsibilities (new)
 
@@ -153,18 +176,59 @@ dependency of `aleo_dart`):
   suspenders outer guard, never described as the cancellation mechanism.
 
 The existing `AleoProgram` Dart methods keep their signatures where possible by
-orchestrating internally: e.g. `tryTransfer(...)` becomes
-`authorize → node.statePaths(required_commitments) → executeProof →
-node.height → feeAuthorize → executeFeeProof → buildTransactionOffline →
-node.broadcast`, so app-facing call sites change little.
+orchestrating internally. The full flow has two independent inclusion snapshots
+— one for the execution, one for the fee — because a **private fee spends its
+own record**, so its proof needs its own state paths. `tryTransfer(...)` becomes:
+
+1. `height = node.height()` (up front — every proof needs it; re-checked for
+   consensus-version stability per the snapshot contract).
+2. `exec = executionAuthorization(...)`.
+3. `execPaths = node.statePaths(required_commitments(exec))` — empty for a
+   public transfer.
+4. `executionProof = executeProof(exec, height, execPaths, publicRoot)` where
+   `publicRoot = execPaths.isEmpty ? node.stateRoot() : ""`.
+5. `feeAuth = executionFeeAuthorization(..., height)`.
+6. `feePaths = node.statePaths(required_commitments(feeAuth))` — **non-empty
+   when the fee is private** (spends a fee record), empty for a public fee.
+7. `feeProof = executeFeeProof(feeAuth, height, feePaths, feePublicRoot)` with
+   `feePublicRoot = feePaths.isEmpty ? node.stateRoot() : ""`.
+8. `tx = buildTransactionOffline(executionProof, feeProof)`.
+9. `node.broadcast(tx)`.
+
+Steps 3–4 and 6–7 are the same snapshot contract applied twice, to two
+different commitment sets. So app-facing call sites change little, but the
+orchestration is not a single linear fetch — the fee path is its own snapshot.
+
+## Resource budgets survive the move
+
+Moving HTTP to Dart does **not** remove the malicious-node risk it was added to
+contain: a node can still answer an endless *acyclic* chain of distinct valid
+programs. Now the Dart closure walk would fetch forever, and the assembled
+`program_sources_json` would grow without limit — `MAX_PROGRAM_SIZE` caps one
+program, not the set. So the **count + total-byte budget is kept, on both
+sides**, even though the HTTP/threading/deadline machinery is deleted:
+
+- **Dart (fetch side):** the closure walk via `required_imports` enforces a
+  max-program-count and cumulative-byte budget (and a wall-clock budget, now
+  natural with `dio`/`CancelToken`); it stops and errors rather than fetch an
+  unbounded chain.
+- **Rust (parse side):** parsing `program_sources_json` re-checks a program
+  count cap and a total-byte cap (not just per-program `MAX_PROGRAM_SIZE`),
+  since Rust must not trust the caller's set blindly either.
+
+Only the *time/deadline* and *worker-thread* parts of the budget are dropped
+(no blocking I/O left in Rust to bound); the *size* parts persist.
 
 ## Deleted from Rust
 
 `ureq` dependency; `http_agent`, `http_get`, `http_get_until`, `http_post`,
-`request_once_bounded`, `InflightPermit`/`MAX_INFLIGHT_REQUESTS`; `LoadBudget`
-and the whole import-load budget; `NodeQuery`'s HTTP impl (replaced by building
-`StaticQuery` from caller JSON); `node_latest_edition`, `add_program_from_node`
-(network), `broadcast_to_node`. The worker-thread/deadline tests go with them.
+`request_once_bounded`, `InflightPermit`/`MAX_INFLIGHT_REQUESTS`; the
+*time/thread* part of `LoadBudget` (the wall-clock deadline, `get_once_bounded`
+plumbing) — **but not** its size budget, which moves to the `program_sources_json`
+parser per above; `NodeQuery`'s HTTP impl (replaced by building `StaticQuery`
+from caller JSON); `node_latest_edition`, `add_program_from_node` (network),
+`broadcast_to_node`. The worker-thread/deadline tests go with them; the
+program-count/byte-budget tests are kept and re-pointed at the parser.
 
 Result: the Rust crate makes **zero network calls** and links no HTTP stack —
 which also simplifies the pending iOS/Android cross-compile (no curl/OpenSSL or
@@ -174,8 +238,11 @@ rustls needed; see the GPL-removal plan).
 
 1. **Add pure primitives + helpers alongside the existing functions** (no
    removals). New exports: `required_commitments`, `required_imports`,
-   `*_static` proving variants, `get_base_fee_at(height)`. CI keeps the old
-   path green.
+   `state_root_from_paths`, `consensus_version_for(height)`, the height-taking
+   proving variants (`execute_proof`/`execute_fee_proof`/`execute_program_proof`
+   with the `height, state_paths_json, public_state_root` shape), and a
+   `program_sources_json` parser carrying the count/byte budget. CI keeps the
+   old path green.
 2. **Move orchestration to Dart**: implement `AleoNode` + rewrite `AleoProgram`
    orchestration onto the pure primitives; keep method signatures stable.
    Parity-test new Dart pipeline vs the old FFI one against testnet.
@@ -192,6 +259,15 @@ rustls needed; see the GPL-removal plan).
   paths agree). The `required_commitments` helper must return *exactly* the set
   snarkVM will ask for during proving — to be pinned by a parity test against
   the current `NodeQuery` path before deleting it.
+- **API churn**: app code calling the one-call functions directly (not via the
+  Dart wrapper) would change. Mitigated by keeping `AleoProgram` method
+  signatures stable in step 2.
+- **Two snapshots per transaction**: the execution and a private fee each need
+  their own inclusion snapshot (different commitment sets). The orchestration
+  must not share one snapshot across both — pinned by a private-fee parity test.
+- **Resource budget parity**: the count/byte budget must reject the same
+  oversized closures Dart's walk does; tested on both sides against a synthetic
+  oversized set.
 - **API churn**: app code calling the one-call functions directly (not via the
   Dart wrapper) would change. Mitigated by keeping `AleoProgram` method
   signatures stable in step 2.

--- a/rust/aleo_ffi/docs/network-io-to-dart.md
+++ b/rust/aleo_ffi/docs/network-io-to-dart.md
@@ -1,0 +1,164 @@
+# Design: move network I/O out of `aleo_ffi` into Dart
+
+Status: **proposed** (spec only; no code yet)
+Owner: aleo_ffi
+Supersedes: the in-Rust HTTP hardening accreted across PR #51 review rounds 5–13.
+
+## Why
+
+Every network-robustness finding on PR #51 (rounds 5, 7, 9, 10, 11, 12, 13 —
+timeouts, retries, batch state paths, import-depth, unbounded import load,
+deadline coverage, connect/DNS, broadcast hang, thread accumulation) has one
+root: **`aleo_ffi` performs blocking network I/O inside synchronous FFI
+calls.** With `ureq` + uninterruptible DNS + a synchronous C ABI, a *hard*
+in-process bound is not achievable — each fix shrinks the leak and the next
+review finds the next one. The worker-thread + budget machinery is the best
+in-process approximation, but it is machinery defending an inherently leaky
+shape.
+
+Moving all HTTP to the Dart layer — which has a real async runtime with proper
+timeouts and cancellation — makes the Rust functions **pure compute** over
+pre-fetched inputs. That deletes the entire finding class instead of shrinking
+it: no `ureq`, no DNS, no worker threads, no deadlines, no retry/budget code in
+Rust at all.
+
+## Current network surface
+
+19 of the 31 exports are already pure (account, record, offline authorization
+and assembly). **12 touch the network:**
+
+| FFI export | Needs from node |
+|---|---|
+| `get_base_fee` | block height (→ consensus version) |
+| `execution_fee_authorization` | block height (base fee) |
+| `execute_proof` | state root + state paths |
+| `execute_fee_proof` | state root + state paths |
+| `execute_program_proof` | program source(s) + state root + state paths |
+| `build_transaction` | height + state root/paths (full pipeline) |
+| `try_transfer` | height + state root/paths + **broadcast POST** |
+| `try_join` | height + state root/paths + **broadcast POST** |
+| `execute_program` | program source(s) + height + state/paths + **broadcast POST** |
+| `contract_execution` | program source(s) + state root/paths |
+| `contract_fee_execution` | program source(s) + height |
+| `broadcast` | **broadcast POST** only |
+
+So the node provides exactly **four** kinds of data:
+
+1. **block height** (`latest/height`) — `u32`.
+2. **state root** (`latest/stateRoot`).
+3. **state paths** for a set of commitments (`statePaths?commitments=…`) — only
+   for record-spending (private / private-fee / join) flows.
+4. **program source at edition** (`/program/{id}/latest_edition`,
+   `/program/{id}/{edition}`) — only for non-builtin programs.
+
+Plus the one **write**: broadcast `POST transaction/broadcast`.
+
+## Key enabler (verified)
+
+snarkVM's `StaticQuery<N>` already carries exactly what proving needs:
+
+```rust
+StaticQuery::new(block_height: u32,
+                 state_root: N::StateRoot,
+                 state_paths: HashMap<Field<N>, StatePath<N>>)
+```
+
+`execute_authorization_raw` / `execute_fee_authorization_raw` only call
+`current_state_root` and `get_state_paths_for_commitments` on the query, both of
+which `StaticQuery` answers from its preloaded data. So proving is fully offline
+once the caller supplies `{height, state_root, state_paths}`.
+
+## New FFI shape
+
+### Pure primitives (replace `url`/`network` with pre-fetched data)
+
+- `execute_proof(authorization, state_root, state_paths_json)` — build a
+  `StaticQuery` from the inputs; no HTTP.
+- `execute_fee_proof(authorization, state_root, state_paths_json)`.
+- `execute_program_proof(authorization, program_sources_json, state_root, state_paths_json)`.
+- `get_base_fee(execution, height)` — height in, fee out, pure.
+- `execution_fee_authorization(private_key, execution, fee_credits, fee_record, height)`
+  — base fee derived from `height`, pure.
+
+`state_paths_json`: a JSON array of snarkVM state-path strings; Rust parses each,
+keys it by its commitment, and assembles the `HashMap`. Empty for public flows.
+
+`program_sources_json`: a JSON array of `{id, edition, source}` the caller has
+already fetched (closure included, topologically any order — Rust still
+validates ids and loads imports-before-importers from the supplied set, with the
+existing cycle / id-mismatch / `MAX_PROGRAM_SIZE` checks, now over an in-memory
+set rather than the network).
+
+### New pure helpers (so Dart knows what to fetch)
+
+- `required_commitments(authorization_json) -> JSON [field]` — the input-record
+  commitments whose state paths the caller must fetch before proving. Empty for
+  public transfers.
+- `required_imports(program_source) -> JSON [program_id]` — direct imports of a
+  program, so Dart can walk the closure it must fetch. (Dart recurses; Rust
+  stays a pure per-program function.)
+
+### Removed exports
+
+The one-call orchestration functions that bundled network I/O —
+`build_transaction`, `try_transfer`, `try_join`, `execute_program` — are dropped
+from Rust and **re-implemented in Dart** as compositions of the pure primitives
+(authorize → fetch → prove → assemble → broadcast). `contract_execution` /
+`contract_fee_execution` likewise become Dart compositions over the program-proof
+primitives. `broadcast` is deleted (Dart does the POST).
+
+## Dart responsibilities (new)
+
+A small `AleoNode` Dart class owns all node I/O with `dio`/`http`:
+
+- `latestHeight()`, `latestStateRoot()`, `statePaths(commitments)`,
+  `programSource(id)` (+ closure walk via `required_imports`), `broadcast(tx)`.
+- Real timeouts / retries / cancellation via `Future.timeout`, `CancelToken` —
+  where they are natural and correct.
+
+The existing `AleoProgram` Dart methods keep their signatures where possible by
+orchestrating internally: e.g. `tryTransfer(...)` becomes
+`authorize → node.statePaths(required_commitments) → executeProof →
+node.height → feeAuthorize → executeFeeProof → buildTransactionOffline →
+node.broadcast`, so app-facing call sites change little.
+
+## Deleted from Rust
+
+`ureq` dependency; `http_agent`, `http_get`, `http_get_until`, `http_post`,
+`request_once_bounded`, `InflightPermit`/`MAX_INFLIGHT_REQUESTS`; `LoadBudget`
+and the whole import-load budget; `NodeQuery`'s HTTP impl (replaced by building
+`StaticQuery` from caller JSON); `node_latest_edition`, `add_program_from_node`
+(network), `broadcast_to_node`. The worker-thread/deadline tests go with them.
+
+Result: the Rust crate makes **zero network calls** and links no HTTP stack —
+which also simplifies the pending iOS/Android cross-compile (no curl/OpenSSL or
+rustls needed; see the GPL-removal plan).
+
+## Migration plan (phased, each independently shippable)
+
+1. **Add pure primitives + helpers alongside the existing functions** (no
+   removals). New exports: `required_commitments`, `required_imports`,
+   `*_static` proving variants, `get_base_fee_at(height)`. CI keeps the old
+   path green.
+2. **Move orchestration to Dart**: implement `AleoNode` + rewrite `AleoProgram`
+   orchestration onto the pure primitives; keep method signatures stable.
+   Parity-test new Dart pipeline vs the old FFI one against testnet.
+3. **Delete the in-Rust network code** and the now-unused exports once Dart no
+   longer calls them; drop `ureq`.
+4. **Re-point cross-compile** (no HTTP stack) — folds into the GPL-removal /
+   mobile-build work.
+
+## Open questions / risks
+
+- **State-path correctness across blocks**: Dart must fetch state root + all
+  state paths atomically (one batch `statePaths?commitments=`, as the in-Rust
+  fix already does) so every path shares one global root. The
+  `required_commitments` helper must return *exactly* the set snarkVM will ask
+  for during proving — to be pinned by a parity test against the current
+  `NodeQuery` path before deleting it.
+- **API churn**: app code calling the one-call functions directly (not via the
+  Dart wrapper) would change. Mitigated by keeping `AleoProgram` method
+  signatures stable in step 2.
+- **Effort**: ~12 FFI functions resigned, an `AleoNode` Dart class, and a
+  parity pass. Bounded, but a real piece of work — hence its own phased PR set,
+  not a rider on #51.

--- a/rust/aleo_ffi/src/lib.rs
+++ b/rust/aleo_ffi/src/lib.rs
@@ -549,10 +549,7 @@ pub unsafe extern "C" fn build_transaction(
     };
     match inner() {
         Ok(transaction) => to_cstring(transaction),
-        Err(error) => {
-            eprintln!("[build_transaction] {error:?}");
-            to_cstring(String::new())
-        }
+        Err(_) => to_cstring(String::new()),
     }
 }
 
@@ -592,10 +589,7 @@ pub unsafe extern "C" fn try_transfer(
     };
     match inner() {
         Ok(response) => to_cstring(response),
-        Err(error) => {
-            eprintln!("[try_transfer] {error:?}");
-            to_cstring(String::new())
-        }
+        Err(_) => to_cstring(String::new()),
     }
 }
 
@@ -630,10 +624,7 @@ pub unsafe extern "C" fn execute_program(
     };
     match inner() {
         Ok(response) => to_cstring(response),
-        Err(error) => {
-            eprintln!("[execute_program] {error:?}");
-            to_cstring(String::new())
-        }
+        Err(_) => to_cstring(String::new()),
     }
 }
 
@@ -663,10 +654,7 @@ pub unsafe extern "C" fn execute_program_proof(
     };
     match inner() {
         Ok(execution) => to_cstring(execution),
-        Err(error) => {
-            eprintln!("[execute_program_proof] {error:?}");
-            to_cstring(String::new())
-        }
+        Err(_) => to_cstring(String::new()),
     }
 }
 
@@ -697,10 +685,7 @@ pub unsafe extern "C" fn contract_execution(
     };
     match inner() {
         Ok(execution) => to_cstring(execution),
-        Err(error) => {
-            eprintln!("[contract_execution] {error:?}");
-            to_cstring(String::new())
-        }
+        Err(_) => to_cstring(String::new()),
     }
 }
 
@@ -729,10 +714,7 @@ pub unsafe extern "C" fn contract_fee_execution(
     };
     match inner() {
         Ok(fee) => to_cstring(fee),
-        Err(error) => {
-            eprintln!("[contract_fee_execution] {error:?}");
-            to_cstring(String::new())
-        }
+        Err(_) => to_cstring(String::new()),
     }
 }
 
@@ -758,10 +740,7 @@ pub unsafe extern "C" fn join_authorization(
     };
     match inner() {
         Ok(authorization) => to_cstring(authorization),
-        Err(error) => {
-            eprintln!("[join_authorization] {error:?}");
-            to_cstring(String::new())
-        }
+        Err(_) => to_cstring(String::new()),
     }
 }
 
@@ -796,10 +775,7 @@ pub unsafe extern "C" fn try_join(
     };
     match inner() {
         Ok(response) => to_cstring(response),
-        Err(error) => {
-            eprintln!("[try_join] {error:?}");
-            to_cstring(String::new())
-        }
+        Err(_) => to_cstring(String::new()),
     }
 }
 
@@ -852,10 +828,7 @@ pub unsafe extern "C" fn execute_proof(
     };
     match inner() {
         Ok(execution) => to_cstring(execution),
-        Err(error) => {
-            eprintln!("[execute_proof] {error:?}");
-            to_cstring(String::new())
-        }
+        Err(_) => to_cstring(String::new()),
     }
 }
 
@@ -880,10 +853,7 @@ pub unsafe extern "C" fn broadcast(
     };
     match inner() {
         Ok(response) => to_cstring(response),
-        Err(error) => {
-            eprintln!("[broadcast] {error:?}");
-            to_cstring(String::new())
-        }
+        Err(_) => to_cstring(String::new()),
     }
 }
 
@@ -937,10 +907,7 @@ pub unsafe extern "C" fn execution_fee_authorization(
     };
     match inner() {
         Ok(authorization) => to_cstring(authorization),
-        Err(error) => {
-            eprintln!("[execution_fee_authorization] {error:?}");
-            to_cstring(String::new())
-        }
+        Err(_) => to_cstring(String::new()),
     }
 }
 
@@ -963,10 +930,7 @@ pub unsafe extern "C" fn execute_fee_proof(
     };
     match inner() {
         Ok(fee) => to_cstring(fee),
-        Err(error) => {
-            eprintln!("[execute_fee_proof] {error:?}");
-            to_cstring(String::new())
-        }
+        Err(_) => to_cstring(String::new()),
     }
 }
 

--- a/rust/aleo_ffi/src/lib.rs
+++ b/rust/aleo_ffi/src/lib.rs
@@ -75,6 +75,9 @@ pub extern "C" fn numbers_add(a: c_int, b: c_int) -> c_int {
 /// SAFETY: `seed` must point to at least 32 readable bytes.
 #[no_mangle]
 pub unsafe extern "C" fn seed_to_private_key(seed: *const u8) -> *mut c_char {
+    if seed.is_null() {
+        return to_cstring(String::new());
+    }
     let bytes = slice::from_raw_parts(seed, 32);
     // Reduce the 32-byte seed modulo the field order. A raw 32-byte value
     // exceeds the BLS12-377 scalar field ~93% of the time, so the canonical
@@ -120,11 +123,15 @@ pub unsafe extern "C" fn view_key_to_address(vk: *const c_char) -> *mut c_char {
     to_cstring(result.unwrap_or_default())
 }
 
-/// Returns "" on a malformed key or signing failure (no panic across the FFI
-/// boundary). SAFETY: `pk` is a NUL-terminated C string; `msg` points to `len`
-/// readable bytes.
+/// Returns "" on a malformed key, a null/negative-length message, or signing
+/// failure (no panic across the FFI boundary). SAFETY: `pk` is a
+/// NUL-terminated C string; `msg` points to `len` readable bytes.
 #[no_mangle]
 pub unsafe extern "C" fn sign_message(pk: *const c_char, msg: *const u8, len: c_int) -> *mut c_char {
+    // A negative length would wrap to a huge usize and read out of bounds.
+    if msg.is_null() || len < 0 {
+        return to_cstring(String::new());
+    }
     let message = slice::from_raw_parts(msg, len as usize);
     let result = (|| -> Option<String> {
         let private_key = PrivateKey::<Net>::from_str(read_str(pk)).ok()?;
@@ -133,7 +140,8 @@ pub unsafe extern "C" fn sign_message(pk: *const c_char, msg: *const u8, len: c_
     to_cstring(result.unwrap_or_default())
 }
 
-/// Returns 1 if the signature is valid, 0 otherwise.
+/// Returns 1 if the signature is valid, 0 otherwise (including for a
+/// null/negative-length message).
 ///
 /// SAFETY: `addr`/`sig` are NUL-terminated C strings; `msg` points to `len` readable bytes.
 #[no_mangle]
@@ -143,6 +151,10 @@ pub unsafe extern "C" fn verify(
     msg: *const u8,
     len: c_int,
 ) -> c_int {
+    // A negative length would wrap to a huge usize and read out of bounds.
+    if msg.is_null() || len < 0 {
+        return 0;
+    }
     let address = match Address::<Net>::from_str(read_str(addr)) {
         Ok(address) => address,
         Err(_) => return 0,
@@ -464,7 +476,7 @@ fn plaintext_record_typed(
 fn transfer_inputs(
     function: &str,
     recipient: &str,
-    amount: i64,
+    amount: u64,
     amount_record: &str,
     private_key: &PrivateKey<Net>,
 ) -> anyhow::Result<Vec<String>> {
@@ -525,6 +537,10 @@ fn node_latest_edition(base: &str, program_id: &str) -> anyhow::Result<u16> {
     Ok(body.trim().trim_matches('"').parse()?)
 }
 
+/// Cap on the import-chain depth accepted from a node. Real Aleo import graphs
+/// are a few levels deep; anything past this is a malicious or broken node.
+const MAX_IMPORT_DEPTH: usize = 16;
+
 /// Fetches a non-builtin program from the node and adds it to the VM, loading
 /// every imported program first (snarkVM rejects a program whose imports are
 /// not already present). A no-op for built-in programs like credits.aleo or any
@@ -537,34 +553,72 @@ fn node_latest_edition(base: &str, program_id: &str) -> anyhow::Result<u16> {
 /// non-upgradeable programs are edition 1, upgraded programs their bumped
 /// edition. A wrong edition would yield a proof that disagrees with chain state,
 /// so any failure to determine it (e.g. a node without the route) propagates.
+///
+/// The node's responses are not trusted: the returned source must declare the
+/// requested program ID, an import cycle (`a -> b -> a`, only possible if the
+/// node lies, since on-chain programs can only import pre-existing ones) is
+/// rejected rather than recursed into, and the chain depth is capped by
+/// [`MAX_IMPORT_DEPTH`] so a hostile node cannot overflow the stack.
 fn add_program_from_node(
     vm: &VM<Net, ConsensusMemory<Net>>,
     program_id: &str,
     url: &str,
     network: &str,
 ) -> anyhow::Result<()> {
+    add_program_from_node_guarded(vm, program_id, url, network, &mut Vec::new())
+}
+
+/// [`add_program_from_node`] with the in-progress import chain (`visiting`)
+/// threaded through the recursion for cycle and depth checks.
+fn add_program_from_node_guarded(
+    vm: &VM<Net, ConsensusMemory<Net>>,
+    program_id: &str,
+    url: &str,
+    network: &str,
+    visiting: &mut Vec<String>,
+) -> anyhow::Result<()> {
+    let requested = ProgramID::<Net>::from_str(program_id)?;
+    let program_id = requested.to_string();
+
     // Skip built-ins and anything already loaded (without holding the lock
     // across the recursion below).
     {
         let process = vm.process();
         let process = process.read();
-        if program_id == "credits.aleo"
-            || process.contains_program(&ProgramID::from_str(program_id)?)
-        {
+        if program_id == "credits.aleo" || process.contains_program(&requested) {
             return Ok(());
         }
     }
 
+    if visiting.iter().any(|id| id == &program_id) {
+        anyhow::bail!("node returned an import cycle: {} -> {program_id}", visiting.join(" -> "));
+    }
+    if visiting.len() >= MAX_IMPORT_DEPTH {
+        anyhow::bail!(
+            "import chain from node exceeds {MAX_IMPORT_DEPTH} levels at {program_id}: {}",
+            visiting.join(" -> ")
+        );
+    }
+
     let base = format!("{}/{}", url.trim_end_matches('/'), network);
-    let edition = node_latest_edition(&base, program_id)?;
+    let edition = node_latest_edition(&base, &program_id)?;
     let body = http_get(&format!("{base}/program/{program_id}/{edition}"))?;
     let source: String = serde_json::from_str(body.trim())?;
     let program = Program::<Net>::from_str(&source)?;
+    if program.id() != &requested {
+        anyhow::bail!("node returned program '{}' for requested '{program_id}'", program.id());
+    }
 
     // Load imports (which may themselves import others) before this program.
-    for import_id in program.imports().keys() {
-        add_program_from_node(vm, &import_id.to_string(), url, network)?;
-    }
+    visiting.push(program_id);
+    let imports = (|| -> anyhow::Result<()> {
+        for import_id in program.imports().keys() {
+            add_program_from_node_guarded(vm, &import_id.to_string(), url, network, visiting)?;
+        }
+        Ok(())
+    })();
+    visiting.pop();
+    imports?;
 
     let process = vm.process();
     let mut process = process.write();
@@ -646,8 +700,8 @@ pub unsafe extern "C" fn build_transaction(
     private_key: *const c_char,
     recipient: *const c_char,
     transfer_type: *const c_char,
-    amount: c_int,
-    fee_credits: c_int,
+    amount: u64,
+    fee_credits: u64,
     url: *const c_char,
     amount_record: *const c_char,
     fee_record: *const c_char,
@@ -659,7 +713,7 @@ pub unsafe extern "C" fn build_transaction(
         let inputs = transfer_inputs(
             function,
             read_str(recipient),
-            amount as i64,
+            amount,
             read_str(amount_record),
             &private_key,
         )?;
@@ -668,7 +722,7 @@ pub unsafe extern "C" fn build_transaction(
             "credits.aleo",
             function,
             inputs,
-            fee_credits as u64,
+            fee_credits,
             read_str(fee_record),
             read_str(url),
             read_str(network),
@@ -689,8 +743,8 @@ pub unsafe extern "C" fn try_transfer(
     private_key: *const c_char,
     recipient: *const c_char,
     transfer_type: *const c_char,
-    amount: c_int,
-    fee_credits: c_int,
+    amount: u64,
+    fee_credits: u64,
     url: *const c_char,
     amount_record: *const c_char,
     fee_record: *const c_char,
@@ -702,7 +756,7 @@ pub unsafe extern "C" fn try_transfer(
         let inputs = transfer_inputs(
             function,
             read_str(recipient),
-            amount as i64,
+            amount,
             read_str(amount_record),
             &private_key,
         )?;
@@ -711,7 +765,7 @@ pub unsafe extern "C" fn try_transfer(
             "credits.aleo",
             function,
             inputs,
-            fee_credits as u64,
+            fee_credits,
             read_str(fee_record),
             read_str(url),
             read_str(network),
@@ -734,7 +788,7 @@ pub unsafe extern "C" fn execute_program(
     program_id: *const c_char,
     function_name: *const c_char,
     arguments: *const c_char,
-    fee: c_int,
+    fee: u64,
     url: *const c_char,
     network: *const c_char,
 ) -> *mut c_char {
@@ -746,7 +800,7 @@ pub unsafe extern "C" fn execute_program(
             read_str(program_id),
             read_str(function_name),
             inputs,
-            fee as u64,
+            fee,
             "",
             read_str(url),
             read_str(network),
@@ -824,7 +878,7 @@ pub unsafe extern "C" fn contract_execution(
 #[no_mangle]
 pub unsafe extern "C" fn contract_fee_execution(
     private_key: *const c_char,
-    fee: c_int,
+    fee: u64,
     execution: *const c_char,
     program_id: *const c_char,
     url: *const c_char,
@@ -834,7 +888,7 @@ pub unsafe extern "C" fn contract_fee_execution(
         let private_key = PrivateKey::<Net>::from_str(read_str(private_key))?;
         program_fee(
             &private_key,
-            fee as u64,
+            fee,
             read_str(execution),
             read_str(program_id),
             read_str(url),
@@ -885,7 +939,7 @@ pub unsafe extern "C" fn try_join(
     private_key: *const c_char,
     record_1: *const c_char,
     record_2: *const c_char,
-    fee_credits: c_int,
+    fee_credits: u64,
     fee_record: *const c_char,
     url: *const c_char,
     network: *const c_char,
@@ -901,7 +955,7 @@ pub unsafe extern "C" fn try_join(
             "credits.aleo",
             "join",
             inputs,
-            fee_credits as u64,
+            fee_credits,
             read_str(fee_record),
             read_str(url),
             read_str(network),
@@ -923,7 +977,7 @@ pub unsafe extern "C" fn execution_authorization(
     private_key: *const c_char,
     recipient: *const c_char,
     transfer_type: *const c_char,
-    amount: c_int,
+    amount: u64,
     _url: *const c_char,
     amount_record: *const c_char,
     _network: *const c_char,
@@ -934,7 +988,7 @@ pub unsafe extern "C" fn execution_authorization(
         let inputs = transfer_inputs(
             function,
             read_str(recipient),
-            amount as i64,
+            amount,
             read_str(amount_record),
             &private_key,
         )?;
@@ -1000,7 +1054,9 @@ pub unsafe extern "C" fn broadcast(
     }
 }
 
-/// Returns the base (minimum) fee in microcredits for a serialized execution.
+/// Returns the base (minimum) fee in microcredits for a serialized execution,
+/// or 0 on failure. u64, like every fee crossing this ABI: snarkVM fees are
+/// u64 microcredits and can legitimately exceed i32.
 ///
 /// SAFETY: the pointer args are NUL-terminated C strings.
 #[no_mangle]
@@ -1008,12 +1064,12 @@ pub unsafe extern "C" fn get_base_fee(
     url: *const c_char,
     execution: *const c_char,
     network: *const c_char,
-) -> c_int {
+) -> u64 {
     let inner = || -> anyhow::Result<u64> {
         let execution: Execution<Net> = serde_json::from_str(read_str(execution))?;
         base_fee_for(&execution, read_str(url), read_str(network))
     };
-    inner().map(|fee| fee as c_int).unwrap_or(0)
+    inner().unwrap_or(0)
 }
 
 /// Builds the fee authorization for an execution. `fee_credits` is the priority
@@ -1026,7 +1082,7 @@ pub unsafe extern "C" fn execution_fee_authorization(
     private_key: *const c_char,
     _transfer_type: *const c_char,
     url: *const c_char,
-    fee_credits: c_int,
+    fee_credits: u64,
     fee_record: *const c_char,
     execution: *const c_char,
     network: *const c_char,
@@ -1036,7 +1092,7 @@ pub unsafe extern "C" fn execution_fee_authorization(
         let execution: Execution<Net> = serde_json::from_str(read_str(execution))?;
         let execution_id = execution.to_execution_id()?;
         let base_fee = base_fee_for(&execution, read_str(url), read_str(network))?;
-        let priority_fee = fee_credits as u64;
+        let priority_fee = fee_credits;
         let fee_record = read_str(fee_record);
         let vm = new_vm()?;
         let rng = &mut rand::thread_rng();
@@ -1267,6 +1323,57 @@ mod tests {
             assert!(CStr::from_ptr(ptr).to_str().unwrap().is_empty());
             free_string(ptr);
         }
+    }
+
+    // A negative message length must be rejected, not wrapped to a huge usize
+    // and read out of bounds.
+    #[test]
+    fn negative_message_length_rejected() {
+        unsafe {
+            let key = CString::new(OWNER_KEY).unwrap();
+            let msg = [1u8, 2, 3];
+            let ptr = sign_message(key.as_ptr(), msg.as_ptr(), -1);
+            assert!(CStr::from_ptr(ptr).to_str().unwrap().is_empty());
+            free_string(ptr);
+
+            let addr = CString::new("aleo1qqq").unwrap();
+            let sig = CString::new("sign1qqq").unwrap();
+            assert_eq!(verify(addr.as_ptr(), sig.as_ptr(), msg.as_ptr(), -1), 0);
+        }
+    }
+
+    // A node claiming `a.aleo -> ... -> a.aleo` must be rejected before any
+    // fetch, not recursed into until the stack overflows. Both guards fire
+    // before HTTP, so these run offline (the URL is never contacted).
+    #[test]
+    fn import_cycle_from_node_rejected() {
+        let vm = new_vm().unwrap();
+        let mut visiting = vec!["token_registry.aleo".to_string()];
+        let error = add_program_from_node_guarded(
+            &vm,
+            "token_registry.aleo",
+            "http://127.0.0.1:1",
+            "testnet",
+            &mut visiting,
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("import cycle"), "got: {error}");
+    }
+
+    #[test]
+    fn import_depth_from_node_capped() {
+        let vm = new_vm().unwrap();
+        let mut visiting =
+            (0..MAX_IMPORT_DEPTH).map(|i| format!("program{i}.aleo")).collect::<Vec<_>>();
+        let error = add_program_from_node_guarded(
+            &vm,
+            "token_registry.aleo",
+            "http://127.0.0.1:1",
+            "testnet",
+            &mut visiting,
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("exceeds"), "got: {error}");
     }
 
     // Calls a few exported functions through their C ABI and frees the result,

--- a/rust/aleo_ffi/src/lib.rs
+++ b/rust/aleo_ffi/src/lib.rs
@@ -25,6 +25,7 @@ use snarkvm_ledger_query::QueryTrait;
 use snarkvm_ledger_store::helpers::memory::ConsensusMemory;
 use snarkvm_ledger_store::ConsensusStore;
 use snarkvm_synthesizer::process::Authorization;
+use snarkvm_synthesizer::program::Program;
 use snarkvm_synthesizer::VM;
 use aleo_std_storage::StorageMode;
 
@@ -299,6 +300,22 @@ fn new_vm() -> anyhow::Result<VM<Net, ConsensusMemory<Net>>> {
     VM::from(ConsensusStore::<Net, ConsensusMemory<Net>>::open(StorageMode::Production)?)
 }
 
+/// HTTP GET with a few retries (the public node occasionally returns transient
+/// 5xx / connection errors).
+fn http_get(url: &str) -> anyhow::Result<String> {
+    let mut last_error = None;
+    for attempt in 0..4 {
+        match ureq::get(url).call() {
+            Ok(response) => return Ok(response.into_string()?),
+            Err(error) => {
+                last_error = Some(error);
+                std::thread::sleep(std::time::Duration::from_millis(500 * (attempt + 1)));
+            }
+        }
+    }
+    Err(anyhow::anyhow!("GET {url} failed after retries: {last_error:?}"))
+}
+
 /// REST query against `{url}/{network}`. snarkVM's own RestQuery derives the
 /// URL path from the network type (MainnetV0 -> `/mainnet`), but Aleo's testnet
 /// runs the network-0 protocol under a `/testnet` path, so we issue the
@@ -313,8 +330,7 @@ impl NodeQuery {
     }
 
     fn get_json<T: serde::de::DeserializeOwned>(&self, route: &str) -> anyhow::Result<T> {
-        let body = ureq::get(&format!("{}/{route}", self.base)).call()?.into_string()?;
-        Ok(serde_json::from_str(body.trim())?)
+        Ok(serde_json::from_str(http_get(&format!("{}/{route}", self.base))?.trim())?)
     }
 }
 
@@ -382,8 +398,10 @@ fn transfer_inputs(
 /// Runs the whole split-proof flow for a credits.aleo function and returns the
 /// assembled transaction: authorize -> execute -> fee authorize -> fee execute
 /// -> assemble. `fee_credits` is the priority fee; empty `fee_record` = public fee.
+#[allow(clippy::too_many_arguments)]
 fn full_transaction(
     private_key: &PrivateKey<Net>,
+    program_id: &str,
     function: &str,
     inputs: Vec<String>,
     fee_credits: u64,
@@ -392,10 +410,11 @@ fn full_transaction(
     network: &str,
 ) -> anyhow::Result<String> {
     let vm = new_vm()?;
+    add_program_from_node(&vm, program_id, url, network)?;
     let query = NodeQuery::new(url, network);
     let rng = &mut rand::thread_rng();
 
-    let authorization = vm.authorize(private_key, "credits.aleo", function, inputs, rng)?;
+    let authorization = vm.authorize(private_key, program_id, function, inputs, rng)?;
     let (execution, _response) = vm.execute_authorization_raw(authorization, &query, rng)?;
 
     let execution_id = execution.to_execution_id()?;
@@ -414,6 +433,28 @@ fn full_transaction(
     let fee = vm.execute_fee_authorization_raw(fee_authorization, &query, rng)?;
 
     Ok(Transaction::from_execution(execution, Some(fee))?.to_string())
+}
+
+/// Fetches a non-builtin program from the node and adds it (and any imports
+/// already built in) to the VM. A no-op for built-in programs like credits.aleo.
+fn add_program_from_node(
+    vm: &VM<Net, ConsensusMemory<Net>>,
+    program_id: &str,
+    url: &str,
+    network: &str,
+) -> anyhow::Result<()> {
+    let process = vm.process();
+    let mut process = process.write();
+    if program_id == "credits.aleo" || process.contains_program(&ProgramID::from_str(program_id)?) {
+        return Ok(());
+    }
+    let base = format!("{}/{}", url.trim_end_matches('/'), network);
+    let body = http_get(&format!("{base}/program/{program_id}"))?;
+    let source: String = serde_json::from_str(body.trim())?;
+    let program = Program::<Net>::from_str(&source)?;
+    // Non-upgradeable programs (no constructor) are deployed at edition 1.
+    process.add_program_with_edition(&program, 1)?;
+    Ok(())
 }
 
 /// POSTs a transaction to the node, returning the node's response body.
@@ -449,6 +490,7 @@ pub unsafe extern "C" fn build_transaction(
                 .ok_or_else(|| anyhow::anyhow!("unsupported transfer type: {function}"))?;
         full_transaction(
             &private_key,
+            "credits.aleo",
             function,
             inputs,
             fee_credits as u64,
@@ -490,6 +532,7 @@ pub unsafe extern "C" fn try_transfer(
                 .ok_or_else(|| anyhow::anyhow!("unsupported transfer type: {function}"))?;
         let transaction = full_transaction(
             &private_key,
+            "credits.aleo",
             function,
             inputs,
             fee_credits as u64,
@@ -503,6 +546,79 @@ pub unsafe extern "C" fn try_transfer(
         Ok(response) => to_cstring(response),
         Err(error) => {
             eprintln!("[try_transfer] {error:?}");
+            to_cstring(String::new())
+        }
+    }
+}
+
+/// Executes an arbitrary program function and broadcasts the transaction.
+/// `arguments` is a JSON array of Aleo value strings. Returns the node response.
+///
+/// SAFETY: the pointer args are NUL-terminated C strings.
+#[no_mangle]
+pub unsafe extern "C" fn execute_program(
+    private_key: *const c_char,
+    program_id: *const c_char,
+    function_name: *const c_char,
+    arguments: *const c_char,
+    fee: c_int,
+    url: *const c_char,
+    network: *const c_char,
+) -> *mut c_char {
+    let inner = || -> anyhow::Result<String> {
+        let private_key = PrivateKey::<Net>::from_str(read_str(private_key))?;
+        let inputs: Vec<String> = serde_json::from_str(read_str(arguments))?;
+        let transaction = full_transaction(
+            &private_key,
+            read_str(program_id),
+            read_str(function_name),
+            inputs,
+            fee as u64,
+            "",
+            read_str(url),
+            read_str(network),
+        )?;
+        broadcast_to_node(&transaction, read_str(url), read_str(network))
+    };
+    match inner() {
+        Ok(response) => to_cstring(response),
+        Err(error) => {
+            eprintln!("[execute_program] {error:?}");
+            to_cstring(String::new())
+        }
+    }
+}
+
+/// Generates the execution proof for an arbitrary program function call (the
+/// authorization + execute step, returning the serialized execution).
+///
+/// SAFETY: the pointer args are NUL-terminated C strings.
+#[no_mangle]
+pub unsafe extern "C" fn execute_program_proof(
+    private_key: *const c_char,
+    program_id: *const c_char,
+    function_name: *const c_char,
+    arguments: *const c_char,
+    url: *const c_char,
+    network: *const c_char,
+) -> *mut c_char {
+    let inner = || -> anyhow::Result<String> {
+        let private_key = PrivateKey::<Net>::from_str(read_str(private_key))?;
+        let program_id = read_str(program_id);
+        let inputs: Vec<String> = serde_json::from_str(read_str(arguments))?;
+        let vm = new_vm()?;
+        add_program_from_node(&vm, program_id, read_str(url), read_str(network))?;
+        let query = NodeQuery::new(read_str(url), read_str(network));
+        let rng = &mut rand::thread_rng();
+        let authorization =
+            vm.authorize(&private_key, program_id, read_str(function_name), inputs, rng)?;
+        let (execution, _response) = vm.execute_authorization_raw(authorization, &query, rng)?;
+        Ok(serde_json::to_string(&execution)?)
+    };
+    match inner() {
+        Ok(execution) => to_cstring(execution),
+        Err(error) => {
+            eprintln!("[execute_program_proof] {error:?}");
             to_cstring(String::new())
         }
     }
@@ -556,6 +672,7 @@ pub unsafe extern "C" fn try_join(
         let inputs = vec![read_str(record_1).to_string(), read_str(record_2).to_string()];
         let transaction = full_transaction(
             &private_key,
+            "credits.aleo",
             "join",
             inputs,
             fee_credits as u64,

--- a/rust/aleo_ffi/src/lib.rs
+++ b/rust/aleo_ffi/src/lib.rs
@@ -934,6 +934,60 @@ pub unsafe extern "C" fn execute_fee_proof(
     }
 }
 
+/// Builds the authorization to migrate an old (version-0) credits record to a
+/// version-1 record via credits.aleo `upgrade`. The encrypted `record` is
+/// decrypted with the key's view key and passed as the single input. Offline.
+/// Returns "" on failure.
+///
+/// SAFETY: the pointer args are NUL-terminated C strings.
+#[no_mangle]
+pub unsafe extern "C" fn upgrade_authorization(
+    private_key: *const c_char,
+    record: *const c_char,
+    _url: *const c_char,
+    _network: *const c_char,
+) -> *mut c_char {
+    let inner = || -> anyhow::Result<String> {
+        let private_key = PrivateKey::<Net>::from_str(read_str(private_key))?;
+        let view_key = ViewKey::<Net>::try_from(&private_key)?;
+        let record = Record::<Net, Ciphertext<Net>>::from_str(read_str(record))?;
+        let plaintext = record.decrypt(&view_key)?;
+        let vm = new_vm()?;
+        let authorization = vm.authorize(
+            &private_key,
+            "credits.aleo",
+            "upgrade",
+            vec![plaintext.to_string()],
+            &mut rand::thread_rng(),
+        )?;
+        Ok(serde_json::to_string(&authorization)?)
+    };
+    match inner() {
+        Ok(authorization) => to_cstring(authorization),
+        Err(_) => to_cstring(String::new()),
+    }
+}
+
+/// Assembles a credits.aleo `upgrade` transaction from its execution alone. A
+/// transaction with a single `upgrade` transition is base-fee exempt, so no fee
+/// is attached (`Transaction::from_execution(execution, None)`). Returns "".
+///
+/// SAFETY: `execution` is a NUL-terminated C string.
+#[no_mangle]
+pub unsafe extern "C" fn build_upgrade_transaction_offline(
+    execution: *const c_char,
+    _network: *const c_char,
+) -> *mut c_char {
+    let inner = || -> anyhow::Result<String> {
+        let execution: Execution<Net> = serde_json::from_str(read_str(execution))?;
+        Ok(Transaction::from_execution(execution, None)?.to_string())
+    };
+    match inner() {
+        Ok(transaction) => to_cstring(transaction),
+        Err(_) => to_cstring(String::new()),
+    }
+}
+
 /// Assembles a transaction from a serialized execution proof and fee proof
 /// (the split-proof flow). Deterministic; returns "" on failure.
 ///

--- a/rust/aleo_ffi/src/lib.rs
+++ b/rust/aleo_ffi/src/lib.rs
@@ -310,6 +310,24 @@ fn static_query(url: &str, network: &str) -> anyhow::Result<Query<Net, BlockMemo
     Query::try_from(json)
 }
 
+/// Current block height from the node (used to select the consensus version).
+fn fetch_height(url: &str, network: &str) -> anyhow::Result<u32> {
+    let base = format!("{}/{}", url.trim_end_matches('/'), network);
+    let height = ureq::get(&format!("{base}/latest/height")).call()?.into_string()?;
+    Ok(height.trim().parse()?)
+}
+
+/// Minimum (base) fee in microcredits for an execution at the node's height.
+fn base_fee_for(execution: &Execution<Net>, url: &str, network: &str) -> anyhow::Result<u64> {
+    let consensus_version = Net::CONSENSUS_VERSION(fetch_height(url, network)?)?;
+    let vm = new_vm()?;
+    let process = vm.process();
+    let process = process.read();
+    let (base_fee, _details) =
+        snarkvm_synthesizer::process::execution_cost(&process, execution, consensus_version)?;
+    Ok(base_fee)
+}
+
 /// Builds an execution authorization for a credits.aleo transfer. Offline
 /// (credits.aleo is built in). Returns "" on failure.
 ///
@@ -372,6 +390,117 @@ pub unsafe extern "C" fn execute_proof(
         Ok(execution) => to_cstring(execution),
         Err(error) => {
             eprintln!("[execute_proof] {error:?}");
+            to_cstring(String::new())
+        }
+    }
+}
+
+/// Broadcasts a serialized transaction to the node, returning the node's
+/// response (the transaction id on success). Returns "" on transport failure.
+///
+/// SAFETY: the pointer args are NUL-terminated C strings.
+#[no_mangle]
+pub unsafe extern "C" fn broadcast(
+    transaction: *const c_char,
+    url: *const c_char,
+    _transfer_type: *const c_char,
+    network: *const c_char,
+) -> *mut c_char {
+    let inner = || -> anyhow::Result<String> {
+        let base = format!("{}/{}", read_str(url).trim_end_matches('/'), read_str(network));
+        let response = ureq::post(&format!("{base}/transaction/broadcast"))
+            .set("Content-Type", "application/json")
+            .send_string(read_str(transaction))?
+            .into_string()?;
+        Ok(response)
+    };
+    match inner() {
+        Ok(response) => to_cstring(response),
+        Err(error) => {
+            eprintln!("[broadcast] {error:?}");
+            to_cstring(String::new())
+        }
+    }
+}
+
+/// Returns the base (minimum) fee in microcredits for a serialized execution.
+///
+/// SAFETY: the pointer args are NUL-terminated C strings.
+#[no_mangle]
+pub unsafe extern "C" fn get_base_fee(
+    url: *const c_char,
+    execution: *const c_char,
+    network: *const c_char,
+) -> c_int {
+    let inner = || -> anyhow::Result<u64> {
+        let execution: Execution<Net> = serde_json::from_str(read_str(execution))?;
+        base_fee_for(&execution, read_str(url), read_str(network))
+    };
+    inner().map(|fee| fee as c_int).unwrap_or(0)
+}
+
+/// Builds the fee authorization for an execution. `fee_credits` is the priority
+/// fee; the base fee is computed from the execution. An empty `fee_record` uses
+/// a public fee, otherwise a private fee spending that record. Returns "".
+///
+/// SAFETY: the pointer args are NUL-terminated C strings.
+#[no_mangle]
+pub unsafe extern "C" fn execution_fee_authorization(
+    private_key: *const c_char,
+    _transfer_type: *const c_char,
+    url: *const c_char,
+    fee_credits: c_int,
+    fee_record: *const c_char,
+    execution: *const c_char,
+    network: *const c_char,
+) -> *mut c_char {
+    let inner = || -> anyhow::Result<String> {
+        let private_key = PrivateKey::<Net>::from_str(read_str(private_key))?;
+        let execution: Execution<Net> = serde_json::from_str(read_str(execution))?;
+        let execution_id = execution.to_execution_id()?;
+        let base_fee = base_fee_for(&execution, read_str(url), read_str(network))?;
+        let priority_fee = fee_credits as u64;
+        let fee_record = read_str(fee_record);
+        let vm = new_vm()?;
+        let rng = &mut rand::thread_rng();
+        let authorization = if fee_record.trim().is_empty() {
+            vm.authorize_fee_public(&private_key, base_fee, priority_fee, execution_id, rng)?
+        } else {
+            let record = Record::<Net, Plaintext<Net>>::from_str(fee_record)?;
+            vm.authorize_fee_private(&private_key, record, base_fee, priority_fee, execution_id, rng)?
+        };
+        Ok(serde_json::to_string(&authorization)?)
+    };
+    match inner() {
+        Ok(authorization) => to_cstring(authorization),
+        Err(error) => {
+            eprintln!("[execution_fee_authorization] {error:?}");
+            to_cstring(String::new())
+        }
+    }
+}
+
+/// Generates the fee proof for a fee authorization (the patched
+/// `execute_fee_authorization_raw`). Returns "" on failure.
+///
+/// SAFETY: the pointer args are NUL-terminated C strings.
+#[no_mangle]
+pub unsafe extern "C" fn execute_fee_proof(
+    url: *const c_char,
+    authorization: *const c_char,
+    network: *const c_char,
+) -> *mut c_char {
+    let inner = || -> anyhow::Result<String> {
+        let authorization: Authorization<Net> = serde_json::from_str(read_str(authorization))?;
+        let query = static_query(read_str(url), read_str(network))?;
+        let vm = new_vm()?;
+        let fee = vm.execute_fee_authorization_raw(authorization, &query, &mut rand::thread_rng())?;
+        Ok(serde_json::to_string(&fee)?)
+    };
+    match inner() {
+        Ok(fee) => to_cstring(fee),
+        Err(error) => {
+            eprintln!("[execute_fee_proof] {error:?}");
             to_cstring(String::new())
         }
     }

--- a/rust/aleo_ffi/src/lib.rs
+++ b/rust/aleo_ffi/src/lib.rs
@@ -45,6 +45,20 @@ fn to_cstring(s: String) -> *mut c_char {
     CString::new(s).expect("unexpected NUL in FFI output").into_raw()
 }
 
+/// Frees a string previously returned by this library. Returned pointers are
+/// allocated with Rust's allocator via `CString::into_raw`, so they must be
+/// handed back to Rust to be freed — calling the C `free` on them is undefined
+/// behaviour. Null is a no-op; each pointer must be freed at most once.
+///
+/// SAFETY: `ptr` is null or a pointer previously returned by this library and
+/// not yet freed.
+#[no_mangle]
+pub unsafe extern "C" fn free_string(ptr: *mut c_char) {
+    if !ptr.is_null() {
+        drop(CString::from_raw(ptr));
+    }
+}
+
 /// FFI sanity check used by the test suite.
 #[no_mangle]
 pub extern "C" fn numbers_add(a: c_int, b: c_int) -> c_int {
@@ -300,12 +314,28 @@ fn new_vm() -> anyhow::Result<VM<Net, ConsensusMemory<Net>>> {
     VM::from(ConsensusStore::<Net, ConsensusMemory<Net>>::open(StorageMode::Production)?)
 }
 
+/// Shared HTTP agent with bounded timeouts. `ureq`'s defaults only bound the
+/// connect phase, so a node that accepts the connection and then stalls would
+/// hang the (synchronous) FFI call forever and the retry loop would never run.
+/// The read/write timeouts cap each attempt so a stalled peer surfaces as an
+/// error and is retried.
+fn http_agent() -> &'static ureq::Agent {
+    static AGENT: std::sync::OnceLock<ureq::Agent> = std::sync::OnceLock::new();
+    AGENT.get_or_init(|| {
+        ureq::AgentBuilder::new()
+            .timeout_connect(std::time::Duration::from_secs(10))
+            .timeout_read(std::time::Duration::from_secs(30))
+            .timeout_write(std::time::Duration::from_secs(30))
+            .build()
+    })
+}
+
 /// HTTP GET with a few retries (the public node occasionally returns transient
 /// 5xx / connection errors).
 fn http_get(url: &str) -> anyhow::Result<String> {
     let mut last_error = None;
     for attempt in 0..4 {
-        match ureq::get(url).call() {
+        match http_agent().get(url).call() {
             Ok(response) => return Ok(response.into_string()?),
             Err(error) => {
                 last_error = Some(error);
@@ -569,7 +599,8 @@ fn program_fee(
 /// POSTs a transaction to the node, returning the node's response body.
 fn broadcast_to_node(transaction: &str, url: &str, network: &str) -> anyhow::Result<String> {
     let base = format!("{}/{}", url.trim_end_matches('/'), network);
-    Ok(ureq::post(&format!("{base}/transaction/broadcast"))
+    Ok(http_agent()
+        .post(&format!("{base}/transaction/broadcast"))
         .set("Content-Type", "application/json")
         .send_string(transaction)?
         .into_string()?)
@@ -1171,6 +1202,36 @@ mod tests {
     #[test]
     fn transfer_inputs_rejects_unknown_function() {
         assert!(transfer_inputs("not_a_transfer", "aleo1recipient", 1, "", &owner()).is_err());
+    }
+
+    // free_string reclaims a returned pointer and tolerates null.
+    #[test]
+    fn free_string_reclaims_returned_pointers() {
+        unsafe {
+            free_string(to_cstring("hello".to_string()));
+            free_string(std::ptr::null_mut());
+        }
+    }
+
+    // Calls a few exported functions through their C ABI and frees the result,
+    // exercising the FFI surface end-to-end (not just internal helpers).
+    #[test]
+    fn ffi_smoke_through_c_abi() {
+        assert_eq!(numbers_add(2, 3), 6); // a + b + 1
+        unsafe {
+            let seed = [1u8; 32];
+            let pk_ptr = seed_to_private_key(seed.as_ptr());
+            let pk = CStr::from_ptr(pk_ptr).to_str().unwrap().to_owned();
+            assert!(pk.starts_with("APrivateKey1"), "got {pk}");
+
+            let pk_c = CString::new(pk).unwrap();
+            let addr_ptr = private_key_to_address(pk_c.as_ptr());
+            let addr = CStr::from_ptr(addr_ptr).to_str().unwrap();
+            assert!(addr.starts_with("aleo1"), "got {addr}");
+
+            free_string(pk_ptr);
+            free_string(addr_ptr);
+        }
     }
 
     // latest_edition reports a program's current edition (token_registry = 1).

--- a/rust/aleo_ffi/src/lib.rs
+++ b/rust/aleo_ffi/src/lib.rs
@@ -19,9 +19,10 @@ use snarkvm_console::network::MainnetV0;
 use snarkvm_console::prelude::*;
 use snarkvm_console::program::{Ciphertext, Identifier, Literal, Plaintext, ProgramID, Record};
 use snarkvm_console::types::Field;
+use snarkvm_console::program::StatePath;
 use snarkvm_ledger_block::{Execution, Fee, Transaction};
-use snarkvm_ledger_query::Query;
-use snarkvm_ledger_store::helpers::memory::{BlockMemory, ConsensusMemory};
+use snarkvm_ledger_query::QueryTrait;
+use snarkvm_ledger_store::helpers::memory::ConsensusMemory;
 use snarkvm_ledger_store::ConsensusStore;
 use snarkvm_synthesizer::process::Authorization;
 use snarkvm_synthesizer::VM;
@@ -298,16 +299,47 @@ fn new_vm() -> anyhow::Result<VM<Net, ConsensusMemory<Net>>> {
     VM::from(ConsensusStore::<Net, ConsensusMemory<Net>>::open(StorageMode::Production)?)
 }
 
-/// Builds a static query by fetching the current state root + height from the
-/// node's REST API at `{url}/{network}` (works regardless of the network-name
-/// path mismatch).
-fn static_query(url: &str, network: &str) -> anyhow::Result<Query<Net, BlockMemory<Net>>> {
-    let base = format!("{}/{}", url.trim_end_matches('/'), network);
-    let state_root = ureq::get(&format!("{base}/latest/stateRoot")).call()?.into_string()?;
-    let state_root = state_root.trim().trim_matches('"');
-    let height = ureq::get(&format!("{base}/latest/height")).call()?.into_string()?;
-    let json = format!(r#"{{"state_root":"{}","height":{}}}"#, state_root, height.trim());
-    Query::try_from(json)
+/// REST query against `{url}/{network}`. snarkVM's own RestQuery derives the
+/// URL path from the network type (MainnetV0 -> `/mainnet`), but Aleo's testnet
+/// runs the network-0 protocol under a `/testnet` path, so we issue the
+/// requests ourselves with the caller-provided network path.
+struct NodeQuery {
+    base: String,
+}
+
+impl NodeQuery {
+    fn new(url: &str, network: &str) -> Self {
+        Self { base: format!("{}/{}", url.trim_end_matches('/'), network) }
+    }
+
+    fn get_json<T: serde::de::DeserializeOwned>(&self, route: &str) -> anyhow::Result<T> {
+        let body = ureq::get(&format!("{}/{route}", self.base)).call()?.into_string()?;
+        Ok(serde_json::from_str(body.trim())?)
+    }
+}
+
+impl QueryTrait<Net> for NodeQuery {
+    fn current_state_root(&self) -> anyhow::Result<<Net as Network>::StateRoot> {
+        self.get_json("latest/stateRoot")
+    }
+
+    fn get_state_path_for_commitment(
+        &self,
+        commitment: &Field<Net>,
+    ) -> anyhow::Result<StatePath<Net>> {
+        self.get_json(&format!("statePath/{commitment}"))
+    }
+
+    fn get_state_paths_for_commitments(
+        &self,
+        commitments: &[Field<Net>],
+    ) -> anyhow::Result<Vec<StatePath<Net>>> {
+        commitments.iter().map(|commitment| self.get_state_path_for_commitment(commitment)).collect()
+    }
+
+    fn current_block_height(&self) -> anyhow::Result<u32> {
+        self.get_json("latest/height")
+    }
 }
 
 /// Current block height from the node (used to select the consensus version).
@@ -328,6 +360,220 @@ fn base_fee_for(execution: &Execution<Net>, url: &str, network: &str) -> anyhow:
     Ok(base_fee)
 }
 
+/// Maps a credits.aleo transfer function to its input list.
+fn transfer_inputs(
+    function: &str,
+    recipient: &str,
+    amount: i64,
+    amount_record: &str,
+) -> Option<Vec<String>> {
+    let amount = format!("{amount}u64");
+    match function {
+        "transfer_public" | "transfer_public_to_private" => {
+            Some(vec![recipient.to_string(), amount])
+        }
+        "transfer_private" | "transfer_private_to_public" => {
+            Some(vec![amount_record.to_string(), recipient.to_string(), amount])
+        }
+        _ => None,
+    }
+}
+
+/// Runs the whole split-proof flow for a credits.aleo function and returns the
+/// assembled transaction: authorize -> execute -> fee authorize -> fee execute
+/// -> assemble. `fee_credits` is the priority fee; empty `fee_record` = public fee.
+fn full_transaction(
+    private_key: &PrivateKey<Net>,
+    function: &str,
+    inputs: Vec<String>,
+    fee_credits: u64,
+    fee_record: &str,
+    url: &str,
+    network: &str,
+) -> anyhow::Result<String> {
+    let vm = new_vm()?;
+    let query = NodeQuery::new(url, network);
+    let rng = &mut rand::thread_rng();
+
+    let authorization = vm.authorize(private_key, "credits.aleo", function, inputs, rng)?;
+    let (execution, _response) = vm.execute_authorization_raw(authorization, &query, rng)?;
+
+    let execution_id = execution.to_execution_id()?;
+    let base_fee = {
+        let consensus_version = Net::CONSENSUS_VERSION(query.current_block_height()?)?;
+        let process = vm.process();
+        let process = process.read();
+        snarkvm_synthesizer::process::execution_cost(&process, &execution, consensus_version)?.0
+    };
+    let fee_authorization = if fee_record.trim().is_empty() {
+        vm.authorize_fee_public(private_key, base_fee, fee_credits, execution_id, rng)?
+    } else {
+        let record = Record::<Net, Plaintext<Net>>::from_str(fee_record)?;
+        vm.authorize_fee_private(private_key, record, base_fee, fee_credits, execution_id, rng)?
+    };
+    let fee = vm.execute_fee_authorization_raw(fee_authorization, &query, rng)?;
+
+    Ok(Transaction::from_execution(execution, Some(fee))?.to_string())
+}
+
+/// POSTs a transaction to the node, returning the node's response body.
+fn broadcast_to_node(transaction: &str, url: &str, network: &str) -> anyhow::Result<String> {
+    let base = format!("{}/{}", url.trim_end_matches('/'), network);
+    Ok(ureq::post(&format!("{base}/transaction/broadcast"))
+        .set("Content-Type", "application/json")
+        .send_string(transaction)?
+        .into_string()?)
+}
+
+/// Builds a complete credits.aleo transfer transaction (without broadcasting).
+/// Returns "" on failure.
+///
+/// SAFETY: the pointer args are NUL-terminated C strings.
+#[no_mangle]
+pub unsafe extern "C" fn build_transaction(
+    private_key: *const c_char,
+    recipient: *const c_char,
+    transfer_type: *const c_char,
+    amount: c_int,
+    fee_credits: c_int,
+    url: *const c_char,
+    amount_record: *const c_char,
+    fee_record: *const c_char,
+    network: *const c_char,
+) -> *mut c_char {
+    let inner = || -> anyhow::Result<String> {
+        let private_key = PrivateKey::<Net>::from_str(read_str(private_key))?;
+        let function = read_str(transfer_type);
+        let inputs =
+            transfer_inputs(function, read_str(recipient), amount as i64, read_str(amount_record))
+                .ok_or_else(|| anyhow::anyhow!("unsupported transfer type: {function}"))?;
+        full_transaction(
+            &private_key,
+            function,
+            inputs,
+            fee_credits as u64,
+            read_str(fee_record),
+            read_str(url),
+            read_str(network),
+        )
+    };
+    match inner() {
+        Ok(transaction) => to_cstring(transaction),
+        Err(error) => {
+            eprintln!("[build_transaction] {error:?}");
+            to_cstring(String::new())
+        }
+    }
+}
+
+/// Builds and broadcasts a credits.aleo transfer, returning the node response.
+/// Returns "" on failure.
+///
+/// SAFETY: the pointer args are NUL-terminated C strings.
+#[no_mangle]
+pub unsafe extern "C" fn try_transfer(
+    private_key: *const c_char,
+    recipient: *const c_char,
+    transfer_type: *const c_char,
+    amount: c_int,
+    fee_credits: c_int,
+    url: *const c_char,
+    amount_record: *const c_char,
+    fee_record: *const c_char,
+    network: *const c_char,
+) -> *mut c_char {
+    let inner = || -> anyhow::Result<String> {
+        let private_key = PrivateKey::<Net>::from_str(read_str(private_key))?;
+        let function = read_str(transfer_type);
+        let inputs =
+            transfer_inputs(function, read_str(recipient), amount as i64, read_str(amount_record))
+                .ok_or_else(|| anyhow::anyhow!("unsupported transfer type: {function}"))?;
+        let transaction = full_transaction(
+            &private_key,
+            function,
+            inputs,
+            fee_credits as u64,
+            read_str(fee_record),
+            read_str(url),
+            read_str(network),
+        )?;
+        broadcast_to_node(&transaction, read_str(url), read_str(network))
+    };
+    match inner() {
+        Ok(response) => to_cstring(response),
+        Err(error) => {
+            eprintln!("[try_transfer] {error:?}");
+            to_cstring(String::new())
+        }
+    }
+}
+
+/// Builds an execution authorization for credits.aleo `join` (merging two
+/// private records). Offline. Returns "" on failure.
+///
+/// SAFETY: the pointer args are NUL-terminated C strings.
+#[no_mangle]
+pub unsafe extern "C" fn join_authorization(
+    private_key: *const c_char,
+    record_1: *const c_char,
+    record_2: *const c_char,
+    _url: *const c_char,
+    _network: *const c_char,
+) -> *mut c_char {
+    let inner = || -> anyhow::Result<String> {
+        let private_key = PrivateKey::<Net>::from_str(read_str(private_key))?;
+        let inputs = vec![read_str(record_1).to_string(), read_str(record_2).to_string()];
+        let vm = new_vm()?;
+        let authorization =
+            vm.authorize(&private_key, "credits.aleo", "join", inputs, &mut rand::thread_rng())?;
+        Ok(serde_json::to_string(&authorization)?)
+    };
+    match inner() {
+        Ok(authorization) => to_cstring(authorization),
+        Err(error) => {
+            eprintln!("[join_authorization] {error:?}");
+            to_cstring(String::new())
+        }
+    }
+}
+
+/// Builds, proves, and broadcasts a credits.aleo `join` of two private records.
+/// Returns the node response, or "" on failure.
+///
+/// SAFETY: the pointer args are NUL-terminated C strings.
+#[no_mangle]
+pub unsafe extern "C" fn try_join(
+    private_key: *const c_char,
+    record_1: *const c_char,
+    record_2: *const c_char,
+    fee_credits: c_int,
+    fee_record: *const c_char,
+    url: *const c_char,
+    network: *const c_char,
+) -> *mut c_char {
+    let inner = || -> anyhow::Result<String> {
+        let private_key = PrivateKey::<Net>::from_str(read_str(private_key))?;
+        let inputs = vec![read_str(record_1).to_string(), read_str(record_2).to_string()];
+        let transaction = full_transaction(
+            &private_key,
+            "join",
+            inputs,
+            fee_credits as u64,
+            read_str(fee_record),
+            read_str(url),
+            read_str(network),
+        )?;
+        broadcast_to_node(&transaction, read_str(url), read_str(network))
+    };
+    match inner() {
+        Ok(response) => to_cstring(response),
+        Err(error) => {
+            eprintln!("[try_join] {error:?}");
+            to_cstring(String::new())
+        }
+    }
+}
+
 /// Builds an execution authorization for a credits.aleo transfer. Offline
 /// (credits.aleo is built in). Returns "" on failure.
 ///
@@ -345,15 +591,8 @@ pub unsafe extern "C" fn execution_authorization(
     let result = (|| -> Option<String> {
         let private_key = PrivateKey::<Net>::from_str(read_str(private_key)).ok()?;
         let function = read_str(transfer_type);
-        let recipient = read_str(recipient).to_string();
-        let amount = format!("{}u64", amount as i64);
-        let inputs: Vec<String> = match function {
-            "transfer_public" | "transfer_public_to_private" => vec![recipient, amount],
-            "transfer_private" | "transfer_private_to_public" => {
-                vec![read_str(amount_record).to_string(), recipient, amount]
-            }
-            _ => return None,
-        };
+        let inputs =
+            transfer_inputs(function, read_str(recipient), amount as i64, read_str(amount_record))?;
         let vm = new_vm().ok()?;
         let authorization = vm
             .authorize(&private_key, "credits.aleo", function, inputs, &mut rand::thread_rng())
@@ -376,11 +615,7 @@ pub unsafe extern "C" fn execute_proof(
 ) -> *mut c_char {
     let inner = || -> anyhow::Result<String> {
         let authorization: Authorization<Net> = serde_json::from_str(read_str(authorization))?;
-        // Aleo's testnet runs the network-0 (Mainnet) protocol but serves under a
-        // `/testnet` REST path, so snarkVM's RestQuery (which derives the path from
-        // the network type) can't reach it. Fetch the state root directly and feed
-        // a static query instead.
-        let query: Query<Net, BlockMemory<Net>> = static_query(read_str(url), read_str(network))?;
+        let query = NodeQuery::new(read_str(url), read_str(network));
         let vm = new_vm()?;
         let (execution, _response) =
             vm.execute_authorization_raw(authorization, &query, &mut rand::thread_rng())?;
@@ -492,7 +727,7 @@ pub unsafe extern "C" fn execute_fee_proof(
 ) -> *mut c_char {
     let inner = || -> anyhow::Result<String> {
         let authorization: Authorization<Net> = serde_json::from_str(read_str(authorization))?;
-        let query = static_query(read_str(url), read_str(network))?;
+        let query = NodeQuery::new(read_str(url), read_str(network));
         let vm = new_vm()?;
         let fee = vm.execute_fee_authorization_raw(authorization, &query, &mut rand::thread_rng())?;
         Ok(serde_json::to_string(&fee)?)

--- a/rust/aleo_ffi/src/lib.rs
+++ b/rust/aleo_ffi/src/lib.rs
@@ -376,23 +376,45 @@ fn base_fee_for(execution: &Execution<Net>, url: &str, network: &str) -> anyhow:
     Ok(base_fee)
 }
 
-/// Maps a credits.aleo transfer function to its input list.
+/// Returns a plaintext record string suitable as a function input. Records are
+/// supplied encrypted (`record1...`); they are decrypted with the key's view
+/// key. An already-plaintext record (`{ ... }`) is returned unchanged.
+fn plaintext_record(record: &str, private_key: &PrivateKey<Net>) -> anyhow::Result<String> {
+    let record = record.trim();
+    if record.starts_with("record1") {
+        let view_key = ViewKey::<Net>::try_from(private_key)?;
+        let ciphertext = Record::<Net, Ciphertext<Net>>::from_str(record)?;
+        Ok(ciphertext.decrypt(&view_key)?.to_string())
+    } else {
+        Ok(record.to_string())
+    }
+}
+
+/// Decrypts (if needed) and parses a record as a typed plaintext record.
+fn plaintext_record_typed(
+    record: &str,
+    private_key: &PrivateKey<Net>,
+) -> anyhow::Result<Record<Net, Plaintext<Net>>> {
+    Ok(Record::<Net, Plaintext<Net>>::from_str(&plaintext_record(record, private_key)?)?)
+}
+
+/// Maps a credits.aleo transfer function to its input list, decrypting the
+/// spent record for private transfers.
 fn transfer_inputs(
     function: &str,
     recipient: &str,
     amount: i64,
     amount_record: &str,
-) -> Option<Vec<String>> {
+    private_key: &PrivateKey<Net>,
+) -> anyhow::Result<Vec<String>> {
     let amount = format!("{amount}u64");
-    match function {
-        "transfer_public" | "transfer_public_to_private" => {
-            Some(vec![recipient.to_string(), amount])
-        }
+    Ok(match function {
+        "transfer_public" | "transfer_public_to_private" => vec![recipient.to_string(), amount],
         "transfer_private" | "transfer_private_to_public" => {
-            Some(vec![amount_record.to_string(), recipient.to_string(), amount])
+            vec![plaintext_record(amount_record, private_key)?, recipient.to_string(), amount]
         }
-        _ => None,
-    }
+        _ => anyhow::bail!("unsupported transfer type: {function}"),
+    })
 }
 
 /// Runs the whole split-proof flow for a credits.aleo function and returns the
@@ -427,7 +449,7 @@ fn full_transaction(
     let fee_authorization = if fee_record.trim().is_empty() {
         vm.authorize_fee_public(private_key, base_fee, fee_credits, execution_id, rng)?
     } else {
-        let record = Record::<Net, Plaintext<Net>>::from_str(fee_record)?;
+        let record = plaintext_record_typed(fee_record, private_key)?;
         vm.authorize_fee_private(private_key, record, base_fee, fee_credits, execution_id, rng)?
     };
     let fee = vm.execute_fee_authorization_raw(fee_authorization, &query, rng)?;
@@ -435,25 +457,49 @@ fn full_transaction(
     Ok(Transaction::from_execution(execution, Some(fee))?.to_string())
 }
 
-/// Fetches a non-builtin program from the node and adds it (and any imports
-/// already built in) to the VM. A no-op for built-in programs like credits.aleo.
+/// Fetches a non-builtin program from the node and adds it to the VM, loading
+/// every imported program first (snarkVM rejects a program whose imports are
+/// not already present). A no-op for built-in programs like credits.aleo or any
+/// program already loaded.
+///
+/// Edition note: programs are added at edition 1, which is correct for the
+/// non-upgradeable programs wallets call. Programs that have been upgraded past
+/// edition 1 (constructor-bearing) would need their on-chain edition, which the
+/// public REST API does not expose as a "current edition" lookup.
 fn add_program_from_node(
     vm: &VM<Net, ConsensusMemory<Net>>,
     program_id: &str,
     url: &str,
     network: &str,
 ) -> anyhow::Result<()> {
-    let process = vm.process();
-    let mut process = process.write();
-    if program_id == "credits.aleo" || process.contains_program(&ProgramID::from_str(program_id)?) {
-        return Ok(());
+    // Skip built-ins and anything already loaded (without holding the lock
+    // across the recursion below).
+    {
+        let process = vm.process();
+        let process = process.read();
+        if program_id == "credits.aleo"
+            || process.contains_program(&ProgramID::from_str(program_id)?)
+        {
+            return Ok(());
+        }
     }
+
     let base = format!("{}/{}", url.trim_end_matches('/'), network);
     let body = http_get(&format!("{base}/program/{program_id}"))?;
     let source: String = serde_json::from_str(body.trim())?;
     let program = Program::<Net>::from_str(&source)?;
-    // Non-upgradeable programs (no constructor) are deployed at edition 1.
-    process.add_program_with_edition(&program, 1)?;
+
+    // Load imports (which may themselves import others) before this program.
+    for import_id in program.imports().keys() {
+        add_program_from_node(vm, &import_id.to_string(), url, network)?;
+    }
+
+    let process = vm.process();
+    let mut process = process.write();
+    // A diamond import graph may have added it during the recursion above.
+    if !process.contains_program(program.id()) {
+        process.add_program_with_edition(&program, 1)?;
+    }
     Ok(())
 }
 
@@ -533,9 +579,13 @@ pub unsafe extern "C" fn build_transaction(
     let inner = || -> anyhow::Result<String> {
         let private_key = PrivateKey::<Net>::from_str(read_str(private_key))?;
         let function = read_str(transfer_type);
-        let inputs =
-            transfer_inputs(function, read_str(recipient), amount as i64, read_str(amount_record))
-                .ok_or_else(|| anyhow::anyhow!("unsupported transfer type: {function}"))?;
+        let inputs = transfer_inputs(
+            function,
+            read_str(recipient),
+            amount as i64,
+            read_str(amount_record),
+            &private_key,
+        )?;
         full_transaction(
             &private_key,
             "credits.aleo",
@@ -572,9 +622,13 @@ pub unsafe extern "C" fn try_transfer(
     let inner = || -> anyhow::Result<String> {
         let private_key = PrivateKey::<Net>::from_str(read_str(private_key))?;
         let function = read_str(transfer_type);
-        let inputs =
-            transfer_inputs(function, read_str(recipient), amount as i64, read_str(amount_record))
-                .ok_or_else(|| anyhow::anyhow!("unsupported transfer type: {function}"))?;
+        let inputs = transfer_inputs(
+            function,
+            read_str(recipient),
+            amount as i64,
+            read_str(amount_record),
+            &private_key,
+        )?;
         let transaction = full_transaction(
             &private_key,
             "credits.aleo",
@@ -628,29 +682,27 @@ pub unsafe extern "C" fn execute_program(
     }
 }
 
-/// Generates the execution proof for an arbitrary program function call (the
-/// authorization + execute step, returning the serialized execution).
+/// Generates the execution proof for a previously built authorization that
+/// targets a non-builtin program. Unlike `execute_proof`, the referenced
+/// `program_id` (and its imports) is fetched from the node and loaded before
+/// the execution. Returns the serialized execution, or "" on failure.
 ///
 /// SAFETY: the pointer args are NUL-terminated C strings.
 #[no_mangle]
 pub unsafe extern "C" fn execute_program_proof(
-    private_key: *const c_char,
-    program_id: *const c_char,
-    function_name: *const c_char,
-    arguments: *const c_char,
     url: *const c_char,
+    authorization: *const c_char,
     network: *const c_char,
+    program_id: *const c_char,
 ) -> *mut c_char {
     let inner = || -> anyhow::Result<String> {
-        let private_key = PrivateKey::<Net>::from_str(read_str(private_key))?;
-        program_execution(
-            &private_key,
-            read_str(program_id),
-            read_str(function_name),
-            read_str(arguments),
-            read_str(url),
-            read_str(network),
-        )
+        let authorization: Authorization<Net> = serde_json::from_str(read_str(authorization))?;
+        let vm = new_vm()?;
+        add_program_from_node(&vm, read_str(program_id), read_str(url), read_str(network))?;
+        let query = NodeQuery::new(read_str(url), read_str(network));
+        let (execution, _response) =
+            vm.execute_authorization_raw(authorization, &query, &mut rand::thread_rng())?;
+        Ok(serde_json::to_string(&execution)?)
     };
     match inner() {
         Ok(execution) => to_cstring(execution),
@@ -732,7 +784,10 @@ pub unsafe extern "C" fn join_authorization(
 ) -> *mut c_char {
     let inner = || -> anyhow::Result<String> {
         let private_key = PrivateKey::<Net>::from_str(read_str(private_key))?;
-        let inputs = vec![read_str(record_1).to_string(), read_str(record_2).to_string()];
+        let inputs = vec![
+            plaintext_record(read_str(record_1), &private_key)?,
+            plaintext_record(read_str(record_2), &private_key)?,
+        ];
         let vm = new_vm()?;
         let authorization =
             vm.authorize(&private_key, "credits.aleo", "join", inputs, &mut rand::thread_rng())?;
@@ -760,7 +815,10 @@ pub unsafe extern "C" fn try_join(
 ) -> *mut c_char {
     let inner = || -> anyhow::Result<String> {
         let private_key = PrivateKey::<Net>::from_str(read_str(private_key))?;
-        let inputs = vec![read_str(record_1).to_string(), read_str(record_2).to_string()];
+        let inputs = vec![
+            plaintext_record(read_str(record_1), &private_key)?,
+            plaintext_record(read_str(record_2), &private_key)?,
+        ];
         let transaction = full_transaction(
             &private_key,
             "credits.aleo",
@@ -793,18 +851,25 @@ pub unsafe extern "C" fn execution_authorization(
     amount_record: *const c_char,
     _network: *const c_char,
 ) -> *mut c_char {
-    let result = (|| -> Option<String> {
-        let private_key = PrivateKey::<Net>::from_str(read_str(private_key)).ok()?;
+    let inner = || -> anyhow::Result<String> {
+        let private_key = PrivateKey::<Net>::from_str(read_str(private_key))?;
         let function = read_str(transfer_type);
-        let inputs =
-            transfer_inputs(function, read_str(recipient), amount as i64, read_str(amount_record))?;
-        let vm = new_vm().ok()?;
-        let authorization = vm
-            .authorize(&private_key, "credits.aleo", function, inputs, &mut rand::thread_rng())
-            .ok()?;
-        serde_json::to_string(&authorization).ok()
-    })();
-    to_cstring(result.unwrap_or_default())
+        let inputs = transfer_inputs(
+            function,
+            read_str(recipient),
+            amount as i64,
+            read_str(amount_record),
+            &private_key,
+        )?;
+        let vm = new_vm()?;
+        let authorization =
+            vm.authorize(&private_key, "credits.aleo", function, inputs, &mut rand::thread_rng())?;
+        Ok(serde_json::to_string(&authorization)?)
+    };
+    match inner() {
+        Ok(authorization) => to_cstring(authorization),
+        Err(_) => to_cstring(String::new()),
+    }
 }
 
 /// Generates the execution proof for an authorization (the patched
@@ -900,7 +965,7 @@ pub unsafe extern "C" fn execution_fee_authorization(
         let authorization = if fee_record.trim().is_empty() {
             vm.authorize_fee_public(&private_key, base_fee, priority_fee, execution_id, rng)?
         } else {
-            let record = Record::<Net, Plaintext<Net>>::from_str(fee_record)?;
+            let record = plaintext_record_typed(fee_record, &private_key)?;
             vm.authorize_fee_private(&private_key, record, base_fee, priority_fee, execution_id, rng)?
         };
         Ok(serde_json::to_string(&authorization)?)
@@ -1034,4 +1099,80 @@ pub unsafe extern "C" fn serial_number_string(
         Some(serial_number.to_string())
     })();
     to_cstring(result.unwrap_or_default())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // record[2] from packages/aleo_dart/test/_diff_records.dart, owned by OWNER_KEY.
+    const TEST_RECORD: &str = "record1qyqspdn8f6lh4eum9a36l93mnxh5vcqssjsep9z4lp4vpya2efgmjdsvqyxx66trwfhkxun9v35hguerqqpqzq9yu3tvsnj4x0a7e2w9w204aya09thraeckdlsn59pve6fnnd3eqv0n7jpp5rsxn48jdjj3z55vhmp42f8hxp7vk5d2430vuvk3fzrsx0w9wqw";
+    const OWNER_KEY: &str = "APrivateKey1zkpC2CbihCvUyg8zcNXTngzGpmCzKTF8uZP4jfyu3LdfT8v";
+
+    fn owner() -> PrivateKey<Net> {
+        PrivateKey::<Net>::from_str(OWNER_KEY).unwrap()
+    }
+
+    fn other_key() -> PrivateKey<Net> {
+        let field = Field::<Net>::new(<Net as Environment>::Field::from_bytes_le_mod_order(&[7u8; 32]));
+        PrivateKey::<Net>::try_from(field).unwrap()
+    }
+
+    // A ciphertext record (record1...) is decrypted to a plaintext record before
+    // it can be used as a function input.
+    #[test]
+    fn plaintext_record_decrypts_ciphertext() {
+        let plaintext = plaintext_record(TEST_RECORD, &owner()).unwrap();
+        assert!(plaintext.starts_with('{'), "expected plaintext record, got: {plaintext}");
+        // Round-trips as a typed plaintext record.
+        Record::<Net, Plaintext<Net>>::from_str(&plaintext).unwrap();
+        // An already-plaintext input is returned unchanged (idempotent).
+        assert_eq!(plaintext_record(&plaintext, &owner()).unwrap(), plaintext);
+    }
+
+    // A key that does not own the record cannot decrypt it -> error (fail closed).
+    #[test]
+    fn plaintext_record_rejects_wrong_owner() {
+        assert!(plaintext_record(TEST_RECORD, &other_key()).is_err());
+    }
+
+    #[test]
+    fn transfer_inputs_public_ordering() {
+        let inputs = transfer_inputs("transfer_public", "aleo1recipient", 5, "", &owner()).unwrap();
+        assert_eq!(inputs, vec!["aleo1recipient".to_string(), "5u64".to_string()]);
+    }
+
+    // Private transfers place the decrypted record first, then recipient, amount.
+    #[test]
+    fn transfer_inputs_private_decrypts_record() {
+        let inputs =
+            transfer_inputs("transfer_private", "aleo1recipient", 5, TEST_RECORD, &owner()).unwrap();
+        assert_eq!(inputs.len(), 3);
+        Record::<Net, Plaintext<Net>>::from_str(&inputs[0]).unwrap();
+        assert_eq!(inputs[1], "aleo1recipient");
+        assert_eq!(inputs[2], "5u64");
+    }
+
+    #[test]
+    fn transfer_inputs_rejects_unknown_function() {
+        assert!(transfer_inputs("not_a_transfer", "aleo1recipient", 1, "", &owner()).is_err());
+    }
+
+    // Loading a program pulls in its non-builtin imports recursively
+    // (wrapped_credits.aleo imports token_registry.aleo). Hits the public node.
+    #[test]
+    #[ignore = "network: run with `cargo test -- --ignored`"]
+    fn add_program_loads_imports_recursively() {
+        let url = std::env::var("ALEO_NODE_URL")
+            .unwrap_or_else(|_| "https://api.explorer.provable.com/v1".to_string());
+        let vm = new_vm().unwrap();
+        add_program_from_node(&vm, "wrapped_credits.aleo", &url, "testnet").unwrap();
+        let process = vm.process();
+        let process = process.read();
+        assert!(process.contains_program(&ProgramID::from_str("wrapped_credits.aleo").unwrap()));
+        assert!(
+            process.contains_program(&ProgramID::from_str("token_registry.aleo").unwrap()),
+            "recursive import token_registry.aleo was not loaded"
+        );
+    }
 }

--- a/rust/aleo_ffi/src/lib.rs
+++ b/rust/aleo_ffi/src/lib.rs
@@ -457,15 +457,44 @@ fn full_transaction(
     Ok(Transaction::from_execution(execution, Some(fee))?.to_string())
 }
 
+/// Returns a program's current on-chain edition by probing the node. snarkVM's
+/// REST serves the program source for any edition `<= current` and 404s above
+/// it, so the current edition is the highest one that exists. Errors (rather
+/// than guessing) when the node can't answer — registering at the wrong edition
+/// would produce a proof that disagrees with chain state.
+fn node_program_edition(base: &str, program_id: &str) -> anyhow::Result<u16> {
+    let exists = |edition: u16| -> anyhow::Result<bool> {
+        match ureq::get(&format!("{base}/program/{program_id}/{edition}")).call() {
+            Ok(_) => Ok(true),
+            Err(ureq::Error::Status(404, _)) => Ok(false),
+            Err(e) => Err(e.into()),
+        }
+    };
+    if !exists(0)? {
+        anyhow::bail!("program {program_id} not found while determining its edition");
+    }
+    let mut edition = 0u16;
+    while exists(edition + 1)? {
+        edition += 1;
+        if edition == u16::MAX {
+            anyhow::bail!("edition probe overflowed for {program_id}");
+        }
+    }
+    Ok(edition)
+}
+
 /// Fetches a non-builtin program from the node and adds it to the VM, loading
 /// every imported program first (snarkVM rejects a program whose imports are
 /// not already present). A no-op for built-in programs like credits.aleo or any
 /// program already loaded.
 ///
-/// Edition note: programs are added at edition 1, which is correct for the
-/// non-upgradeable programs wallets call. Programs that have been upgraded past
-/// edition 1 (constructor-bearing) would need their on-chain edition, which the
-/// public REST API does not expose as a "current edition" lookup.
+/// Edition selection:
+/// - Non-upgradeable programs (no constructor) execute at edition 1; edition 0
+///   is rejected by `Authorization::check_valid_edition` post-V8.
+/// - Upgradeable programs (with a constructor) start at edition 0 (added via
+///   `add_program`, which execution permits for constructor programs) and bump
+///   on each upgrade. Their current edition is read from the node; if it can't
+///   be determined the call fails rather than emit a proof at the wrong edition.
 fn add_program_from_node(
     vm: &VM<Net, ConsensusMemory<Net>>,
     program_id: &str,
@@ -494,11 +523,23 @@ fn add_program_from_node(
         add_program_from_node(vm, &import_id.to_string(), url, network)?;
     }
 
+    let edition = if program.contains_constructor() {
+        node_program_edition(&base, program_id)?
+    } else {
+        1
+    };
+
     let process = vm.process();
     let mut process = process.write();
     // A diamond import graph may have added it during the recursion above.
     if !process.contains_program(program.id()) {
-        process.add_program_with_edition(&program, 1)?;
+        // edition 0 uses `add_program` (the reviewer's recommended path for
+        // first-deploy constructor programs); higher editions are explicit.
+        if edition == 0 {
+            process.add_program(&program)?;
+        } else {
+            process.add_program_with_edition(&program, edition)?;
+        }
     }
     Ok(())
 }
@@ -1156,6 +1197,17 @@ mod tests {
     #[test]
     fn transfer_inputs_rejects_unknown_function() {
         assert!(transfer_inputs("not_a_transfer", "aleo1recipient", 1, "", &owner()).is_err());
+    }
+
+    // A non-upgradeable program (no constructor) reports edition 1. Validates
+    // the edition probe against a program whose execution edition is known.
+    #[test]
+    #[ignore = "network: run with `cargo test -- --ignored`"]
+    fn node_program_edition_non_upgradeable_is_one() {
+        let base = std::env::var("ALEO_NODE_URL")
+            .unwrap_or_else(|_| "https://api.explorer.provable.com/v1".to_string())
+            + "/testnet";
+        assert_eq!(node_program_edition(&base, "token_registry.aleo").unwrap(), 1);
     }
 
     // Loading a program pulls in its non-builtin imports recursively

--- a/rust/aleo_ffi/src/lib.rs
+++ b/rust/aleo_ffi/src/lib.rs
@@ -377,21 +377,84 @@ const HTTP_GET_ATTEMPTS: u32 = 4;
 /// incidental one.
 const HTTP_GET_DEADLINE: std::time::Duration = std::time::Duration::from_secs(240);
 
-/// Performs one GET, bounding the caller's wait by `budget` *wherever* the
-/// request blocks. ureq's per-request `.timeout()` covers the request and body
-/// read but not connection setup (a separate connect timeout) and cannot
-/// interrupt blocking DNS resolution, so a near-expired deadline could still be
-/// overrun by a slow connect or DNS lookup. Running the blocking call on a
-/// worker thread and waiting at most `budget` for it makes the deadline a real
-/// bound: the caller returns on time; the orphaned worker, itself capped by
-/// ureq's connect/request timeouts, exits on its own shortly after.
-fn get_once_bounded(url: &str, budget: std::time::Duration) -> anyhow::Result<String> {
+/// Most request workers allowed in flight at once. A worker can outlive its
+/// caller when blocked on connection setup or DNS resolution (ended by the OS
+/// resolver, which ureq cannot interrupt — not by us), so without a ceiling a
+/// burst of such calls could pile up threads and stacks until `thread::spawn`
+/// itself fails. Over the ceiling, a request fails fast instead of spawning.
+const MAX_INFLIGHT_REQUESTS: usize = 16;
+
+static INFLIGHT_REQUESTS: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+
+/// Counts one live request worker. The slot frees when the worker *thread*
+/// ends — which, for an abandoned worker stuck in DNS, is when the OS resolver
+/// finally returns, not when the caller stopped waiting — so the count tracks
+/// real live threads, capping accumulation rather than just concurrent callers.
+struct InflightPermit;
+
+impl InflightPermit {
+    fn acquire() -> Option<Self> {
+        use std::sync::atomic::Ordering::{Acquire, Relaxed};
+        let mut current = INFLIGHT_REQUESTS.load(Relaxed);
+        loop {
+            if current >= MAX_INFLIGHT_REQUESTS {
+                return None;
+            }
+            match INFLIGHT_REQUESTS.compare_exchange_weak(current, current + 1, Acquire, Relaxed) {
+                Ok(_) => return Some(Self),
+                Err(actual) => current = actual,
+            }
+        }
+    }
+}
+
+impl Drop for InflightPermit {
+    fn drop(&mut self) {
+        INFLIGHT_REQUESTS.fetch_sub(1, std::sync::atomic::Ordering::Release);
+    }
+}
+
+/// A GET, or a POST carrying a body. POST is issued at most once by callers
+/// (broadcasting a transaction is not idempotent — a retry could double-submit).
+enum HttpMethod {
+    Get,
+    Post(String),
+}
+
+/// Runs one request, bounding the caller's wait by `budget` *wherever* it
+/// blocks — including connection setup and DNS resolution, which ureq's own
+/// timeout cannot interrupt. The blocking call runs on a worker thread the
+/// caller waits at most `budget` for; an over-budget worker is left to finish
+/// on its own (bounded by ureq's timeouts for connect/read, or by the OS
+/// resolver for a DNS stall) and holds its in-flight permit until it does, so
+/// abandoned workers are capped at [`MAX_INFLIGHT_REQUESTS`] instead of able to
+/// accumulate without limit. This is what bounds the caller; ureq's timeouts
+/// alone cannot, because they do not cover connect-precedence and DNS.
+fn request_once_bounded(
+    method: HttpMethod,
+    url: &str,
+    budget: std::time::Duration,
+) -> anyhow::Result<String> {
+    let permit = InflightPermit::acquire()
+        .ok_or_else(|| anyhow::anyhow!("too many in-flight node requests (>{MAX_INFLIGHT_REQUESTS})"))?;
     let request_timeout = budget.min(HTTP_REQUEST_TIMEOUT);
     let url = url.to_string();
     let (tx, rx) = std::sync::mpsc::channel();
     std::thread::spawn(move || {
+        // The permit rides with the worker, so the slot is held until the
+        // thread truly ends — even after the caller has abandoned us.
+        let _permit = permit;
         let outcome = (|| -> anyhow::Result<String> {
-            Ok(http_agent().get(&url).timeout(request_timeout).call()?.into_string()?)
+            let agent = http_agent();
+            let response = match method {
+                HttpMethod::Get => agent.get(&url).timeout(request_timeout).call()?,
+                HttpMethod::Post(body) => agent
+                    .post(&url)
+                    .timeout(request_timeout)
+                    .set("Content-Type", "application/json")
+                    .send_string(&body)?,
+            };
+            Ok(response.into_string()?)
         })();
         // The receiver is gone if we already timed out; that is expected.
         let _ = tx.send(outcome);
@@ -421,7 +484,7 @@ fn http_get_until(url: &str, deadline: std::time::Instant) -> anyhow::Result<Str
         if remaining.is_zero() {
             break;
         }
-        match get_once_bounded(url, remaining) {
+        match request_once_bounded(HttpMethod::Get, url, remaining) {
             Ok(body) => return Ok(body),
             Err(error) => {
                 last_error = Some(error);
@@ -445,6 +508,13 @@ fn http_get_until(url: &str, deadline: std::time::Instant) -> anyhow::Result<Str
 /// have no overall budget of their own.
 fn http_get(url: &str) -> anyhow::Result<String> {
     http_get_until(url, std::time::Instant::now() + HTTP_GET_DEADLINE)
+}
+
+/// Single bounded POST, through the same worker-thread executor as GET so a
+/// POST cannot hang the synchronous call on connect/DNS either. Not retried
+/// (a transaction broadcast is not idempotent).
+fn http_post(url: &str, body: &str) -> anyhow::Result<String> {
+    request_once_bounded(HttpMethod::Post(body.to_string()), url, HTTP_GET_DEADLINE)
 }
 
 /// REST query against `{url}/{network}`. snarkVM's own RestQuery derives the
@@ -729,6 +799,12 @@ fn fetch_program_at_latest_edition(
 /// which execution permits; non-upgradeable programs are edition 1, upgraded
 /// programs their bumped edition. A wrong edition would yield a proof that
 /// disagrees with chain state, so edition determination failures propagate.
+///
+/// `add_program_with_edition` builds and verifies the program's `Stack` —
+/// real CPU work that snarkVM exposes no way to interrupt. The caller checks
+/// the load deadline *before* each call, so no new add starts once the budget
+/// is spent, but a call already under way runs to completion: the deadline
+/// bounds when adds *start*, with an overshoot of at most one program's add.
 fn add_fetched_program(
     vm: &VM<Net, ConsensusMemory<Net>>,
     program: &Program<Net>,
@@ -761,7 +837,10 @@ fn add_fetched_program(
 /// before it — and is rejected as a lying node. Because the protocol does not
 /// bound closure size, the whole walk runs against a [`LoadBudget`] (total time
 /// and program count) so an unbounded acyclic chain of distinct valid programs
-/// cannot block the synchronous call forever or exhaust memory.
+/// cannot block the synchronous call indefinitely or exhaust memory. The time
+/// budget gates the *start* of every fetch, parse and add; one in-flight
+/// `add_fetched_program` is not interrupted (see its docs), so the real
+/// overshoot past the deadline is at most a single program's add.
 fn add_program_from_node(
     vm: &VM<Net, ConsensusMemory<Net>>,
     program_id: &str,
@@ -868,14 +947,12 @@ fn program_fee(
     Ok(serde_json::to_string(&fee)?)
 }
 
-/// POSTs a transaction to the node, returning the node's response body.
+/// POSTs a transaction to the node, returning the node's response body. Goes
+/// through the bounded executor, so a stalled/odd-DNS node fails the call
+/// instead of hanging the synchronous broadcast forever.
 fn broadcast_to_node(transaction: &str, url: &str, network: &str) -> anyhow::Result<String> {
     let base = format!("{}/{}", url.trim_end_matches('/'), network);
-    Ok(http_agent()
-        .post(&format!("{base}/transaction/broadcast"))
-        .set("Content-Type", "application/json")
-        .send_string(transaction)?
-        .into_string()?)
+    http_post(&format!("{base}/transaction/broadcast"), transaction)
 }
 
 /// Builds a complete credits.aleo transfer transaction (without broadcasting).
@@ -1227,13 +1304,7 @@ pub unsafe extern "C" fn broadcast(
     network: *const c_char,
 ) -> *mut c_char {
     let inner = || -> anyhow::Result<String> {
-        let base = format!("{}/{}", read_str(url).trim_end_matches('/'), read_str(network));
-        let response = http_agent()
-            .post(&format!("{base}/transaction/broadcast"))
-            .set("Content-Type", "application/json")
-            .send_string(read_str(transaction))?
-            .into_string()?;
-        Ok(response)
+        broadcast_to_node(read_str(transaction), read_str(url), read_str(network))
     };
     match inner() {
         Ok(response) => to_cstring(response),
@@ -1725,6 +1796,40 @@ mod tests {
             http_get_until(&format!("{url}/x"), started + std::time::Duration::from_secs(1));
         assert!(result.is_err());
         assert!(started.elapsed() < std::time::Duration::from_secs(15), "took {:?}", started.elapsed());
+    }
+
+    // POST (broadcast) goes through the same bounded executor, so a stalling
+    // node bounds it too instead of hanging the synchronous broadcast forever.
+    #[test]
+    fn post_bounded_against_stalling_node() {
+        let url = serve_stalling();
+        let started = std::time::Instant::now();
+        let result = request_once_bounded(
+            HttpMethod::Post("{}".to_string()),
+            &format!("{url}/x"),
+            std::time::Duration::from_secs(1),
+        );
+        assert!(result.is_err());
+        assert!(started.elapsed() < std::time::Duration::from_secs(15), "took {:?}", started.elapsed());
+    }
+
+    // The in-flight permit caps concurrency: once the ceiling is held, the next
+    // acquire is refused; freeing a permit lets a later one through. Acquire
+    // up-to-refusal rather than from a fixed base, since other tests share the
+    // global counter.
+    #[test]
+    fn inflight_permit_caps_then_recovers() {
+        let mut held = Vec::new();
+        while held.len() <= MAX_INFLIGHT_REQUESTS {
+            match InflightPermit::acquire() {
+                Some(permit) => held.push(permit),
+                None => break,
+            }
+        }
+        assert!(held.len() <= MAX_INFLIGHT_REQUESTS, "never exceeds the cap");
+        assert!(!held.is_empty(), "acquired at least one");
+        held.clear(); // free them all
+        assert!(InflightPermit::acquire().is_some(), "freed slots are reusable");
     }
 
     // The whole import-graph load — not just one request — is bounded by the

--- a/rust/aleo_ffi/src/lib.rs
+++ b/rust/aleo_ffi/src/lib.rs
@@ -457,6 +457,54 @@ fn add_program_from_node(
     Ok(())
 }
 
+/// Authorizes and executes a program function, returning the serialized
+/// execution. Fetches the program if it isn't built in.
+fn program_execution(
+    private_key: &PrivateKey<Net>,
+    program_id: &str,
+    function: &str,
+    arguments: &str,
+    url: &str,
+    network: &str,
+) -> anyhow::Result<String> {
+    let inputs: Vec<String> = serde_json::from_str(arguments)?;
+    let vm = new_vm()?;
+    add_program_from_node(&vm, program_id, url, network)?;
+    let query = NodeQuery::new(url, network);
+    let rng = &mut rand::thread_rng();
+    let authorization = vm.authorize(private_key, program_id, function, inputs, rng)?;
+    let (execution, _response) = vm.execute_authorization_raw(authorization, &query, rng)?;
+    Ok(serde_json::to_string(&execution)?)
+}
+
+/// Produces the (public) fee proof for a serialized execution of `program_id`.
+/// The program is loaded so its per-transition cost can be computed.
+fn program_fee(
+    private_key: &PrivateKey<Net>,
+    priority_fee: u64,
+    execution: &str,
+    program_id: &str,
+    url: &str,
+    network: &str,
+) -> anyhow::Result<String> {
+    let execution: Execution<Net> = serde_json::from_str(execution)?;
+    let vm = new_vm()?;
+    add_program_from_node(&vm, program_id, url, network)?;
+    let query = NodeQuery::new(url, network);
+    let rng = &mut rand::thread_rng();
+    let execution_id = execution.to_execution_id()?;
+    let base_fee = {
+        let consensus_version = Net::CONSENSUS_VERSION(query.current_block_height()?)?;
+        let process = vm.process();
+        let process = process.read();
+        snarkvm_synthesizer::process::execution_cost(&process, &execution, consensus_version)?.0
+    };
+    let fee_authorization =
+        vm.authorize_fee_public(private_key, base_fee, priority_fee, execution_id, rng)?;
+    let fee = vm.execute_fee_authorization_raw(fee_authorization, &query, rng)?;
+    Ok(serde_json::to_string(&fee)?)
+}
+
 /// POSTs a transaction to the node, returning the node's response body.
 fn broadcast_to_node(transaction: &str, url: &str, network: &str) -> anyhow::Result<String> {
     let base = format!("{}/{}", url.trim_end_matches('/'), network);
@@ -604,21 +652,85 @@ pub unsafe extern "C" fn execute_program_proof(
 ) -> *mut c_char {
     let inner = || -> anyhow::Result<String> {
         let private_key = PrivateKey::<Net>::from_str(read_str(private_key))?;
-        let program_id = read_str(program_id);
-        let inputs: Vec<String> = serde_json::from_str(read_str(arguments))?;
-        let vm = new_vm()?;
-        add_program_from_node(&vm, program_id, read_str(url), read_str(network))?;
-        let query = NodeQuery::new(read_str(url), read_str(network));
-        let rng = &mut rand::thread_rng();
-        let authorization =
-            vm.authorize(&private_key, program_id, read_str(function_name), inputs, rng)?;
-        let (execution, _response) = vm.execute_authorization_raw(authorization, &query, rng)?;
-        Ok(serde_json::to_string(&execution)?)
+        program_execution(
+            &private_key,
+            read_str(program_id),
+            read_str(function_name),
+            read_str(arguments),
+            read_str(url),
+            read_str(network),
+        )
     };
     match inner() {
         Ok(execution) => to_cstring(execution),
         Err(error) => {
             eprintln!("[execute_program_proof] {error:?}");
+            to_cstring(String::new())
+        }
+    }
+}
+
+/// Like `execute_program_proof`: authorizes + executes a program function,
+/// returning the serialized execution (split-proof; fee comes separately via
+/// `contract_fee_execution`).
+///
+/// SAFETY: the pointer args are NUL-terminated C strings.
+#[no_mangle]
+pub unsafe extern "C" fn contract_execution(
+    private_key: *const c_char,
+    program_id: *const c_char,
+    function_name: *const c_char,
+    arguments: *const c_char,
+    url: *const c_char,
+    network: *const c_char,
+) -> *mut c_char {
+    let inner = || -> anyhow::Result<String> {
+        let private_key = PrivateKey::<Net>::from_str(read_str(private_key))?;
+        program_execution(
+            &private_key,
+            read_str(program_id),
+            read_str(function_name),
+            read_str(arguments),
+            read_str(url),
+            read_str(network),
+        )
+    };
+    match inner() {
+        Ok(execution) => to_cstring(execution),
+        Err(error) => {
+            eprintln!("[contract_execution] {error:?}");
+            to_cstring(String::new())
+        }
+    }
+}
+
+/// Produces the public fee proof for a contract execution. Returns "".
+///
+/// SAFETY: the pointer args are NUL-terminated C strings.
+#[no_mangle]
+pub unsafe extern "C" fn contract_fee_execution(
+    private_key: *const c_char,
+    fee: c_int,
+    execution: *const c_char,
+    program_id: *const c_char,
+    url: *const c_char,
+    network: *const c_char,
+) -> *mut c_char {
+    let inner = || -> anyhow::Result<String> {
+        let private_key = PrivateKey::<Net>::from_str(read_str(private_key))?;
+        program_fee(
+            &private_key,
+            fee as u64,
+            read_str(execution),
+            read_str(program_id),
+            read_str(url),
+            read_str(network),
+        )
+    };
+    match inner() {
+        Ok(fee) => to_cstring(fee),
+        Err(error) => {
+            eprintln!("[contract_fee_execution] {error:?}");
             to_cstring(String::new())
         }
     }

--- a/rust/aleo_ffi/src/lib.rs
+++ b/rust/aleo_ffi/src/lib.rs
@@ -335,18 +335,19 @@ fn new_vm() -> anyhow::Result<VM<Net, ConsensusMemory<Net>>> {
     VM::from(ConsensusStore::<Net, ConsensusMemory<Net>>::open(StorageMode::Production)?)
 }
 
-/// Shared HTTP agent with bounded timeouts. `ureq`'s defaults only bound the
-/// connect phase, so a node that accepts the connection and then stalls would
-/// hang the (synchronous) FFI call forever and the retry loop would never run.
-/// The read/write timeouts cap each attempt so a stalled peer surfaces as an
-/// error and is retried.
+/// Shared HTTP agent with bounded timeouts. `.timeout()` is a deadline for the
+/// whole exchange — connect, request, and reading the response body — so a
+/// node that stalls *or trickles bytes indefinitely* surfaces as an error
+/// instead of hanging the (synchronous) FFI call. Per-read timeouts alone
+/// would not do that: each trickled byte resets them. Response memory is
+/// bounded as well: every body is read via `into_string()`, which fails past
+/// 10 MiB rather than growing without limit.
 fn http_agent() -> &'static ureq::Agent {
     static AGENT: std::sync::OnceLock<ureq::Agent> = std::sync::OnceLock::new();
     AGENT.get_or_init(|| {
         ureq::AgentBuilder::new()
             .timeout_connect(std::time::Duration::from_secs(10))
-            .timeout_read(std::time::Duration::from_secs(30))
-            .timeout_write(std::time::Duration::from_secs(30))
+            .timeout(std::time::Duration::from_secs(60))
             .build()
     })
 }
@@ -401,7 +402,16 @@ impl QueryTrait<Net> for NodeQuery {
         &self,
         commitments: &[Field<Net>],
     ) -> anyhow::Result<Vec<StatePath<Net>>> {
-        commitments.iter().map(|commitment| self.get_state_path_for_commitment(commitment)).collect()
+        // One batch request (the same `statePaths` route snarkVM's RestQuery
+        // uses) so every returned path is anchored to a single block: fetching
+        // per commitment can straddle a block boundary, and the inclusion
+        // prover rejects state paths that disagree on the global state root.
+        if commitments.is_empty() {
+            return Ok(Vec::new());
+        }
+        let commitments =
+            commitments.iter().map(|commitment| commitment.to_string()).collect::<Vec<_>>();
+        self.get_json(&format!("statePaths?commitments={}", commitments.join(",")))
     }
 
     fn current_block_height(&self) -> anyhow::Result<u32> {

--- a/rust/aleo_ffi/src/lib.rs
+++ b/rust/aleo_ffi/src/lib.rs
@@ -562,6 +562,51 @@ struct PendingProgram {
     pending: Vec<ProgramID<Net>>,
 }
 
+/// Wall-clock ceiling on resolving one import graph from a node. A real
+/// closure loads in a second or two; this is a DoS guard, not a protocol
+/// limit, so it sits far above any honest case. Checked between fetches, each
+/// of which is itself bounded by the per-request agent timeout.
+const IMPORT_LOAD_DEADLINE: std::time::Duration = std::time::Duration::from_secs(120);
+
+/// Ceiling on the number of programs fetched while resolving one import graph.
+/// On-chain closures are tens of programs; this is far above any of them but,
+/// with each source bounded by `MAX_PROGRAM_SIZE`, caps total memory. Like the
+/// deadline it is a DoS budget the protocol itself does not define (it bounds
+/// only a program's *direct* imports and source size, not transitive closure
+/// size), made generous so it never rejects an honest closure — the explicit
+/// trade-off for not reintroducing a depth/length cap that would.
+const MAX_IMPORT_PROGRAMS: usize = 256;
+
+/// Resource budget for a single `add_program_from_node` load, bounding the two
+/// ways a hostile node can make an honest, acyclic, individually-valid import
+/// chain expensive: total time and total programs (hence memory).
+struct LoadBudget {
+    deadline: std::time::Instant,
+    remaining_programs: usize,
+}
+
+impl LoadBudget {
+    fn new() -> Self {
+        Self {
+            deadline: std::time::Instant::now() + IMPORT_LOAD_DEADLINE,
+            remaining_programs: MAX_IMPORT_PROGRAMS,
+        }
+    }
+
+    /// Accounts for one program about to be fetched, failing if either budget
+    /// is spent.
+    fn charge_one_program(&mut self) -> anyhow::Result<()> {
+        anyhow::ensure!(
+            std::time::Instant::now() < self.deadline,
+            "import load exceeded its {IMPORT_LOAD_DEADLINE:?} time budget"
+        );
+        self.remaining_programs = self.remaining_programs.checked_sub(1).ok_or_else(|| {
+            anyhow::anyhow!("import load exceeded its {MAX_IMPORT_PROGRAMS}-program budget")
+        })?;
+        Ok(())
+    }
+}
+
 /// True for built-in programs and anything already loaded in the process.
 fn program_is_present(vm: &VM<Net, ConsensusMemory<Net>>, id: &ProgramID<Net>) -> bool {
     id.to_string() == "credits.aleo" || vm.process().read().contains_program(id)
@@ -570,15 +615,25 @@ fn program_is_present(vm: &VM<Net, ConsensusMemory<Net>>, id: &ProgramID<Net>) -
 /// Fetches `id`'s source at its current on-chain edition. The two are read in
 /// that order (`latest_edition`, then `/program/{id}/{edition}`) so they stay
 /// consistent even if the program is upgraded concurrently. The node is not
-/// trusted: the returned source must actually declare `id`, so a node cannot
-/// substitute a different program for a requested import.
+/// trusted: the source may not exceed `MAX_PROGRAM_SIZE` (a larger one cannot
+/// be a valid on-chain program, so rejecting it never rejects a real one) and
+/// must actually declare `id`, so a node can neither flood memory with an
+/// oversized body nor substitute a different program for a requested import.
 fn fetch_program_at_latest_edition(
     base: &str,
     id: &ProgramID<Net>,
+    budget: &mut LoadBudget,
 ) -> anyhow::Result<PendingProgram> {
+    budget.charge_one_program()?;
     let edition = node_latest_edition(base, &id.to_string())?;
     let body = http_get(&format!("{base}/program/{id}/{edition}"))?;
     let source: String = serde_json::from_str(body.trim())?;
+    anyhow::ensure!(
+        source.len() <= Net::MAX_PROGRAM_SIZE,
+        "node returned a {}-byte source for '{id}', over the {}-byte maximum",
+        source.len(),
+        Net::MAX_PROGRAM_SIZE
+    );
     let program = Program::<Net>::from_str(&source)?;
     if program.id() != id {
         anyhow::bail!("node returned program '{}' for requested '{id}'", program.id());
@@ -621,7 +676,10 @@ fn add_fetched_program(
 /// no limit on transitive chain length, so arbitrarily deep legal chains must
 /// load. An import referring back to a program still being loaded is a cycle —
 /// impossible on-chain, where a program can only import programs deployed
-/// before it — and is rejected as a lying node.
+/// before it — and is rejected as a lying node. Because the protocol does not
+/// bound closure size, the whole walk runs against a [`LoadBudget`] (total time
+/// and program count) so an unbounded acyclic chain of distinct valid programs
+/// cannot block the synchronous call forever or exhaust memory.
 fn add_program_from_node(
     vm: &VM<Net, ConsensusMemory<Net>>,
     program_id: &str,
@@ -633,9 +691,10 @@ fn add_program_from_node(
         return Ok(());
     }
     let base = format!("{}/{}", url.trim_end_matches('/'), network);
+    let budget = &mut LoadBudget::new();
 
     // `stack` holds fetched programs whose imports are still being satisfied.
-    let mut stack = vec![fetch_program_at_latest_edition(&base, &requested)?];
+    let mut stack = vec![fetch_program_at_latest_edition(&base, &requested, budget)?];
     while let Some(frame) = stack.last_mut() {
         match frame.pending.pop() {
             Some(import_id) => {
@@ -650,7 +709,7 @@ fn add_program_from_node(
                     anyhow::bail!("node returned an import cycle: {chain} -> {import_id}");
                 }
                 if !program_is_present(vm, &import_id) {
-                    stack.push(fetch_program_at_latest_edition(&base, &import_id)?);
+                    stack.push(fetch_program_at_latest_edition(&base, &import_id, budget)?);
                 }
             }
             None => {
@@ -1400,6 +1459,44 @@ mod tests {
         address
     }
 
+    /// Like [`serve_canned`] but computes each response from the request path,
+    /// so a test can model an *unbounded* node (e.g. an endless distinct import
+    /// chain) without materializing infinite routes.
+    fn serve_dynamic<F>(handler: F) -> String
+    where
+        F: Fn(&str) -> Option<String> + Send + 'static,
+    {
+        use std::io::{Read, Write};
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = format!("http://{}", listener.local_addr().unwrap());
+        std::thread::spawn(move || {
+            for stream in listener.incoming() {
+                let Ok(mut stream) = stream else { continue };
+                let mut buffer = [0u8; 4096];
+                let read = stream.read(&mut buffer).unwrap_or(0);
+                let request = String::from_utf8_lossy(&buffer[..read]).into_owned();
+                let path = request.split_whitespace().nth(1).unwrap_or("");
+                let (status, body) = match handler(path) {
+                    Some(body) => ("200 OK", body),
+                    None => ("404 Not Found", String::new()),
+                };
+                let _ = write!(
+                    stream,
+                    "HTTP/1.1 {status}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                    body.len()
+                );
+            }
+        });
+        address
+    }
+
+    /// Source for a minimal valid program named `id` importing `imports`.
+    fn program_source(id: &str, imports: &[String]) -> String {
+        let imports_block =
+            imports.iter().map(|import| format!("import {import};\n")).collect::<String>();
+        format!("{imports_block}\nprogram {id};\n\nfunction noop:\n    add 1u8 1u8 into r0;\n")
+    }
+
     /// Registers the `latest_edition` and source routes for a minimal valid
     /// program named `id` importing `imports`.
     fn program_routes(
@@ -1407,10 +1504,7 @@ mod tests {
         id: &str,
         imports: &[String],
     ) {
-        let imports_block =
-            imports.iter().map(|import| format!("import {import};\n")).collect::<String>();
-        let source =
-            format!("{imports_block}\nprogram {id};\n\nfunction noop:\n    add 1u8 1u8 into r0;\n");
+        let source = program_source(id, imports);
         routes.insert(format!("/testnet/program/{id}/latest_edition"), "1".to_string());
         routes.insert(format!("/testnet/program/{id}/1"), serde_json::to_string(&source).unwrap());
     }
@@ -1467,6 +1561,48 @@ mod tests {
         assert!(process.contains_program(&ProgramID::from_str("deep0.aleo").unwrap()));
         assert!(process
             .contains_program(&ProgramID::from_str(&format!("deep{}.aleo", DEPTH - 1)).unwrap()));
+    }
+
+    // An acyclic but endless chain of distinct, individually-valid programs
+    // (no cycle, each within protocol limits) must still terminate, on the
+    // program-count budget, rather than fetch forever or exhaust memory.
+    #[test]
+    fn unbounded_import_chain_hits_budget() {
+        // Every `deepN.aleo` validly imports `deep{N+1}.aleo`, without end.
+        let url = serve_dynamic(|path| {
+            let parts: Vec<&str> = path.trim_start_matches('/').split('/').collect();
+            // ["testnet", "program", "deepN.aleo", "latest_edition" | "1"]
+            if parts.len() != 4 || parts[1] != "program" {
+                return None;
+            }
+            let id = parts[2];
+            if parts[3] == "latest_edition" {
+                return Some("1".to_string());
+            }
+            let n: usize = id.strip_prefix("deep")?.strip_suffix(".aleo")?.parse().ok()?;
+            let source = program_source(id, &[format!("deep{}.aleo", n + 1)]);
+            Some(serde_json::to_string(&source).unwrap())
+        });
+        let vm = new_vm().unwrap();
+        let error = add_program_from_node(&vm, "deep0.aleo", &url, "testnet").unwrap_err();
+        assert!(error.to_string().contains("program budget"), "got: {error}");
+    }
+
+    // A source larger than the protocol maximum can't be a real program, so it
+    // must be rejected (bounding per-fetch memory) rather than parsed.
+    #[test]
+    fn oversized_program_source_rejected() {
+        let mut routes = std::collections::HashMap::new();
+        let bloated = format!("program big.aleo;\n{}", " ".repeat(Net::MAX_PROGRAM_SIZE + 1));
+        routes.insert("/testnet/program/big.aleo/latest_edition".to_string(), "1".to_string());
+        routes.insert(
+            "/testnet/program/big.aleo/1".to_string(),
+            serde_json::to_string(&bloated).unwrap(),
+        );
+        let url = serve_canned(routes);
+        let vm = new_vm().unwrap();
+        let error = add_program_from_node(&vm, "big.aleo", &url, "testnet").unwrap_err();
+        assert!(error.to_string().contains("maximum"), "got: {error}");
     }
 
     // A fee the network would reject must fail before proving, and the

--- a/rust/aleo_ffi/src/lib.rs
+++ b/rust/aleo_ffi/src/lib.rs
@@ -359,10 +359,10 @@ impl QueryTrait<Net> for NodeQuery {
 }
 
 /// Current block height from the node (used to select the consensus version).
+/// Goes through `NodeQuery` so it shares the retrying `http_get` (the public
+/// node returns transient 5xx/522), like every other node read.
 fn fetch_height(url: &str, network: &str) -> anyhow::Result<u32> {
-    let base = format!("{}/{}", url.trim_end_matches('/'), network);
-    let height = ureq::get(&format!("{base}/latest/height")).call()?.into_string()?;
-    Ok(height.trim().parse()?)
+    NodeQuery::new(url, network).current_block_height()
 }
 
 /// Minimum (base) fee in microcredits for an execution at the node's height.

--- a/rust/aleo_ffi/src/lib.rs
+++ b/rust/aleo_ffi/src/lib.rs
@@ -34,15 +34,22 @@ use aleo_std_storage::StorageMode;
 /// these account operations.
 type Net = MainnetV0;
 
+/// Borrows a C string as `&str`. Invalid UTF-8 yields "" rather than panicking,
+/// so malformed input is handled by the caller's normal "" error path instead
+/// of unwinding across the FFI boundary (which aborts the process).
+///
 /// SAFETY: `p` must be a valid NUL-terminated C string for the duration of the call.
 unsafe fn read_str<'a>(p: *const c_char) -> &'a str {
-    CStr::from_ptr(p).to_str().expect("invalid UTF-8 in FFI input")
+    CStr::from_ptr(p).to_str().unwrap_or("")
 }
 
 /// Transfers ownership of a heap C string to the caller (matches the existing
-/// FFI contract; the caller is responsible for the buffer).
+/// FFI contract; the caller is responsible for the buffer). A NUL in the output
+/// (never expected for our textual outputs) is truncated rather than panicking.
 fn to_cstring(s: String) -> *mut c_char {
-    CString::new(s).expect("unexpected NUL in FFI output").into_raw()
+    let bytes: Vec<u8> = s.into_bytes().into_iter().take_while(|&b| b != 0).collect();
+    // SAFETY: `take_while` stops at the first NUL, so `bytes` has no interior NUL.
+    unsafe { CString::from_vec_unchecked(bytes) }.into_raw()
 }
 
 /// Frees a string previously returned by this library. Returned pointers are
@@ -80,36 +87,50 @@ pub unsafe extern "C" fn seed_to_private_key(seed: *const u8) -> *mut c_char {
     }
 }
 
+/// Returns "" on a malformed key (rather than panicking, which would unwind
+/// across the FFI boundary and abort the process).
+///
 /// SAFETY: `pk` must be a valid NUL-terminated C string.
 #[no_mangle]
 pub unsafe extern "C" fn private_key_to_address(pk: *const c_char) -> *mut c_char {
-    let private_key = PrivateKey::<Net>::from_str(read_str(pk)).expect("parse private key");
-    let address = Address::<Net>::try_from(&private_key).expect("private key -> address");
-    to_cstring(address.to_string())
+    let result = (|| -> Option<String> {
+        let private_key = PrivateKey::<Net>::from_str(read_str(pk)).ok()?;
+        Some(Address::<Net>::try_from(&private_key).ok()?.to_string())
+    })();
+    to_cstring(result.unwrap_or_default())
 }
 
-/// SAFETY: `pk` must be a valid NUL-terminated C string.
+/// Returns "" on a malformed key. SAFETY: `pk` is a NUL-terminated C string.
 #[no_mangle]
 pub unsafe extern "C" fn private_key_to_view_key(pk: *const c_char) -> *mut c_char {
-    let private_key = PrivateKey::<Net>::from_str(read_str(pk)).expect("parse private key");
-    let view_key = ViewKey::<Net>::try_from(&private_key).expect("private key -> view key");
-    to_cstring(view_key.to_string())
+    let result = (|| -> Option<String> {
+        let private_key = PrivateKey::<Net>::from_str(read_str(pk)).ok()?;
+        Some(ViewKey::<Net>::try_from(&private_key).ok()?.to_string())
+    })();
+    to_cstring(result.unwrap_or_default())
 }
 
-/// SAFETY: `vk` must be a valid NUL-terminated C string.
+/// Returns "" on a malformed key. SAFETY: `vk` is a NUL-terminated C string.
 #[no_mangle]
 pub unsafe extern "C" fn view_key_to_address(vk: *const c_char) -> *mut c_char {
-    let view_key = ViewKey::<Net>::from_str(read_str(vk)).expect("parse view key");
-    to_cstring(view_key.to_address().to_string())
+    let result = (|| -> Option<String> {
+        let view_key = ViewKey::<Net>::from_str(read_str(vk)).ok()?;
+        Some(view_key.to_address().to_string())
+    })();
+    to_cstring(result.unwrap_or_default())
 }
 
-/// SAFETY: `pk` is a NUL-terminated C string; `msg` points to `len` readable bytes.
+/// Returns "" on a malformed key or signing failure (no panic across the FFI
+/// boundary). SAFETY: `pk` is a NUL-terminated C string; `msg` points to `len`
+/// readable bytes.
 #[no_mangle]
 pub unsafe extern "C" fn sign_message(pk: *const c_char, msg: *const u8, len: c_int) -> *mut c_char {
-    let private_key = PrivateKey::<Net>::from_str(read_str(pk)).expect("parse private key");
     let message = slice::from_raw_parts(msg, len as usize);
-    let signature = private_key.sign_bytes(message, &mut OsRng).expect("sign");
-    to_cstring(signature.to_string())
+    let result = (|| -> Option<String> {
+        let private_key = PrivateKey::<Net>::from_str(read_str(pk)).ok()?;
+        Some(private_key.sign_bytes(message, &mut OsRng).ok()?.to_string())
+    })();
+    to_cstring(result.unwrap_or_default())
 }
 
 /// Returns 1 if the signature is valid, 0 otherwise.
@@ -1210,6 +1231,28 @@ mod tests {
         unsafe {
             free_string(to_cstring("hello".to_string()));
             free_string(std::ptr::null_mut());
+        }
+    }
+
+    // Malformed input must return "" (not panic/abort across the FFI boundary).
+    #[test]
+    fn malformed_key_returns_empty_not_abort() {
+        unsafe {
+            let bad = CString::new("not-a-valid-key").unwrap();
+            let fns: [unsafe extern "C" fn(*const c_char) -> *mut c_char; 3] = [
+                private_key_to_address,
+                private_key_to_view_key,
+                view_key_to_address,
+            ];
+            for f in fns {
+                let ptr = f(bad.as_ptr());
+                assert!(CStr::from_ptr(ptr).to_str().unwrap().is_empty());
+                free_string(ptr);
+            }
+            let msg = [1u8, 2, 3];
+            let ptr = sign_message(bad.as_ptr(), msg.as_ptr(), 3);
+            assert!(CStr::from_ptr(ptr).to_str().unwrap().is_empty());
+            free_string(ptr);
         }
     }
 

--- a/rust/aleo_ffi/src/lib.rs
+++ b/rust/aleo_ffi/src/lib.rs
@@ -364,20 +364,58 @@ fn http_agent() -> &'static ureq::Agent {
     })
 }
 
+/// Per-attempt ceiling on one HTTP request (connect, request, body read).
+/// Overridden downward when less of the caller's overall deadline remains.
+const HTTP_REQUEST_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(60);
+
+/// Number of attempts `http_get` makes against the (flaky) public node.
+const HTTP_GET_ATTEMPTS: u32 = 4;
+
+/// Default overall deadline for a standalone `http_get`, for callers without
+/// their own budget. Covers all attempts and their backoff, keeping the
+/// historical 4 x 60s retry envelope — but now as a hard bound rather than an
+/// incidental one.
+const HTTP_GET_DEADLINE: std::time::Duration = std::time::Duration::from_secs(240);
+
 /// HTTP GET with a few retries (the public node occasionally returns transient
-/// 5xx / connection errors).
-fn http_get(url: &str) -> anyhow::Result<String> {
+/// 5xx / connection errors), bounded by `deadline`: no request, retry, or
+/// backoff sleep runs past it, and each request's own timeout is the smaller of
+/// [`HTTP_REQUEST_TIMEOUT`] and the time left. Passing an overall `deadline`
+/// lets a caller's budget (e.g. the import-graph load) cap the *total* time
+/// across every request it triggers, not just each one in isolation — a
+/// per-request timeout alone bounds one attempt, but several attempts across
+/// several fetches still add up well past any single-request limit.
+fn http_get_until(url: &str, deadline: std::time::Instant) -> anyhow::Result<String> {
     let mut last_error = None;
-    for attempt in 0..4 {
-        match http_agent().get(url).call() {
+    for attempt in 0..HTTP_GET_ATTEMPTS {
+        let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+        if remaining.is_zero() {
+            break;
+        }
+        match http_agent().get(url).timeout(remaining.min(HTTP_REQUEST_TIMEOUT)).call() {
             Ok(response) => return Ok(response.into_string()?),
             Err(error) => {
                 last_error = Some(error);
-                std::thread::sleep(std::time::Duration::from_millis(500 * (attempt + 1)));
+                // Back off before retrying, but never past the deadline and not
+                // at all after the final attempt.
+                if attempt + 1 < HTTP_GET_ATTEMPTS {
+                    let backoff = std::time::Duration::from_millis(500 * (attempt as u64 + 1));
+                    let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+                    if remaining.is_zero() {
+                        break;
+                    }
+                    std::thread::sleep(backoff.min(remaining));
+                }
             }
         }
     }
     Err(anyhow::anyhow!("GET {url} failed after retries: {last_error:?}"))
+}
+
+/// [`http_get_until`] with the default standalone deadline, for callers that
+/// have no overall budget of their own.
+fn http_get(url: &str) -> anyhow::Result<String> {
+    http_get_until(url, std::time::Instant::now() + HTTP_GET_DEADLINE)
 }
 
 /// REST query against `{url}/{network}`. snarkVM's own RestQuery derives the
@@ -548,9 +586,14 @@ fn full_transaction(
 }
 
 /// Reads a program's current on-chain edition from snarkOS's
-/// `/program/{id}/latest_edition` route (via the retrying `http_get`).
-fn node_latest_edition(base: &str, program_id: &str) -> anyhow::Result<u16> {
-    let body = http_get(&format!("{base}/program/{program_id}/latest_edition"))?;
+/// `/program/{id}/latest_edition` route, bounded by `deadline` (shared with the
+/// rest of the import-graph load).
+fn node_latest_edition(
+    base: &str,
+    program_id: &str,
+    deadline: std::time::Instant,
+) -> anyhow::Result<u16> {
+    let body = http_get_until(&format!("{base}/program/{program_id}/latest_edition"), deadline)?;
     Ok(body.trim().trim_matches('"').parse()?)
 }
 
@@ -625,8 +668,8 @@ fn fetch_program_at_latest_edition(
     budget: &mut LoadBudget,
 ) -> anyhow::Result<PendingProgram> {
     budget.charge_one_program()?;
-    let edition = node_latest_edition(base, &id.to_string())?;
-    let body = http_get(&format!("{base}/program/{id}/{edition}"))?;
+    let edition = node_latest_edition(base, &id.to_string(), budget.deadline)?;
+    let body = http_get_until(&format!("{base}/program/{id}/{edition}"), budget.deadline)?;
     let source: String = serde_json::from_str(body.trim())?;
     anyhow::ensure!(
         source.len() <= Net::MAX_PROGRAM_SIZE,
@@ -686,12 +729,24 @@ fn add_program_from_node(
     url: &str,
     network: &str,
 ) -> anyhow::Result<()> {
+    add_program_from_node_within(vm, program_id, url, network, LoadBudget::new())
+}
+
+/// [`add_program_from_node`] with an explicit budget, so a caller (or test) can
+/// bound the whole load rather than take the default.
+fn add_program_from_node_within(
+    vm: &VM<Net, ConsensusMemory<Net>>,
+    program_id: &str,
+    url: &str,
+    network: &str,
+    mut budget: LoadBudget,
+) -> anyhow::Result<()> {
     let requested = ProgramID::<Net>::from_str(program_id)?;
     if program_is_present(vm, &requested) {
         return Ok(());
     }
     let base = format!("{}/{}", url.trim_end_matches('/'), network);
-    let budget = &mut LoadBudget::new();
+    let budget = &mut budget;
 
     // `stack` holds fetched programs whose imports are still being satisfied.
     let mut stack = vec![fetch_program_at_latest_edition(&base, &requested, budget)?];
@@ -1588,6 +1643,66 @@ mod tests {
         assert!(error.to_string().contains("program budget"), "got: {error}");
     }
 
+    /// Accepts connections and never replies, so a client's per-request timeout
+    /// / overall deadline — not the server — is what ends the call.
+    fn serve_stalling() -> String {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = format!("http://{}", listener.local_addr().unwrap());
+        std::thread::spawn(move || {
+            for stream in listener.incoming() {
+                let Ok(stream) = stream else { continue };
+                // Hold the socket open a while without responding, then drop it.
+                std::thread::spawn(move || {
+                    std::thread::sleep(std::time::Duration::from_secs(30));
+                    drop(stream);
+                });
+            }
+        });
+        address
+    }
+
+    // A deadline already in the past makes no request at all and returns at
+    // once (the URL is never contacted).
+    #[test]
+    fn http_get_past_deadline_returns_immediately() {
+        let started = std::time::Instant::now();
+        let result =
+            http_get_until("http://203.0.113.1/never", started - std::time::Duration::from_secs(1));
+        assert!(result.is_err());
+        assert!(started.elapsed() < std::time::Duration::from_secs(1), "took {:?}", started.elapsed());
+    }
+
+    // A stalling node must not hold the call past the deadline: without the
+    // deadline plumbing this would block ~4 x 60s, here it ends in ~1s.
+    #[test]
+    fn http_get_bounded_by_deadline_against_stalling_node() {
+        let url = serve_stalling();
+        let started = std::time::Instant::now();
+        let result =
+            http_get_until(&format!("{url}/x"), started + std::time::Duration::from_secs(1));
+        assert!(result.is_err());
+        assert!(started.elapsed() < std::time::Duration::from_secs(15), "took {:?}", started.elapsed());
+    }
+
+    // The whole import-graph load — not just one request — is bounded by the
+    // budget's deadline, even when each fetch would otherwise stall for minutes.
+    #[test]
+    fn import_load_bounded_by_budget_deadline() {
+        let url = serve_stalling();
+        let vm = new_vm().unwrap();
+        let budget = LoadBudget {
+            deadline: std::time::Instant::now() + std::time::Duration::from_secs(1),
+            remaining_programs: MAX_IMPORT_PROGRAMS,
+        };
+        let started = std::time::Instant::now();
+        let error =
+            add_program_from_node_within(&vm, "stall.aleo", &url, "testnet", budget).unwrap_err();
+        assert!(started.elapsed() < std::time::Duration::from_secs(15), "took {:?}", started.elapsed());
+        // Ended on the network/deadline, not by loading anything.
+        assert!(!vm.process().read().contains_program(&ProgramID::from_str("stall.aleo").unwrap()));
+        let _ = error;
+    }
+
     // A source larger than the protocol maximum can't be a real program, so it
     // must be rejected (bounding per-fetch memory) rather than parsed.
     #[test]
@@ -1645,7 +1760,8 @@ mod tests {
         let base = std::env::var("ALEO_NODE_URL")
             .unwrap_or_else(|_| "https://api.explorer.provable.com/v1".to_string())
             + "/testnet";
-        assert_eq!(node_latest_edition(&base, "token_registry.aleo").unwrap(), 1);
+        let deadline = std::time::Instant::now() + HTTP_GET_DEADLINE;
+        assert_eq!(node_latest_edition(&base, "token_registry.aleo", deadline).unwrap(), 1);
     }
 
     // Loading a program pulls in its non-builtin imports recursively

--- a/rust/aleo_ffi/src/lib.rs
+++ b/rust/aleo_ffi/src/lib.rs
@@ -457,30 +457,11 @@ fn full_transaction(
     Ok(Transaction::from_execution(execution, Some(fee))?.to_string())
 }
 
-/// Returns a program's current on-chain edition by probing the node. snarkVM's
-/// REST serves the program source for any edition `<= current` and 404s above
-/// it, so the current edition is the highest one that exists. Errors (rather
-/// than guessing) when the node can't answer — registering at the wrong edition
-/// would produce a proof that disagrees with chain state.
-fn node_program_edition(base: &str, program_id: &str) -> anyhow::Result<u16> {
-    let exists = |edition: u16| -> anyhow::Result<bool> {
-        match ureq::get(&format!("{base}/program/{program_id}/{edition}")).call() {
-            Ok(_) => Ok(true),
-            Err(ureq::Error::Status(404, _)) => Ok(false),
-            Err(e) => Err(e.into()),
-        }
-    };
-    if !exists(0)? {
-        anyhow::bail!("program {program_id} not found while determining its edition");
-    }
-    let mut edition = 0u16;
-    while exists(edition + 1)? {
-        edition += 1;
-        if edition == u16::MAX {
-            anyhow::bail!("edition probe overflowed for {program_id}");
-        }
-    }
-    Ok(edition)
+/// Reads a program's current on-chain edition from snarkOS's
+/// `/program/{id}/latest_edition` route (via the retrying `http_get`).
+fn node_latest_edition(base: &str, program_id: &str) -> anyhow::Result<u16> {
+    let body = http_get(&format!("{base}/program/{program_id}/latest_edition"))?;
+    Ok(body.trim().trim_matches('"').parse()?)
 }
 
 /// Fetches a non-builtin program from the node and adds it to the VM, loading
@@ -488,13 +469,13 @@ fn node_program_edition(base: &str, program_id: &str) -> anyhow::Result<u16> {
 /// not already present). A no-op for built-in programs like credits.aleo or any
 /// program already loaded.
 ///
-/// Edition selection:
-/// - Non-upgradeable programs (no constructor) execute at edition 1; edition 0
-///   is rejected by `Authorization::check_valid_edition` post-V8.
-/// - Upgradeable programs (with a constructor) start at edition 0 (added via
-///   `add_program`, which execution permits for constructor programs) and bump
-///   on each upgrade. Their current edition is read from the node; if it can't
-///   be determined the call fails rather than emit a proof at the wrong edition.
+/// The current edition is read first, then the source is fetched *at that
+/// edition* (`/program/{id}/{edition}`) so the two are consistent even if the
+/// program is upgraded concurrently. Edition 0 (first-deployed, constructor-
+/// bearing programs) is added via `add_program`, which execution permits;
+/// non-upgradeable programs are edition 1, upgraded programs their bumped
+/// edition. A wrong edition would yield a proof that disagrees with chain state,
+/// so any failure to determine it (e.g. a node without the route) propagates.
 fn add_program_from_node(
     vm: &VM<Net, ConsensusMemory<Net>>,
     program_id: &str,
@@ -514,7 +495,8 @@ fn add_program_from_node(
     }
 
     let base = format!("{}/{}", url.trim_end_matches('/'), network);
-    let body = http_get(&format!("{base}/program/{program_id}"))?;
+    let edition = node_latest_edition(&base, program_id)?;
+    let body = http_get(&format!("{base}/program/{program_id}/{edition}"))?;
     let source: String = serde_json::from_str(body.trim())?;
     let program = Program::<Net>::from_str(&source)?;
 
@@ -523,18 +505,10 @@ fn add_program_from_node(
         add_program_from_node(vm, &import_id.to_string(), url, network)?;
     }
 
-    let edition = if program.contains_constructor() {
-        node_program_edition(&base, program_id)?
-    } else {
-        1
-    };
-
     let process = vm.process();
     let mut process = process.write();
     // A diamond import graph may have added it during the recursion above.
     if !process.contains_program(program.id()) {
-        // edition 0 uses `add_program` (the reviewer's recommended path for
-        // first-deploy constructor programs); higher editions are explicit.
         if edition == 0 {
             process.add_program(&program)?;
         } else {
@@ -1199,15 +1173,14 @@ mod tests {
         assert!(transfer_inputs("not_a_transfer", "aleo1recipient", 1, "", &owner()).is_err());
     }
 
-    // A non-upgradeable program (no constructor) reports edition 1. Validates
-    // the edition probe against a program whose execution edition is known.
+    // latest_edition reports a program's current edition (token_registry = 1).
     #[test]
     #[ignore = "network: run with `cargo test -- --ignored`"]
-    fn node_program_edition_non_upgradeable_is_one() {
+    fn node_latest_edition_reads_current_edition() {
         let base = std::env::var("ALEO_NODE_URL")
             .unwrap_or_else(|_| "https://api.explorer.provable.com/v1".to_string())
             + "/testnet";
-        assert_eq!(node_program_edition(&base, "token_registry.aleo").unwrap(), 1);
+        assert_eq!(node_latest_edition(&base, "token_registry.aleo").unwrap(), 1);
     }
 
     // Loading a program pulls in its non-builtin imports recursively

--- a/rust/aleo_ffi/src/lib.rs
+++ b/rust/aleo_ffi/src/lib.rs
@@ -20,6 +20,12 @@ use snarkvm_console::prelude::*;
 use snarkvm_console::program::{Ciphertext, Identifier, Literal, Plaintext, ProgramID, Record};
 use snarkvm_console::types::Field;
 use snarkvm_ledger_block::{Execution, Fee, Transaction};
+use snarkvm_ledger_query::Query;
+use snarkvm_ledger_store::helpers::memory::{BlockMemory, ConsensusMemory};
+use snarkvm_ledger_store::ConsensusStore;
+use snarkvm_synthesizer::process::Authorization;
+use snarkvm_synthesizer::VM;
+use aleo_std_storage::StorageMode;
 
 /// Aleo keys/addresses are encoded identically across networks (same curve,
 /// network-independent bech32 HRPs), so the concrete network is irrelevant to
@@ -285,6 +291,91 @@ pub unsafe extern "C" fn decrypt_to_private_key(
 // ----------------------------------------------------------------------------
 // Group 3: programs / proofs / transactions.
 // ----------------------------------------------------------------------------
+
+/// A fresh in-memory VM (credits.aleo and the other built-in programs are
+/// bundled in snarkVM, so no network fetch is needed to authorize/execute them).
+fn new_vm() -> anyhow::Result<VM<Net, ConsensusMemory<Net>>> {
+    VM::from(ConsensusStore::<Net, ConsensusMemory<Net>>::open(StorageMode::Production)?)
+}
+
+/// Builds a static query by fetching the current state root + height from the
+/// node's REST API at `{url}/{network}` (works regardless of the network-name
+/// path mismatch).
+fn static_query(url: &str, network: &str) -> anyhow::Result<Query<Net, BlockMemory<Net>>> {
+    let base = format!("{}/{}", url.trim_end_matches('/'), network);
+    let state_root = ureq::get(&format!("{base}/latest/stateRoot")).call()?.into_string()?;
+    let state_root = state_root.trim().trim_matches('"');
+    let height = ureq::get(&format!("{base}/latest/height")).call()?.into_string()?;
+    let json = format!(r#"{{"state_root":"{}","height":{}}}"#, state_root, height.trim());
+    Query::try_from(json)
+}
+
+/// Builds an execution authorization for a credits.aleo transfer. Offline
+/// (credits.aleo is built in). Returns "" on failure.
+///
+/// SAFETY: the pointer args are NUL-terminated C strings.
+#[no_mangle]
+pub unsafe extern "C" fn execution_authorization(
+    private_key: *const c_char,
+    recipient: *const c_char,
+    transfer_type: *const c_char,
+    amount: c_int,
+    _url: *const c_char,
+    amount_record: *const c_char,
+    _network: *const c_char,
+) -> *mut c_char {
+    let result = (|| -> Option<String> {
+        let private_key = PrivateKey::<Net>::from_str(read_str(private_key)).ok()?;
+        let function = read_str(transfer_type);
+        let recipient = read_str(recipient).to_string();
+        let amount = format!("{}u64", amount as i64);
+        let inputs: Vec<String> = match function {
+            "transfer_public" | "transfer_public_to_private" => vec![recipient, amount],
+            "transfer_private" | "transfer_private_to_public" => {
+                vec![read_str(amount_record).to_string(), recipient, amount]
+            }
+            _ => return None,
+        };
+        let vm = new_vm().ok()?;
+        let authorization = vm
+            .authorize(&private_key, "credits.aleo", function, inputs, &mut rand::thread_rng())
+            .ok()?;
+        serde_json::to_string(&authorization).ok()
+    })();
+    to_cstring(result.unwrap_or_default())
+}
+
+/// Generates the execution proof for an authorization (the patched
+/// `execute_authorization_raw`). Queries `url`/`network` for the state root.
+/// Returns "" on failure.
+///
+/// SAFETY: the pointer args are NUL-terminated C strings.
+#[no_mangle]
+pub unsafe extern "C" fn execute_proof(
+    url: *const c_char,
+    authorization: *const c_char,
+    network: *const c_char,
+) -> *mut c_char {
+    let inner = || -> anyhow::Result<String> {
+        let authorization: Authorization<Net> = serde_json::from_str(read_str(authorization))?;
+        // Aleo's testnet runs the network-0 (Mainnet) protocol but serves under a
+        // `/testnet` REST path, so snarkVM's RestQuery (which derives the path from
+        // the network type) can't reach it. Fetch the state root directly and feed
+        // a static query instead.
+        let query: Query<Net, BlockMemory<Net>> = static_query(read_str(url), read_str(network))?;
+        let vm = new_vm()?;
+        let (execution, _response) =
+            vm.execute_authorization_raw(authorization, &query, &mut rand::thread_rng())?;
+        Ok(serde_json::to_string(&execution)?)
+    };
+    match inner() {
+        Ok(execution) => to_cstring(execution),
+        Err(error) => {
+            eprintln!("[execute_proof] {error:?}");
+            to_cstring(String::new())
+        }
+    }
+}
 
 /// Assembles a transaction from a serialized execution proof and fee proof
 /// (the split-proof flow). Deterministic; returns "" on failure.

--- a/rust/aleo_ffi/src/lib.rs
+++ b/rust/aleo_ffi/src/lib.rs
@@ -977,7 +977,8 @@ pub unsafe extern "C" fn broadcast(
 ) -> *mut c_char {
     let inner = || -> anyhow::Result<String> {
         let base = format!("{}/{}", read_str(url).trim_end_matches('/'), read_str(network));
-        let response = ureq::post(&format!("{base}/transaction/broadcast"))
+        let response = http_agent()
+            .post(&format!("{base}/transaction/broadcast"))
             .set("Content-Type", "application/json")
             .send_string(read_str(transaction))?
             .into_string()?;
@@ -1123,11 +1124,13 @@ pub unsafe extern "C" fn build_upgrade_transaction_offline(
 /// Assembles a transaction from a serialized execution proof and fee proof
 /// (the split-proof flow). Deterministic; returns "" on failure.
 ///
-/// SAFETY: `execution`/`fee` are NUL-terminated C strings (snarkVM serde JSON).
+/// SAFETY: `execution`/`fee`/`_network` are NUL-terminated C strings
+/// (snarkVM serde JSON).
 #[no_mangle]
 pub unsafe extern "C" fn build_transaction_offline(
     execution: *const c_char,
     fee: *const c_char,
+    _network: *const c_char,
 ) -> *mut c_char {
     let result = (|| -> Option<String> {
         let execution: Execution<Net> = serde_json::from_str(read_str(execution)).ok()?;

--- a/rust/aleo_ffi/src/lib.rs
+++ b/rust/aleo_ffi/src/lib.rs
@@ -440,7 +440,11 @@ fn request_once_bounded(
     let request_timeout = budget.min(HTTP_REQUEST_TIMEOUT);
     let url = url.to_string();
     let (tx, rx) = std::sync::mpsc::channel();
-    std::thread::spawn(move || {
+    // `Builder::spawn`, not `thread::spawn`: spawning panics on OS thread
+    // exhaustion, and a panic across this `extern "C"` boundary would abort the
+    // host app. Turn the failure into an error instead. (On `Err` the closure —
+    // and the permit it captured — is dropped, releasing the slot.)
+    std::thread::Builder::new().name("aleo-ffi-http".into()).spawn(move || {
         // The permit rides with the worker, so the slot is held until the
         // thread truly ends — even after the caller has abandoned us.
         let _permit = permit;
@@ -458,7 +462,8 @@ fn request_once_bounded(
         })();
         // The receiver is gone if we already timed out; that is expected.
         let _ = tx.send(outcome);
-    });
+    })
+    .map_err(|e| anyhow::anyhow!("could not spawn request worker: {e}"))?;
     match rx.recv_timeout(budget) {
         Ok(outcome) => outcome,
         Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {

--- a/rust/aleo_ffi/src/lib.rs
+++ b/rust/aleo_ffi/src/lib.rs
@@ -347,13 +347,13 @@ fn new_vm() -> anyhow::Result<VM<Net, ConsensusMemory<Net>>> {
     VM::from(ConsensusStore::<Net, ConsensusMemory<Net>>::open(StorageMode::Production)?)
 }
 
-/// Shared HTTP agent with bounded timeouts. `.timeout()` is a deadline for the
-/// whole exchange — connect, request, and reading the response body — so a
-/// node that stalls *or trickles bytes indefinitely* surfaces as an error
-/// instead of hanging the (synchronous) FFI call. Per-read timeouts alone
-/// would not do that: each trickled byte resets them. Response memory is
-/// bounded as well: every body is read via `into_string()`, which fails past
-/// 10 MiB rather than growing without limit.
+/// Shared HTTP agent. `.timeout()` bounds the request and body read (so a node
+/// that stalls or trickles bytes errors out), and every body is read via
+/// `into_string()`, which fails past 10 MiB rather than growing without limit.
+/// Connection setup is bounded separately by `timeout_connect`, and ureq cannot
+/// interrupt blocking DNS resolution at all — so neither is covered by the
+/// per-request `.timeout()`. `get_once_bounded` closes that gap by running the
+/// whole call on a worker thread the caller stops waiting for on deadline.
 fn http_agent() -> &'static ureq::Agent {
     static AGENT: std::sync::OnceLock<ureq::Agent> = std::sync::OnceLock::new();
     AGENT.get_or_init(|| {
@@ -377,14 +377,43 @@ const HTTP_GET_ATTEMPTS: u32 = 4;
 /// incidental one.
 const HTTP_GET_DEADLINE: std::time::Duration = std::time::Duration::from_secs(240);
 
+/// Performs one GET, bounding the caller's wait by `budget` *wherever* the
+/// request blocks. ureq's per-request `.timeout()` covers the request and body
+/// read but not connection setup (a separate connect timeout) and cannot
+/// interrupt blocking DNS resolution, so a near-expired deadline could still be
+/// overrun by a slow connect or DNS lookup. Running the blocking call on a
+/// worker thread and waiting at most `budget` for it makes the deadline a real
+/// bound: the caller returns on time; the orphaned worker, itself capped by
+/// ureq's connect/request timeouts, exits on its own shortly after.
+fn get_once_bounded(url: &str, budget: std::time::Duration) -> anyhow::Result<String> {
+    let request_timeout = budget.min(HTTP_REQUEST_TIMEOUT);
+    let url = url.to_string();
+    let (tx, rx) = std::sync::mpsc::channel();
+    std::thread::spawn(move || {
+        let outcome = (|| -> anyhow::Result<String> {
+            Ok(http_agent().get(&url).timeout(request_timeout).call()?.into_string()?)
+        })();
+        // The receiver is gone if we already timed out; that is expected.
+        let _ = tx.send(outcome);
+    });
+    match rx.recv_timeout(budget) {
+        Ok(outcome) => outcome,
+        Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
+            anyhow::bail!("request exceeded its {budget:?} budget (connect/DNS/read)")
+        }
+        Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+            anyhow::bail!("request worker terminated unexpectedly")
+        }
+    }
+}
+
 /// HTTP GET with a few retries (the public node occasionally returns transient
-/// 5xx / connection errors), bounded by `deadline`: no request, retry, or
-/// backoff sleep runs past it, and each request's own timeout is the smaller of
-/// [`HTTP_REQUEST_TIMEOUT`] and the time left. Passing an overall `deadline`
-/// lets a caller's budget (e.g. the import-graph load) cap the *total* time
-/// across every request it triggers, not just each one in isolation — a
-/// per-request timeout alone bounds one attempt, but several attempts across
-/// several fetches still add up well past any single-request limit.
+/// 5xx / connection errors), bounded by `deadline`: no attempt, retry, or
+/// backoff sleep runs past it, and each attempt — connect, DNS, request and
+/// body read alike — is bounded by the time left via [`get_once_bounded`].
+/// Passing an overall `deadline` lets a caller's budget (e.g. the import-graph
+/// load) cap the *total* time across every request it triggers, not just each
+/// one in isolation.
 fn http_get_until(url: &str, deadline: std::time::Instant) -> anyhow::Result<String> {
     let mut last_error = None;
     for attempt in 0..HTTP_GET_ATTEMPTS {
@@ -392,8 +421,8 @@ fn http_get_until(url: &str, deadline: std::time::Instant) -> anyhow::Result<Str
         if remaining.is_zero() {
             break;
         }
-        match http_agent().get(url).timeout(remaining.min(HTTP_REQUEST_TIMEOUT)).call() {
-            Ok(response) => return Ok(response.into_string()?),
+        match get_once_bounded(url, remaining) {
+            Ok(body) => return Ok(body),
             Err(error) => {
                 last_error = Some(error);
                 // Back off before retrying, but never past the deadline and not
@@ -636,13 +665,21 @@ impl LoadBudget {
         }
     }
 
-    /// Accounts for one program about to be fetched, failing if either budget
-    /// is spent.
-    fn charge_one_program(&mut self) -> anyhow::Result<()> {
+    /// Fails if the time budget is spent. Cheap, so it gates not just fetches
+    /// but the CPU-bound parse and add-to-process steps, which on a deep chain
+    /// run many in a row after the final fetch.
+    fn check_time(&self) -> anyhow::Result<()> {
         anyhow::ensure!(
             std::time::Instant::now() < self.deadline,
             "import load exceeded its {IMPORT_LOAD_DEADLINE:?} time budget"
         );
+        Ok(())
+    }
+
+    /// Accounts for one program about to be fetched, failing if either budget
+    /// is spent.
+    fn charge_one_program(&mut self) -> anyhow::Result<()> {
+        self.check_time()?;
         self.remaining_programs = self.remaining_programs.checked_sub(1).ok_or_else(|| {
             anyhow::anyhow!("import load exceeded its {MAX_IMPORT_PROGRAMS}-program budget")
         })?;
@@ -678,6 +715,8 @@ fn fetch_program_at_latest_edition(
         Net::MAX_PROGRAM_SIZE
     );
     let program = Program::<Net>::from_str(&source)?;
+    // Parsing a (≤ MAX_PROGRAM_SIZE) source is CPU work; re-check after it.
+    budget.check_time()?;
     if program.id() != id {
         anyhow::bail!("node returned program '{}' for requested '{id}'", program.id());
     }
@@ -751,6 +790,10 @@ fn add_program_from_node_within(
     // `stack` holds fetched programs whose imports are still being satisfied.
     let mut stack = vec![fetch_program_at_latest_edition(&base, &requested, budget)?];
     while let Some(frame) = stack.last_mut() {
+        // Gate every iteration — including the run of `add_fetched_program`
+        // calls that unwinds the stack after the last fetch, which is otherwise
+        // pure CPU work with no fetch (hence no charge) between adds.
+        budget.check_time()?;
         match frame.pending.pop() {
             Some(import_id) => {
                 // A stack entry is a program still waiting on its imports, so
@@ -1686,6 +1729,8 @@ mod tests {
 
     // The whole import-graph load — not just one request — is bounded by the
     // budget's deadline, even when each fetch would otherwise stall for minutes.
+    // The bound comes from the worker thread, so it holds wherever the request
+    // blocks (connect / DNS / read), not just on the part ureq can time out.
     #[test]
     fn import_load_bounded_by_budget_deadline() {
         let url = serve_stalling();
@@ -1701,6 +1746,28 @@ mod tests {
         // Ended on the network/deadline, not by loading anything.
         assert!(!vm.process().read().contains_program(&ProgramID::from_str("stall.aleo").unwrap()));
         let _ = error;
+    }
+
+    // check_time gates the CPU-bound parse/add phase (not just fetches), so an
+    // already-spent time budget refuses to load even an instantly-served,
+    // protocol-valid program rather than running the add phase unchecked.
+    #[test]
+    fn spent_time_budget_loads_nothing() {
+        assert!(LoadBudget::new().check_time().is_ok());
+        let spent = LoadBudget {
+            deadline: std::time::Instant::now() - std::time::Duration::from_secs(1),
+            remaining_programs: MAX_IMPORT_PROGRAMS,
+        };
+        assert!(spent.check_time().is_err());
+
+        let mut routes = std::collections::HashMap::new();
+        program_routes(&mut routes, "solo.aleo", &[]);
+        let url = serve_canned(routes);
+        let vm = new_vm().unwrap();
+        let error =
+            add_program_from_node_within(&vm, "solo.aleo", &url, "testnet", spent).unwrap_err();
+        assert!(error.to_string().contains("time budget"), "got: {error}");
+        assert!(!vm.process().read().contains_program(&ProgramID::from_str("solo.aleo").unwrap()));
     }
 
     // A source larger than the protocol maximum can't be a real program, so it

--- a/rust/aleo_ffi/src/lib.rs
+++ b/rust/aleo_ffi/src/lib.rs
@@ -438,6 +438,22 @@ fn fetch_height(url: &str, network: &str) -> anyhow::Result<u32> {
     NodeQuery::new(url, network).current_block_height()
 }
 
+/// Rejects a fee the network can never accept, *before* the expensive fee
+/// proving: snarkVM verification requires `fee.amount() <= N::MAX_FEE`, so a
+/// base + priority total past the cap could only produce a proof of a
+/// transaction every node rejects.
+fn check_total_fee(base_fee: u64, priority_fee: u64) -> anyhow::Result<()> {
+    let total = base_fee
+        .checked_add(priority_fee)
+        .ok_or_else(|| anyhow::anyhow!("total fee overflows u64"))?;
+    anyhow::ensure!(
+        total <= Net::MAX_FEE,
+        "total fee {total} exceeds the network maximum {}",
+        Net::MAX_FEE
+    );
+    Ok(())
+}
+
 /// Minimum (base) fee in microcredits for an execution at the node's height.
 fn base_fee_for(execution: &Execution<Net>, url: &str, network: &str) -> anyhow::Result<u64> {
     let consensus_version = Net::CONSENSUS_VERSION(fetch_height(url, network)?)?;
@@ -519,6 +535,7 @@ fn full_transaction(
         let process = process.read();
         snarkvm_synthesizer::process::execution_cost(&process, &execution, consensus_version)?.0
     };
+    check_total_fee(base_fee, fee_credits)?;
     let fee_authorization = if fee_record.trim().is_empty() {
         vm.authorize_fee_public(private_key, base_fee, fee_credits, execution_id, rng)?
     } else {
@@ -537,97 +554,109 @@ fn node_latest_edition(base: &str, program_id: &str) -> anyhow::Result<u16> {
     Ok(body.trim().trim_matches('"').parse()?)
 }
 
-/// Cap on the import-chain depth accepted from a node. Real Aleo import graphs
-/// are a few levels deep; anything past this is a malicious or broken node.
-const MAX_IMPORT_DEPTH: usize = 16;
+/// A fetched program whose imports have not all been confirmed present yet.
+struct PendingProgram {
+    program: Program<Net>,
+    edition: u16,
+    /// Imports still to satisfy before this program can be added.
+    pending: Vec<ProgramID<Net>>,
+}
+
+/// True for built-in programs and anything already loaded in the process.
+fn program_is_present(vm: &VM<Net, ConsensusMemory<Net>>, id: &ProgramID<Net>) -> bool {
+    id.to_string() == "credits.aleo" || vm.process().read().contains_program(id)
+}
+
+/// Fetches `id`'s source at its current on-chain edition. The two are read in
+/// that order (`latest_edition`, then `/program/{id}/{edition}`) so they stay
+/// consistent even if the program is upgraded concurrently. The node is not
+/// trusted: the returned source must actually declare `id`, so a node cannot
+/// substitute a different program for a requested import.
+fn fetch_program_at_latest_edition(
+    base: &str,
+    id: &ProgramID<Net>,
+) -> anyhow::Result<PendingProgram> {
+    let edition = node_latest_edition(base, &id.to_string())?;
+    let body = http_get(&format!("{base}/program/{id}/{edition}"))?;
+    let source: String = serde_json::from_str(body.trim())?;
+    let program = Program::<Net>::from_str(&source)?;
+    if program.id() != id {
+        anyhow::bail!("node returned program '{}' for requested '{id}'", program.id());
+    }
+    let pending = program.imports().keys().cloned().collect();
+    Ok(PendingProgram { program, edition, pending })
+}
+
+/// Adds a fetched program to the process at its edition. Edition 0
+/// (first-deployed, constructor-bearing programs) goes through `add_program`,
+/// which execution permits; non-upgradeable programs are edition 1, upgraded
+/// programs their bumped edition. A wrong edition would yield a proof that
+/// disagrees with chain state, so edition determination failures propagate.
+fn add_fetched_program(
+    vm: &VM<Net, ConsensusMemory<Net>>,
+    program: &Program<Net>,
+    edition: u16,
+) -> anyhow::Result<()> {
+    let process = vm.process();
+    let mut process = process.write();
+    // A diamond import graph may have added it along another path already.
+    if !process.contains_program(program.id()) {
+        if edition == 0 {
+            process.add_program(program)?;
+        } else {
+            process.add_program_with_edition(program, edition)?;
+        }
+    }
+    Ok(())
+}
 
 /// Fetches a non-builtin program from the node and adds it to the VM, loading
 /// every imported program first (snarkVM rejects a program whose imports are
 /// not already present). A no-op for built-in programs like credits.aleo or any
 /// program already loaded.
 ///
-/// The current edition is read first, then the source is fetched *at that
-/// edition* (`/program/{id}/{edition}`) so the two are consistent even if the
-/// program is upgraded concurrently. Edition 0 (first-deployed, constructor-
-/// bearing programs) is added via `add_program`, which execution permits;
-/// non-upgradeable programs are edition 1, upgraded programs their bumped
-/// edition. A wrong edition would yield a proof that disagrees with chain state,
-/// so any failure to determine it (e.g. a node without the route) propagates.
-///
-/// The node's responses are not trusted: the returned source must declare the
-/// requested program ID, an import cycle (`a -> b -> a`, only possible if the
-/// node lies, since on-chain programs can only import pre-existing ones) is
-/// rejected rather than recursed into, and the chain depth is capped by
-/// [`MAX_IMPORT_DEPTH`] so a hostile node cannot overflow the stack.
+/// The import graph is walked iteratively in post-order (imports before
+/// importers), so a hostile node cannot drive call-stack depth: the protocol
+/// caps a program's *direct* imports (parsing enforces `MAX_IMPORTS`) but puts
+/// no limit on transitive chain length, so arbitrarily deep legal chains must
+/// load. An import referring back to a program still being loaded is a cycle —
+/// impossible on-chain, where a program can only import programs deployed
+/// before it — and is rejected as a lying node.
 fn add_program_from_node(
     vm: &VM<Net, ConsensusMemory<Net>>,
     program_id: &str,
     url: &str,
     network: &str,
 ) -> anyhow::Result<()> {
-    add_program_from_node_guarded(vm, program_id, url, network, &mut Vec::new())
-}
-
-/// [`add_program_from_node`] with the in-progress import chain (`visiting`)
-/// threaded through the recursion for cycle and depth checks.
-fn add_program_from_node_guarded(
-    vm: &VM<Net, ConsensusMemory<Net>>,
-    program_id: &str,
-    url: &str,
-    network: &str,
-    visiting: &mut Vec<String>,
-) -> anyhow::Result<()> {
     let requested = ProgramID::<Net>::from_str(program_id)?;
-    let program_id = requested.to_string();
-
-    // Skip built-ins and anything already loaded (without holding the lock
-    // across the recursion below).
-    {
-        let process = vm.process();
-        let process = process.read();
-        if program_id == "credits.aleo" || process.contains_program(&requested) {
-            return Ok(());
-        }
+    if program_is_present(vm, &requested) {
+        return Ok(());
     }
-
-    if visiting.iter().any(|id| id == &program_id) {
-        anyhow::bail!("node returned an import cycle: {} -> {program_id}", visiting.join(" -> "));
-    }
-    if visiting.len() >= MAX_IMPORT_DEPTH {
-        anyhow::bail!(
-            "import chain from node exceeds {MAX_IMPORT_DEPTH} levels at {program_id}: {}",
-            visiting.join(" -> ")
-        );
-    }
-
     let base = format!("{}/{}", url.trim_end_matches('/'), network);
-    let edition = node_latest_edition(&base, &program_id)?;
-    let body = http_get(&format!("{base}/program/{program_id}/{edition}"))?;
-    let source: String = serde_json::from_str(body.trim())?;
-    let program = Program::<Net>::from_str(&source)?;
-    if program.id() != &requested {
-        anyhow::bail!("node returned program '{}' for requested '{program_id}'", program.id());
-    }
 
-    // Load imports (which may themselves import others) before this program.
-    visiting.push(program_id);
-    let imports = (|| -> anyhow::Result<()> {
-        for import_id in program.imports().keys() {
-            add_program_from_node_guarded(vm, &import_id.to_string(), url, network, visiting)?;
-        }
-        Ok(())
-    })();
-    visiting.pop();
-    imports?;
-
-    let process = vm.process();
-    let mut process = process.write();
-    // A diamond import graph may have added it during the recursion above.
-    if !process.contains_program(program.id()) {
-        if edition == 0 {
-            process.add_program(&program)?;
-        } else {
-            process.add_program_with_edition(&program, edition)?;
+    // `stack` holds fetched programs whose imports are still being satisfied.
+    let mut stack = vec![fetch_program_at_latest_edition(&base, &requested)?];
+    while let Some(frame) = stack.last_mut() {
+        match frame.pending.pop() {
+            Some(import_id) => {
+                // A stack entry is a program still waiting on its imports, so
+                // an import pointing back into the stack is a cycle.
+                if stack.iter().any(|frame| frame.program.id() == &import_id) {
+                    let chain = stack
+                        .iter()
+                        .map(|frame| frame.program.id().to_string())
+                        .collect::<Vec<_>>()
+                        .join(" -> ");
+                    anyhow::bail!("node returned an import cycle: {chain} -> {import_id}");
+                }
+                if !program_is_present(vm, &import_id) {
+                    stack.push(fetch_program_at_latest_edition(&base, &import_id)?);
+                }
+            }
+            None => {
+                let done = stack.pop().expect("the loop condition saw a frame");
+                add_fetched_program(vm, &done.program, done.edition)?;
+            }
         }
     }
     Ok(())
@@ -675,6 +704,7 @@ fn program_fee(
         let process = process.read();
         snarkvm_synthesizer::process::execution_cost(&process, &execution, consensus_version)?.0
     };
+    check_total_fee(base_fee, priority_fee)?;
     let fee_authorization =
         vm.authorize_fee_public(private_key, base_fee, priority_fee, execution_id, rng)?;
     let fee = vm.execute_fee_authorization_raw(fee_authorization, &query, rng)?;
@@ -1093,6 +1123,7 @@ pub unsafe extern "C" fn execution_fee_authorization(
         let execution_id = execution.to_execution_id()?;
         let base_fee = base_fee_for(&execution, read_str(url), read_str(network))?;
         let priority_fee = fee_credits;
+        check_total_fee(base_fee, priority_fee)?;
         let fee_record = read_str(fee_record);
         let vm = new_vm()?;
         let rng = &mut rand::thread_rng();
@@ -1342,38 +1373,112 @@ mod tests {
         }
     }
 
-    // A node claiming `a.aleo -> ... -> a.aleo` must be rejected before any
-    // fetch, not recursed into until the stack overflows. Both guards fire
-    // before HTTP, so these run offline (the URL is never contacted).
+    /// Serves canned `path -> body` responses on a local port, so the
+    /// node-facing program loader can be exercised without a network.
+    fn serve_canned(routes: std::collections::HashMap<String, String>) -> String {
+        use std::io::{Read, Write};
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = format!("http://{}", listener.local_addr().unwrap());
+        std::thread::spawn(move || {
+            for stream in listener.incoming() {
+                let Ok(mut stream) = stream else { continue };
+                let mut buffer = [0u8; 4096];
+                let read = stream.read(&mut buffer).unwrap_or(0);
+                let request = String::from_utf8_lossy(&buffer[..read]).into_owned();
+                let path = request.split_whitespace().nth(1).unwrap_or("").to_string();
+                let (status, body) = match routes.get(&path) {
+                    Some(body) => ("200 OK", body.clone()),
+                    None => ("404 Not Found", String::new()),
+                };
+                let _ = write!(
+                    stream,
+                    "HTTP/1.1 {status}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                    body.len()
+                );
+            }
+        });
+        address
+    }
+
+    /// Registers the `latest_edition` and source routes for a minimal valid
+    /// program named `id` importing `imports`.
+    fn program_routes(
+        routes: &mut std::collections::HashMap<String, String>,
+        id: &str,
+        imports: &[String],
+    ) {
+        let imports_block =
+            imports.iter().map(|import| format!("import {import};\n")).collect::<String>();
+        let source =
+            format!("{imports_block}\nprogram {id};\n\nfunction noop:\n    add 1u8 1u8 into r0;\n");
+        routes.insert(format!("/testnet/program/{id}/latest_edition"), "1".to_string());
+        routes.insert(format!("/testnet/program/{id}/1"), serde_json::to_string(&source).unwrap());
+    }
+
+    // A node claiming `a.aleo -> b.aleo -> a.aleo` must be rejected, not
+    // walked forever: such a cycle is impossible on-chain (programs can only
+    // import programs deployed before them), so it can only be a lying node.
     #[test]
     fn import_cycle_from_node_rejected() {
+        let mut routes = std::collections::HashMap::new();
+        program_routes(&mut routes, "cyclea.aleo", &["cycleb.aleo".to_string()]);
+        program_routes(&mut routes, "cycleb.aleo", &["cyclea.aleo".to_string()]);
+        let url = serve_canned(routes);
         let vm = new_vm().unwrap();
-        let mut visiting = vec!["token_registry.aleo".to_string()];
-        let error = add_program_from_node_guarded(
-            &vm,
-            "token_registry.aleo",
-            "http://127.0.0.1:1",
-            "testnet",
-            &mut visiting,
-        )
-        .unwrap_err();
+        let error = add_program_from_node(&vm, "cyclea.aleo", &url, "testnet").unwrap_err();
         assert!(error.to_string().contains("import cycle"), "got: {error}");
     }
 
+    // The returned source must declare the requested ID: a node answering the
+    // request for one program with another must be rejected.
     #[test]
-    fn import_depth_from_node_capped() {
+    fn node_substituting_a_program_rejected() {
+        let mut routes = std::collections::HashMap::new();
+        program_routes(&mut routes, "evil.aleo", &[]);
+        let evil_body = routes["/testnet/program/evil.aleo/1"].clone();
+        routes.insert("/testnet/program/honest.aleo/latest_edition".to_string(), "1".to_string());
+        routes.insert("/testnet/program/honest.aleo/1".to_string(), evil_body);
+        let url = serve_canned(routes);
         let vm = new_vm().unwrap();
-        let mut visiting =
-            (0..MAX_IMPORT_DEPTH).map(|i| format!("program{i}.aleo")).collect::<Vec<_>>();
-        let error = add_program_from_node_guarded(
-            &vm,
-            "token_registry.aleo",
-            "http://127.0.0.1:1",
-            "testnet",
-            &mut visiting,
-        )
-        .unwrap_err();
+        let error = add_program_from_node(&vm, "honest.aleo", &url, "testnet").unwrap_err();
+        assert!(error.to_string().contains("returned program"), "got: {error}");
+    }
+
+    // The protocol caps a program's direct imports, not transitive chain
+    // depth, so a legal chain deeper than any fixed guess must still load
+    // (and must not grow the call stack while doing so).
+    #[test]
+    fn deep_import_chain_loads() {
+        const DEPTH: usize = 20;
+        let mut routes = std::collections::HashMap::new();
+        for i in 0..DEPTH {
+            let imports = if i + 1 < DEPTH {
+                vec![format!("deep{}.aleo", i + 1)]
+            } else {
+                Vec::new()
+            };
+            program_routes(&mut routes, &format!("deep{i}.aleo"), &imports);
+        }
+        let url = serve_canned(routes);
+        let vm = new_vm().unwrap();
+        add_program_from_node(&vm, "deep0.aleo", &url, "testnet").unwrap();
+        let process = vm.process();
+        let process = process.read();
+        assert!(process.contains_program(&ProgramID::from_str("deep0.aleo").unwrap()));
+        assert!(process
+            .contains_program(&ProgramID::from_str(&format!("deep{}.aleo", DEPTH - 1)).unwrap()));
+    }
+
+    // A fee the network would reject must fail before proving, and the
+    // base + priority sum must not wrap.
+    #[test]
+    fn total_fee_capped_at_network_maximum() {
+        assert!(check_total_fee(Net::MAX_FEE, 0).is_ok());
+        assert!(check_total_fee(Net::MAX_FEE - 1, 1).is_ok());
+        let error = check_total_fee(Net::MAX_FEE, 1).unwrap_err();
         assert!(error.to_string().contains("exceeds"), "got: {error}");
+        let error = check_total_fee(u64::MAX, 1).unwrap_err();
+        assert!(error.to_string().contains("overflows"), "got: {error}");
     }
 
     // Calls a few exported functions through their C ABI and frees the result,


### PR DESCRIPTION
## What

Group 3 — the final group — of the clean-room Apache-2.0 rewrite: the program/proof/transaction layer on the patched snarkVM VM. This completes the clean-room `aleo_ffi` at **31/31** of the FFI surface (Groups 1 & 2 — account/keys and records — merged earlier in #49). Built clean-room: FFI contract + snarkVM public API only, no GPL source.

**Transfer pipeline (split-proof):** `execution_authorization`, `execute_proof`, `execution_fee_authorization`, `execute_fee_proof`, `get_base_fee`, `build_transaction_offline`, `broadcast`.

**Orchestration:** `build_transaction`, `try_transfer`, `join_authorization`, `try_join`.

**Arbitrary programs / contracts:** `execute_program`, `execute_program_proof`, `contract_execution`, `contract_fee_execution` (fetch a non-builtin program + its import closure from the node, add at the on-chain edition, authorize/execute/fee).

**Program upgrade:** `upgrade_authorization`, `build_upgrade_transaction_offline` (credits.aleo `upgrade` migrating a v0 record to v1 — an ordinary one-record function; the single-transition upgrade tx is base-fee exempt).

## How it's verified — real testnet transactions

Every primitive was exercised against live testnet (`api.explorer.provable.com/v1`) and **accepted by the node** (proofs + fee + state root validated on ingestion):
- full clean-room `transfer_public` pipeline → `at1jnjgqazgqgxsay39ppxx5aut053e34f4p4tf5mq2t8hmh8uxm5xskgmle6`
- one-call `try_transfer` → `at1scppdakgenw7axj2854lur5ej45gu2lphd57n43j6ngvd4da7y8q9zlhr8`
- `execute_program` running `token_registry.aleo register_token` → `at1krpw85tlnzyy9a4a2g0z3d430q4jwm698ap49ruxgekj6mcdy5rqampppm`
- `execution_authorization` / `execute_proof` produce transitions byte-identical to the reference lib (only the randomized proof differs); `get_base_fee` matches exactly (2725µ for transfer_public).
- `build_transaction_offline` is byte-identical to the reference (committed fixture test).

## Key technical notes

- Aleo testnet runs the **network-0 (Mainnet) protocol** under a `/testnet` REST path, so snarkVM's `RestQuery` (derives the path from the network type) can't reach it. `NodeQuery` is a `QueryTrait` impl that issues requests against the caller-provided `{url}/{network}` path, fetching inclusion state paths via the batch `statePaths?commitments=...` route so every path shares one state root (private record-spending flows).
- Fee: `priority_fee = fee_credits` (caller input), `base_fee = snarkvm_synthesizer::process::execution_cost(...)` at the node's consensus version; `base + priority` is validated `<= Net::MAX_FEE` before proving.
- Non-builtin programs: the import closure is loaded iteratively (no recursion) at each program's current on-chain edition, read from `/program/{id}/latest_edition` then source at that edition.
- Uses the snarkVM visibility patch from the already-merged P0 (`rust/vendor/...`).
- `http_get` retries transient 5xx/522; the shared agent has connect + overall-request timeouts.

## Amount/fee ABI

Amounts and fees cross the C ABI as **`u64` / `ffi.Uint64`** microcredits end-to-end (snarkVM's own fee/amount type); the Dart API rejects negative values. Both sides ship together from this repo.

## Hardening (added across review)

Untrusted-node and FFI-boundary safety, all covered by offline tests run in CI against the freshly-built cdylib:
- node-driven program loading rejects import cycles, mismatched program IDs, and over-`MAX_PROGRAM_SIZE` sources, and is bounded by a per-load time + program-count budget (an acyclic but unbounded chain can't block or OOM the synchronous call);
- FFI functions never panic across the C boundary (malformed input → `""`/`0`), negative slice lengths and null pointers are rejected, and every returned native string is freed (Dart inputs freed in `try/finally`).

## CI

`.github/workflows/rust.yml` builds the release cdylib, verifies all 31 exported symbols, and runs the `aleo_dart` Dart suite against it (`ALEO_NEW_LIB`), so Dart↔Rust ABI mismatches and wrapper regressions fail CI.

## Known / deferred (explicit)

- Proof and fee *generation* are not in CI — they need the inclusion-prover parameters (large download) plus minutes of proving; they stay as manual live-node tests. Offline transaction assembly **is** CI-covered (byte-for-byte fixture).
- Loading an old GPL-build library with the new `ffi.Uint64` typedefs is mixed-ABI; for values ≤ i32 max the common calling conventions read identically (the only range the old lib supported).
- The import-load time/program-count budgets are fixed constants set far above any real closure, not configurable; the protocol defines no closure-size bound, so this is an explicit DoS trade-off rather than a protocol limit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
