### PR TITLE
feat(aleo): I/O→Dart phase 2 — Dart AleoNode + orchestration on the pure primitives

### DIFF
--- a/packages/aleo_dart/lib/aleo.dart
+++ b/packages/aleo_dart/lib/aleo.dart
@@ -1,6 +1,7 @@
 library aleo_dart;
 
 export 'package:aleo_dart/src/aleo_account.dart';
+export 'package:aleo_dart/src/aleo_node.dart';
 export 'package:aleo_dart/src/aleo_programs.dart';
 export 'package:aleo_dart/src/aleo_record.dart';
 export 'package:aleo_dart/src/aleo_transaction.dart';

--- a/packages/aleo_dart/lib/src/aleo_node.dart
+++ b/packages/aleo_dart/lib/src/aleo_node.dart
@@ -35,6 +35,34 @@ class AleoNodeException implements Exception {
 /// Untrusted node responses are budget-checked here on the fetch side, mirroring
 /// the Rust parser's caps, and streamed so an oversized or endless body is
 /// rejected — and the request cancelled — before it can exhaust memory.
+///
+/// ## Request lifecycle contract
+///
+/// One place to reason about *what bounds a read* — the dimension five review
+/// rounds each chipped at. Pinned by the table-driven tests in
+/// `aleo_node_test.dart`:
+///
+/// - **Budget (one logical read).** Each read runs under a single monotonic
+///   [_Budget] (a [Stopwatch], so a system-clock step cannot lengthen or shorten
+///   it): [requestTimeout] for the single-request reads *and* the two-request
+///   [programSource]; [closureDeadline] for the whole [programClosure] walk,
+///   shared across every fetch. Each individual request is additionally capped
+///   at [requestTimeout] (`min(remaining, requestTimeout)`), so one slow request
+///   cannot eat the larger closure budget.
+/// - **Retry (GET only).** Retried *while budget remains*: 5xx, connection /
+///   socket timeouts, and a per-attempt timeout (the request was merely slow).
+///   Not retried: 4xx (the node rejected our input), an over-budget body (a
+///   separate AleoNodeException path), an exhausted overall budget, and any POST
+///   — [broadcast] is never retried (a transaction broadcast is not idempotent).
+///   The whole rule is [retryableGet].
+/// - **Cancellation.** A per-attempt timeout and an over-budget body both
+///   `cancel()` the [CancelToken], aborting the socket — not merely the await.
+/// - **Untrusted body.** Streamed and rejected with [AleoNodeException] on: the
+///   byte / entry budgets, malformed JSON, invalid UTF-8, a height outside u32,
+///   and an oversized decoded program source.
+/// - **Client ownership.** A self-created [Dio] is closed by [close]; an injected
+///   one belongs to the caller. [AleoProgram] shares one client across
+///   operations and frees it via its `dispose`.
 class AleoNode {
   /// `{url}/{network}` — the REST base every route hangs off. Aleo's testnet
   /// runs the network-0 protocol under a `/testnet` path, so the network
@@ -330,16 +358,8 @@ class AleoNode {
       } on DioException catch (e) {
         last = e;
         final left = overall.remaining;
-        // A cancel here is our per-attempt timer firing — a single slow request,
-        // not the whole read out of time (an over-budget body throws an
-        // AleoNodeException, which is not caught here). So it is retryable while
-        // the overall budget still has room: otherwise a slow first import would
-        // never get a second try even with most of the closure budget left.
-        // Non-cancel failures defer to _isRetryable.
-        final retryable = CancelToken.isCancel(e)
-            ? left > Duration.zero
-            : _isRetryable(e);
-        if (!retryable || attempt + 1 == getAttempts || left <= Duration.zero) {
+        if (!retryableGet(e, budgetRemains: left > Duration.zero) ||
+            attempt + 1 == getAttempts) {
           throw _wrap(route, e);
         }
         final backoff = Duration(milliseconds: 500 * (attempt + 1));
@@ -389,11 +409,21 @@ class AleoNode {
     }
   }
 
-  /// Retry only on errors a retry could actually fix: connection/timeout
-  /// failures and 5xx (the public node's transient 522). A 4xx is the node
-  /// rejecting our input — retrying just repeats it. Cancels (our per-attempt
-  /// timer) are classified by the caller against the overall budget, not here.
-  bool _isRetryable(DioException e) {
+  /// The whole "should this GET attempt be retried" rule — the single source of
+  /// truth for the contract's retry row (see the class doc), so the policy lives
+  /// in one table-tested place rather than scattered across the loop.
+  ///
+  /// - `budgetRemains == false` → never (the overall budget is spent).
+  /// - a cancel → yes (it is our per-attempt timer firing on a merely-slow
+  ///   request; an over-budget body throws [AleoNodeException], not a
+  ///   [DioException], so it never reaches here).
+  /// - connection / socket-timeout failures and 5xx → yes.
+  /// - 4xx and everything else → no.
+  ///
+  /// POST/[broadcast] never calls this — it does not retry.
+  static bool retryableGet(DioException e, {required bool budgetRemains}) {
+    if (!budgetRemains) return false;
+    if (CancelToken.isCancel(e)) return true;
     switch (e.type) {
       case DioExceptionType.connectionError:
       case DioExceptionType.connectionTimeout:
@@ -401,8 +431,7 @@ class AleoNode {
       case DioExceptionType.receiveTimeout:
         return true;
       case DioExceptionType.badResponse:
-        final status = e.response?.statusCode ?? 0;
-        return status >= 500;
+        return (e.response?.statusCode ?? 0) >= 500;
       default:
         return false;
     }

--- a/packages/aleo_dart/lib/src/aleo_node.dart
+++ b/packages/aleo_dart/lib/src/aleo_node.dart
@@ -43,10 +43,12 @@ class AleoNode {
 
   final Dio _dio;
 
-  /// **Overall** wall-clock budget for one logical read — every retry attempt
-  /// and every backoff together must fit inside it, so a stalling node cannot
-  /// stretch a read to `getAttempts × timeout`. On expiry the in-flight
-  /// request's [CancelToken] is cancelled, aborting the socket.
+  /// Wall-clock budget for one logical read: every retry attempt and backoff
+  /// together must fit inside it, so a stalling node cannot stretch a read to
+  /// `getAttempts × timeout`. It also caps each *individual* request even under
+  /// the larger [closureDeadline] — so one slow-but-progressing import cannot
+  /// occupy the whole closure budget. On expiry the in-flight request's
+  /// [CancelToken] is cancelled, aborting the socket.
   final Duration requestTimeout;
 
   /// Retries for an idempotent GET (the public node returns transient 5xx/522).
@@ -118,8 +120,13 @@ class AleoNode {
   Future<int> latestHeight() async {
     final body = await _getWithRetry('latest/height', maxBytes: maxHeightBytes);
     final height = int.tryParse(_unquote(body));
-    if (height == null || height < 0) {
-      throw AleoNodeException('latest/height returned a non-integer: $body');
+    // Block heights are u32 on-chain and are marshalled to the FFI as Uint32; a
+    // value past u32::MAX is a lying/buggy node and would silently truncate to a
+    // different height (and thus the wrong consensus version), so reject it here
+    // at the trust boundary rather than let it through.
+    if (height == null || height < 0 || height > 0xFFFFFFFF) {
+      throw AleoNodeException(
+          'latest/height out of u32 range or non-integer: $body');
     }
     return height;
   }
@@ -286,8 +293,14 @@ class AleoNode {
     for (var attempt = 0; attempt < getAttempts; attempt++) {
       final remaining = overall.difference(DateTime.now());
       if (remaining <= Duration.zero) break;
+      // Cap each individual request at requestTimeout even when the overall
+      // budget is the larger closureDeadline, so one slow-but-progressing node
+      // cannot occupy the whole closure budget (mirrors the old Rust
+      // http_get_until's per-attempt `budget.min(HTTP_REQUEST_TIMEOUT)`).
+      final attemptTimeout =
+          remaining < requestTimeout ? remaining : requestTimeout;
       try {
-        return await _getOnce(route, maxBytes: maxBytes, timeout: remaining);
+        return await _getOnce(route, maxBytes: maxBytes, timeout: attemptTimeout);
       } on DioException catch (e) {
         last = e;
         if (!_isRetryable(e) || attempt + 1 == getAttempts) {

--- a/packages/aleo_dart/lib/src/aleo_node.dart
+++ b/packages/aleo_dart/lib/src/aleo_node.dart
@@ -303,11 +303,19 @@ class AleoNode {
         return await _getOnce(route, maxBytes: maxBytes, timeout: attemptTimeout);
       } on DioException catch (e) {
         last = e;
-        if (!_isRetryable(e) || attempt + 1 == getAttempts) {
+        final left = overall.difference(DateTime.now());
+        // A cancel here is our per-attempt timer firing — a single slow request,
+        // not the whole read out of time (an over-budget body throws an
+        // AleoNodeException, which is not caught here). So it is retryable while
+        // the overall budget still has room: otherwise a slow first import would
+        // never get a second try even with most of the closure budget left.
+        // Non-cancel failures defer to _isRetryable.
+        final retryable = CancelToken.isCancel(e)
+            ? left > Duration.zero
+            : _isRetryable(e);
+        if (!retryable || attempt + 1 == getAttempts || left <= Duration.zero) {
           throw _wrap(route, e);
         }
-        final left = overall.difference(DateTime.now());
-        if (left <= Duration.zero) break;
         final backoff = Duration(milliseconds: 500 * (attempt + 1));
         await Future<void>.delayed(backoff < left ? backoff : left);
       }
@@ -357,10 +365,9 @@ class AleoNode {
 
   /// Retry only on errors a retry could actually fix: connection/timeout
   /// failures and 5xx (the public node's transient 522). A 4xx is the node
-  /// rejecting our input — retrying just repeats it. A cancel (our overall
-  /// timeout) is never retryable: the overall deadline has passed.
+  /// rejecting our input — retrying just repeats it. Cancels (our per-attempt
+  /// timer) are classified by the caller against the overall budget, not here.
   bool _isRetryable(DioException e) {
-    if (CancelToken.isCancel(e)) return false;
     switch (e.type) {
       case DioExceptionType.connectionError:
       case DioExceptionType.connectionTimeout:

--- a/packages/aleo_dart/lib/src/aleo_node.dart
+++ b/packages/aleo_dart/lib/src/aleo_node.dart
@@ -1,0 +1,340 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:dio/dio.dart';
+
+/// Thrown for any node-I/O failure: a transport error, a timeout/cancellation,
+/// a non-2xx status, a malformed body, or a response that blows a safety
+/// budget. The phase-1 FFI primitives collapse every error to `""`, so moving
+/// node I/O here is also what finally lets a caller tell a network failure
+/// apart from bad input.
+class AleoNodeException implements Exception {
+  final String message;
+  AleoNodeException(this.message);
+
+  @override
+  String toString() => 'AleoNodeException: $message';
+}
+
+/// Owns all Aleo node REST I/O for the phase-2 orchestration, replacing the
+/// blocking HTTP that used to live inside the synchronous FFI calls (PR #51's
+/// recurring DoS/timeout finding class). The node provides exactly four reads —
+/// block height, state root, state paths for a commitment set, and a program's
+/// source at its current edition — plus the one write, broadcast.
+///
+/// Every request carries a dio [CancelToken] so a timeout actually *aborts* the
+/// underlying socket: `Future.timeout` only stops awaiting and leaks the
+/// connection, which would recreate the abandoned-worker leak we are leaving
+/// Rust to escape. dio's own [BaseOptions.connectTimeout] / `receiveTimeout`
+/// bound the connect and inter-chunk read phases; an outer [requestTimeout]
+/// timer cancels the whole request wherever it blocks (including a stalled
+/// body the per-chunk timeout never trips).
+///
+/// Untrusted node responses are budget-checked here on the fetch side, mirroring
+/// the Rust parser's caps, so an oversized or endless response is rejected
+/// before it can exhaust memory — the size budgets survive the move to Dart even
+/// though the worker-thread machinery does not.
+class AleoNode {
+  /// `{url}/{network}` — the REST base every route hangs off. Aleo's testnet
+  /// runs the network-0 protocol under a `/testnet` path, so the network
+  /// segment is caller-supplied rather than derived from the snarkVM type.
+  final String base;
+
+  final Dio _dio;
+
+  /// Overall per-request wall-clock bound. On expiry the request's
+  /// [CancelToken] is cancelled, aborting the socket — not merely the await.
+  final Duration requestTimeout;
+
+  /// Retries for an idempotent GET (the public node returns transient 5xx/522).
+  /// A POST (broadcast) is never retried — re-submitting a transaction is not
+  /// idempotent.
+  final int getAttempts;
+
+  /// Wall-clock ceiling on resolving one program import closure. A DoS guard,
+  /// not a protocol limit, so it sits far above any honest closure.
+  final Duration closureDeadline;
+
+  /// Resolves a program's direct imports from its source, so [programClosure]
+  /// can walk the closure it must fetch. Supplied by [AleoProgram] as the pure
+  /// `required_imports` FFI helper; kept as an injected callback so this class
+  /// has no FFI dependency (and can be unit-tested with a fake resolver).
+  final List<String> Function(String source)? parseImports;
+
+  // --- Untrusted-response budgets (mirror the Rust parser in aleo_ffi) -------
+
+  /// `MAX_INPUTS` (16) record inputs per transition across at most
+  /// `Transaction::MAX_TRANSITIONS` (32) transitions — the most state paths any
+  /// execution can require.
+  static const int maxStatePaths = 16 * 32;
+
+  /// Per-path byte budget; the array byte cap is `maxStatePaths * this`.
+  static const int maxStatePathBytes = 16 * 1024;
+
+  /// `latest/stateRoot` is a single `sr1…` string.
+  static const int maxStateRootBytes = 256;
+
+  /// `latest/height` is a small decimal; bound it generously anyway.
+  static const int maxHeightBytes = 64;
+
+  /// `MAX_IMPORT_PROGRAMS` — the program-count cap on one import closure.
+  static const int maxImportPrograms = 256;
+
+  /// `Net::MAX_PROGRAM_SIZE` — the per-program source byte cap; a larger body
+  /// cannot be a valid on-chain program.
+  static const int maxProgramSize = 100 * 1000;
+
+  AleoNode(
+    String url, {
+    String network = 'testnet',
+    Dio? dio,
+    this.requestTimeout = const Duration(seconds: 30),
+    this.getAttempts = 4,
+    this.closureDeadline = const Duration(seconds: 120),
+    this.parseImports,
+  })  : base = '${url.replaceAll(RegExp(r'/+$'), '')}/$network',
+        _dio = dio ??
+            Dio(BaseOptions(
+              connectTimeout: const Duration(seconds: 15),
+              receiveTimeout: const Duration(seconds: 30),
+              // We read the raw bytes ourselves (bounded), so dio must not try
+              // to JSON-decode or buffer the body for us.
+              responseType: ResponseType.stream,
+            ));
+
+  /// Current block height — selects the consensus version proving pins.
+  Future<int> latestHeight() async {
+    final body = await _getWithRetry('latest/height', maxBytes: maxHeightBytes);
+    final height = int.tryParse(_unquote(body));
+    if (height == null || height < 0) {
+      throw AleoNodeException('latest/height returned a non-integer: $body');
+    }
+    return height;
+  }
+
+  /// Latest global state root (the opaque `sr1…` string), for public flows that
+  /// have no state path to derive it from. Passed straight through to the FFI.
+  Future<String> latestStateRoot() async {
+    final body =
+        await _getWithRetry('latest/stateRoot', maxBytes: maxStateRootBytes);
+    final root = _unquote(body);
+    if (root.isEmpty) {
+      throw AleoNodeException('latest/stateRoot returned an empty root');
+    }
+    return root;
+  }
+
+  /// State paths for [commitments] (the global input-record commitments
+  /// `required_commitments` reported), as the raw JSON array the FFI's
+  /// `*_static` primitives parse. One batch request so every path is anchored to
+  /// a single block — per-commitment fetches can straddle a block and the
+  /// inclusion prover rejects paths that disagree on the root. Returns `[]` for
+  /// an empty set (a public flow), without a request.
+  Future<String> statePaths(List<String> commitments) async {
+    if (commitments.isEmpty) return '[]';
+    final route = 'statePaths?commitments=${commitments.join(',')}';
+    final body = await _getWithRetry(route,
+        maxBytes: maxStatePaths * maxStatePathBytes);
+    final decoded = jsonDecode(body);
+    if (decoded is! List) {
+      throw AleoNodeException('statePaths response was not a JSON array');
+    }
+    if (decoded.length > maxStatePaths) {
+      throw AleoNodeException(
+          'statePaths returned ${decoded.length} entries, over the '
+          '$maxStatePaths-entry budget');
+    }
+    return body.trim();
+  }
+
+  /// A program's source at its current on-chain edition. The edition and source
+  /// are read in that order (`/program/{id}/latest_edition`, then
+  /// `/program/{id}/{edition}`) so they stay consistent across a concurrent
+  /// upgrade. The source must not exceed [maxProgramSize] — a larger body cannot
+  /// be a valid on-chain program, so rejecting it never drops a real one.
+  Future<({int edition, String source})> programSource(String id) async {
+    final editionBody = await _getWithRetry(
+        'program/$id/latest_edition',
+        maxBytes: maxHeightBytes);
+    final edition = int.tryParse(_unquote(editionBody));
+    if (edition == null || edition < 0) {
+      throw AleoNodeException(
+          "program/$id/latest_edition returned a non-integer: $editionBody");
+    }
+    final sourceBody = await _getWithRetry('program/$id/$edition',
+        maxBytes: maxProgramSize + 2 /* surrounding quotes */);
+    final decoded = jsonDecode(sourceBody);
+    if (decoded is! String) {
+      throw AleoNodeException('program/$id/$edition was not a JSON string');
+    }
+    if (decoded.length > maxProgramSize) {
+      throw AleoNodeException(
+          "program '$id' source is ${decoded.length} bytes, over the "
+          '$maxProgramSize-byte maximum');
+    }
+    return (edition: edition, source: decoded);
+  }
+
+  /// The full import closure of [rootId] as the `program_sources_json` the FFI
+  /// program-proof primitives load: a JSON array of `{id, edition, source}`,
+  /// imports included, any order (Rust adds them imports-before-importers).
+  /// `credits.aleo` is built in and never fetched. Bounded on every axis a
+  /// hostile node can stretch an honest, acyclic, individually-valid chain:
+  /// program count, cumulative bytes, and wall-clock time.
+  Future<String> programClosure(String rootId) async {
+    final resolve = parseImports;
+    if (resolve == null) {
+      throw AleoNodeException(
+          'programClosure needs an import resolver (required_imports); '
+          'construct AleoNode with parseImports');
+    }
+    final deadline = DateTime.now().add(closureDeadline);
+    final fetched = <String, Map<String, dynamic>>{};
+    final queue = <String>[rootId];
+    var totalBytes = 0;
+    while (queue.isNotEmpty) {
+      if (DateTime.now().isAfter(deadline)) {
+        throw AleoNodeException(
+            'program closure load exceeded its $closureDeadline time budget');
+      }
+      final id = queue.removeAt(0);
+      if (id == 'credits.aleo' || fetched.containsKey(id)) continue;
+      if (fetched.length >= maxImportPrograms) {
+        throw AleoNodeException(
+            'program closure exceeded its $maxImportPrograms-program budget');
+      }
+      final program = await programSource(id);
+      totalBytes += program.source.length;
+      if (totalBytes > maxImportPrograms * maxProgramSize) {
+        throw AleoNodeException(
+            'program closure exceeded its total-byte budget');
+      }
+      fetched[id] = {
+        'id': id,
+        'edition': program.edition,
+        'source': program.source,
+      };
+      queue.addAll(resolve(program.source));
+    }
+    return jsonEncode(fetched.values.toList());
+  }
+
+  /// Broadcasts a serialized transaction, returning the node's response (the
+  /// `at1…` transaction id on success). Not retried.
+  Future<String> broadcast(String transaction) async {
+    final token = CancelToken();
+    final timer = Timer(requestTimeout,
+        () => token.cancel('broadcast exceeded $requestTimeout'));
+    try {
+      final resp = await _dio.post<ResponseBody>(
+        '$base/transaction/broadcast',
+        data: transaction,
+        options: Options(
+          contentType: 'application/json',
+          responseType: ResponseType.stream,
+        ),
+        cancelToken: token,
+      );
+      final body = await _readBounded(resp.data!, maxBytes: maxStateRootBytes);
+      return _unquote(body);
+    } on DioException catch (e) {
+      throw _wrap('transaction/broadcast', e);
+    } finally {
+      timer.cancel();
+    }
+  }
+
+  // --- internals ------------------------------------------------------------
+
+  /// GET `route` with a bounded body and a few retries on a transient failure,
+  /// the whole sequence capped by [requestTimeout] per attempt and aborted via
+  /// the cancel token wherever it blocks.
+  Future<String> _getWithRetry(String route,
+      {required int maxBytes}) async {
+    DioException? last;
+    for (var attempt = 0; attempt < getAttempts; attempt++) {
+      try {
+        return await _getOnce(route, maxBytes: maxBytes);
+      } on DioException catch (e) {
+        last = e;
+        if (!_isRetryable(e) || attempt + 1 == getAttempts) {
+          throw _wrap(route, e);
+        }
+        await Future<void>.delayed(Duration(milliseconds: 500 * (attempt + 1)));
+      }
+    }
+    throw _wrap(route, last!); // unreachable; the loop returns or throws.
+  }
+
+  Future<String> _getOnce(String route, {required int maxBytes}) async {
+    final token = CancelToken();
+    final timer = Timer(
+        requestTimeout, () => token.cancel('$route exceeded $requestTimeout'));
+    try {
+      final resp = await _dio.get<ResponseBody>(
+        '$base/$route',
+        options: Options(responseType: ResponseType.stream),
+        cancelToken: token,
+      );
+      return await _readBounded(resp.data!, maxBytes: maxBytes);
+    } finally {
+      timer.cancel();
+    }
+  }
+
+  /// Streams a response body, accumulating into memory but aborting (and
+  /// cancelling the request) the instant it passes [maxBytes], so a malicious
+  /// node cannot exhaust the heap with one giant body.
+  Future<String> _readBounded(ResponseBody body,
+      {required int maxBytes}) async {
+    final builder = BytesBuilder(copy: false);
+    await for (final Uint8List chunk in body.stream) {
+      builder.add(chunk);
+      if (builder.length > maxBytes) {
+        throw AleoNodeException(
+            'node response exceeded its $maxBytes-byte budget');
+      }
+    }
+    return utf8.decode(builder.takeBytes());
+  }
+
+  /// Retry only on errors a retry could actually fix: connection/timeout
+  /// failures and 5xx (the public node's transient 522). A 4xx is the node
+  /// rejecting our input — retrying just repeats it.
+  bool _isRetryable(DioException e) {
+    switch (e.type) {
+      case DioExceptionType.connectionError:
+      case DioExceptionType.connectionTimeout:
+      case DioExceptionType.sendTimeout:
+      case DioExceptionType.receiveTimeout:
+        return true;
+      case DioExceptionType.badResponse:
+        final status = e.response?.statusCode ?? 0;
+        return status >= 500;
+      default:
+        return false;
+    }
+  }
+
+  AleoNodeException _wrap(String route, DioException e) {
+    if (CancelToken.isCancel(e)) {
+      return AleoNodeException('$route timed out after $requestTimeout');
+    }
+    final status = e.response?.statusCode;
+    final suffix = status != null ? ' (HTTP $status)' : '';
+    return AleoNodeException('$route request failed$suffix: ${e.message}');
+  }
+
+  /// Strips one layer of surrounding double quotes from a JSON-string body
+  /// (`"sr1…"` -> `sr1…`), leaving a bare value untouched.
+  static String _unquote(String body) {
+    final trimmed = body.trim();
+    if (trimmed.length >= 2 &&
+        trimmed.startsWith('"') &&
+        trimmed.endsWith('"')) {
+      return trimmed.substring(1, trimmed.length - 1);
+    }
+    return trimmed;
+  }
+}

--- a/packages/aleo_dart/lib/src/aleo_node.dart
+++ b/packages/aleo_dart/lib/src/aleo_node.dart
@@ -43,6 +43,10 @@ class AleoNode {
 
   final Dio _dio;
 
+  /// Whether this AleoNode created [_dio] (and so must close it) or had one
+  /// injected (the caller owns its lifecycle).
+  final bool _ownsDio;
+
   /// Wall-clock budget for one logical read: every retry attempt and backoff
   /// together must fit inside it, so a stalling node cannot stretch a read to
   /// `getAttempts × timeout`. It also caps each *individual* request even under
@@ -107,14 +111,29 @@ class AleoNode {
     this.closureDeadline = const Duration(seconds: 120),
     this.parseImports,
   })  : base = '${url.replaceAll(RegExp(r'/+$'), '')}/$network',
-        _dio = dio ??
-            Dio(BaseOptions(
-              connectTimeout: const Duration(seconds: 15),
-              receiveTimeout: const Duration(seconds: 30),
-              // We read the raw bytes ourselves (bounded), so dio must not try
-              // to JSON-decode or buffer the body for us.
-              responseType: ResponseType.stream,
-            ));
+        _ownsDio = dio == null,
+        _dio = dio ?? defaultDio();
+
+  /// The streaming Dio AleoNode uses when none is injected. Exposed so a
+  /// long-lived owner (e.g. [AleoProgram]) can create one and share it across
+  /// many short-lived AleoNodes, instead of spawning — and leaking — a client
+  /// per operation.
+  static Dio defaultDio() => Dio(BaseOptions(
+        connectTimeout: const Duration(seconds: 15),
+        receiveTimeout: const Duration(seconds: 30),
+        // We read the raw bytes ourselves (bounded), so dio must not try to
+        // JSON-decode or buffer the body for us.
+        responseType: ResponseType.stream,
+      ));
+
+  /// Closes the underlying Dio and its pooled keep-alive connections — but only
+  /// if this AleoNode created it; a no-op for an injected Dio (the caller owns
+  /// it). Dio's IOHttpClientAdapter caches an HttpClient that only `Dio.close()`
+  /// tears down, so a client created per operation must be closed to avoid
+  /// accumulating idle sockets.
+  void close() {
+    if (_ownsDio) _dio.close(force: true);
+  }
 
   /// Current block height — selects the consensus version proving pins.
   Future<int> latestHeight() async {
@@ -174,20 +193,24 @@ class AleoNode {
   /// A program's source at its current on-chain edition. The edition and source
   /// are read in that order (`/program/{id}/latest_edition`, then
   /// `/program/{id}/{edition}`) so they stay consistent across a concurrent
-  /// upgrade. The decoded source must not exceed [maxProgramSize]. [deadline],
-  /// when supplied, bounds both reads against one shared budget (the closure
-  /// walk passes its own).
-  Future<({int edition, String source})> programSource(String id,
-      {DateTime? deadline}) async {
+  /// upgrade. The decoded source must not exceed [maxProgramSize].
+  Future<({int edition, String source})> programSource(String id) =>
+      _programSourceWithin(id, null);
+
+  /// [programSource] bounded by a shared monotonic [budget] (the closure walk
+  /// passes one across all its fetches; a standalone call passes `null`, giving
+  /// each fetch its own [requestTimeout]).
+  Future<({int edition, String source})> _programSourceWithin(
+      String id, _Budget? budget) async {
     final editionBody = await _getWithRetry('program/$id/latest_edition',
-        maxBytes: maxHeightBytes, deadline: deadline);
+        maxBytes: maxHeightBytes, budget: budget);
     final edition = int.tryParse(_unquote(editionBody));
     if (edition == null || edition < 0) {
       throw AleoNodeException(
           "program/$id/latest_edition returned a non-integer: $editionBody");
     }
     final sourceBody = await _getWithRetry('program/$id/$edition',
-        maxBytes: maxProgramSourceWireBytes, deadline: deadline);
+        maxBytes: maxProgramSourceWireBytes, budget: budget);
     final dynamic decoded;
     try {
       decoded = jsonDecode(sourceBody);
@@ -219,12 +242,12 @@ class AleoNode {
           'programClosure needs an import resolver (required_imports); '
           'construct AleoNode with parseImports');
     }
-    final deadline = DateTime.now().add(closureDeadline);
+    final budget = _Budget(closureDeadline);
     final fetched = <String, Map<String, dynamic>>{};
     final queue = <String>[rootId];
     var totalBytes = 0;
     while (queue.isNotEmpty) {
-      if (DateTime.now().isAfter(deadline)) {
+      if (budget.isExhausted) {
         throw AleoNodeException(
             'program closure load exceeded its $closureDeadline time budget');
       }
@@ -234,7 +257,7 @@ class AleoNode {
         throw AleoNodeException(
             'program closure exceeded its $maxImportPrograms-program budget');
       }
-      final program = await programSource(id, deadline: deadline);
+      final program = await _programSourceWithin(id, budget);
       // Aleo program sources are ASCII, so code-unit length == byte length; use
       // the UTF-8 byte length anyway so the budget faithfully mirrors the Rust
       // total-byte cap regardless of content.
@@ -287,11 +310,11 @@ class AleoNode {
   /// walk shares one across all its fetches). Each attempt is given only the
   /// time left, and a backoff never runs past the deadline.
   Future<String> _getWithRetry(String route,
-      {required int maxBytes, DateTime? deadline}) async {
-    final overall = deadline ?? DateTime.now().add(requestTimeout);
+      {required int maxBytes, _Budget? budget}) async {
+    final overall = budget ?? _Budget(requestTimeout);
     DioException? last;
     for (var attempt = 0; attempt < getAttempts; attempt++) {
-      final remaining = overall.difference(DateTime.now());
+      final remaining = overall.remaining;
       if (remaining <= Duration.zero) break;
       // Cap each individual request at requestTimeout even when the overall
       // budget is the larger closureDeadline, so one slow-but-progressing node
@@ -303,7 +326,7 @@ class AleoNode {
         return await _getOnce(route, maxBytes: maxBytes, timeout: attemptTimeout);
       } on DioException catch (e) {
         last = e;
-        final left = overall.difference(DateTime.now());
+        final left = overall.remaining;
         // A cancel here is our per-attempt timer firing — a single slow request,
         // not the whole read out of time (an over-budget body throws an
         // AleoNodeException, which is not caught here). So it is retryable while
@@ -402,4 +425,24 @@ class AleoNode {
     }
     return trimmed;
   }
+}
+
+/// A wall-clock budget measured with a monotonic [Stopwatch] rather than
+/// `DateTime.now()`. A system-clock adjustment mid-flight (NTP step, manual
+/// change) must not extend a deadline past its budget or expire it early, so
+/// elapsed time is read from a monotonic source — like the old Rust loader's
+/// `Instant`.
+class _Budget {
+  final Stopwatch _elapsed = Stopwatch()..start();
+  final Duration total;
+
+  _Budget(this.total);
+
+  /// Time left, never negative.
+  Duration get remaining {
+    final left = total - _elapsed.elapsed;
+    return left.isNegative ? Duration.zero : left;
+  }
+
+  bool get isExhausted => remaining <= Duration.zero;
 }

--- a/packages/aleo_dart/lib/src/aleo_node.dart
+++ b/packages/aleo_dart/lib/src/aleo_node.dart
@@ -27,14 +27,14 @@ class AleoNodeException implements Exception {
 /// underlying socket: `Future.timeout` only stops awaiting and leaks the
 /// connection, which would recreate the abandoned-worker leak we are leaving
 /// Rust to escape. dio's own [BaseOptions.connectTimeout] / `receiveTimeout`
-/// bound the connect and inter-chunk read phases; an outer [requestTimeout]
-/// timer cancels the whole request wherever it blocks (including a stalled
-/// body the per-chunk timeout never trips).
+/// bound the connect and inter-chunk read phases; [requestTimeout] is the
+/// **overall** wall-clock budget for one logical read (covering all retries and
+/// their backoff, like the old Rust `http_get_until` deadline) — when it
+/// expires the token is cancelled wherever the request blocks.
 ///
 /// Untrusted node responses are budget-checked here on the fetch side, mirroring
-/// the Rust parser's caps, so an oversized or endless response is rejected
-/// before it can exhaust memory — the size budgets survive the move to Dart even
-/// though the worker-thread machinery does not.
+/// the Rust parser's caps, and streamed so an oversized or endless body is
+/// rejected — and the request cancelled — before it can exhaust memory.
 class AleoNode {
   /// `{url}/{network}` — the REST base every route hangs off. Aleo's testnet
   /// runs the network-0 protocol under a `/testnet` path, so the network
@@ -43,8 +43,10 @@ class AleoNode {
 
   final Dio _dio;
 
-  /// Overall per-request wall-clock bound. On expiry the request's
-  /// [CancelToken] is cancelled, aborting the socket — not merely the await.
+  /// **Overall** wall-clock budget for one logical read — every retry attempt
+  /// and every backoff together must fit inside it, so a stalling node cannot
+  /// stretch a read to `getAttempts × timeout`. On expiry the in-flight
+  /// request's [CancelToken] is cancelled, aborting the socket.
   final Duration requestTimeout;
 
   /// Retries for an idempotent GET (the public node returns transient 5xx/522).
@@ -52,8 +54,9 @@ class AleoNode {
   /// idempotent.
   final int getAttempts;
 
-  /// Wall-clock ceiling on resolving one program import closure. A DoS guard,
-  /// not a protocol limit, so it sits far above any honest closure.
+  /// Wall-clock ceiling on resolving one program import closure — threaded into
+  /// every fetch it triggers (not just checked between fetches), so a single
+  /// stalling import cannot overrun it. A DoS guard, not a protocol limit.
   final Duration closureDeadline;
 
   /// Resolves a program's direct imports from its source, so [programClosure]
@@ -81,9 +84,17 @@ class AleoNode {
   /// `MAX_IMPORT_PROGRAMS` — the program-count cap on one import closure.
   static const int maxImportPrograms = 256;
 
-  /// `Net::MAX_PROGRAM_SIZE` — the per-program source byte cap; a larger body
-  /// cannot be a valid on-chain program.
+  /// `Net::MAX_PROGRAM_SIZE` — the per-program *decoded* source byte cap; a
+  /// larger one cannot be a valid on-chain program.
   static const int maxProgramSize = 100 * 1000;
+
+  /// Streaming cap on the *wire* (JSON-quoted, escape-expanded) program-source
+  /// body. A program source is delivered as a JSON string, and JSON escaping can
+  /// inflate it up to ~6× (`\uXXXX` per code unit) over the decoded length, so
+  /// the wire cap must allow for that — the real `maxProgramSize` bound is then
+  /// enforced on the *decoded* string. Sizing the wire cap at `maxProgramSize`
+  /// would wrongly reject a legitimate near-max program full of newlines.
+  static const int maxProgramSourceWireBytes = maxProgramSize * 6 + 64;
 
   AleoNode(
     String url, {
@@ -136,7 +147,12 @@ class AleoNode {
     final route = 'statePaths?commitments=${commitments.join(',')}';
     final body = await _getWithRetry(route,
         maxBytes: maxStatePaths * maxStatePathBytes);
-    final decoded = jsonDecode(body);
+    final dynamic decoded;
+    try {
+      decoded = jsonDecode(body);
+    } on FormatException catch (e) {
+      throw AleoNodeException('statePaths response was not valid JSON: ${e.message}');
+    }
     if (decoded is! List) {
       throw AleoNodeException('statePaths response was not a JSON array');
     }
@@ -151,20 +167,26 @@ class AleoNode {
   /// A program's source at its current on-chain edition. The edition and source
   /// are read in that order (`/program/{id}/latest_edition`, then
   /// `/program/{id}/{edition}`) so they stay consistent across a concurrent
-  /// upgrade. The source must not exceed [maxProgramSize] — a larger body cannot
-  /// be a valid on-chain program, so rejecting it never drops a real one.
-  Future<({int edition, String source})> programSource(String id) async {
-    final editionBody = await _getWithRetry(
-        'program/$id/latest_edition',
-        maxBytes: maxHeightBytes);
+  /// upgrade. The decoded source must not exceed [maxProgramSize]. [deadline],
+  /// when supplied, bounds both reads against one shared budget (the closure
+  /// walk passes its own).
+  Future<({int edition, String source})> programSource(String id,
+      {DateTime? deadline}) async {
+    final editionBody = await _getWithRetry('program/$id/latest_edition',
+        maxBytes: maxHeightBytes, deadline: deadline);
     final edition = int.tryParse(_unquote(editionBody));
     if (edition == null || edition < 0) {
       throw AleoNodeException(
           "program/$id/latest_edition returned a non-integer: $editionBody");
     }
     final sourceBody = await _getWithRetry('program/$id/$edition',
-        maxBytes: maxProgramSize + 2 /* surrounding quotes */);
-    final decoded = jsonDecode(sourceBody);
+        maxBytes: maxProgramSourceWireBytes, deadline: deadline);
+    final dynamic decoded;
+    try {
+      decoded = jsonDecode(sourceBody);
+    } on FormatException catch (e) {
+      throw AleoNodeException('program/$id/$edition was not valid JSON: ${e.message}');
+    }
     if (decoded is! String) {
       throw AleoNodeException('program/$id/$edition was not a JSON string');
     }
@@ -181,7 +203,8 @@ class AleoNode {
   /// imports included, any order (Rust adds them imports-before-importers).
   /// `credits.aleo` is built in and never fetched. Bounded on every axis a
   /// hostile node can stretch an honest, acyclic, individually-valid chain:
-  /// program count, cumulative bytes, and wall-clock time.
+  /// program count, cumulative bytes, and wall-clock time (the deadline is
+  /// threaded into each fetch, so a single stalling import cannot overrun it).
   Future<String> programClosure(String rootId) async {
     final resolve = parseImports;
     if (resolve == null) {
@@ -204,8 +227,11 @@ class AleoNode {
         throw AleoNodeException(
             'program closure exceeded its $maxImportPrograms-program budget');
       }
-      final program = await programSource(id);
-      totalBytes += program.source.length;
+      final program = await programSource(id, deadline: deadline);
+      // Aleo program sources are ASCII, so code-unit length == byte length; use
+      // the UTF-8 byte length anyway so the budget faithfully mirrors the Rust
+      // total-byte cap regardless of content.
+      totalBytes += utf8.encode(program.source).length;
       if (totalBytes > maxImportPrograms * maxProgramSize) {
         throw AleoNodeException(
             'program closure exceeded its total-byte budget');
@@ -236,7 +262,8 @@ class AleoNode {
         ),
         cancelToken: token,
       );
-      final body = await _readBounded(resp.data!, maxBytes: maxStateRootBytes);
+      final body = await _readBounded(resp.data!,
+          maxBytes: maxStateRootBytes, token: token);
       return _unquote(body);
     } on DioException catch (e) {
       throw _wrap('transaction/broadcast', e);
@@ -248,61 +275,79 @@ class AleoNode {
   // --- internals ------------------------------------------------------------
 
   /// GET `route` with a bounded body and a few retries on a transient failure,
-  /// the whole sequence capped by [requestTimeout] per attempt and aborted via
-  /// the cancel token wherever it blocks.
+  /// the whole sequence (attempts + backoff) capped by one **overall** deadline
+  /// — `requestTimeout` from now, or the caller-supplied [deadline] (the closure
+  /// walk shares one across all its fetches). Each attempt is given only the
+  /// time left, and a backoff never runs past the deadline.
   Future<String> _getWithRetry(String route,
-      {required int maxBytes}) async {
+      {required int maxBytes, DateTime? deadline}) async {
+    final overall = deadline ?? DateTime.now().add(requestTimeout);
     DioException? last;
     for (var attempt = 0; attempt < getAttempts; attempt++) {
+      final remaining = overall.difference(DateTime.now());
+      if (remaining <= Duration.zero) break;
       try {
-        return await _getOnce(route, maxBytes: maxBytes);
+        return await _getOnce(route, maxBytes: maxBytes, timeout: remaining);
       } on DioException catch (e) {
         last = e;
         if (!_isRetryable(e) || attempt + 1 == getAttempts) {
           throw _wrap(route, e);
         }
-        await Future<void>.delayed(Duration(milliseconds: 500 * (attempt + 1)));
+        final left = overall.difference(DateTime.now());
+        if (left <= Duration.zero) break;
+        final backoff = Duration(milliseconds: 500 * (attempt + 1));
+        await Future<void>.delayed(backoff < left ? backoff : left);
       }
     }
-    throw _wrap(route, last!); // unreachable; the loop returns or throws.
+    if (last != null) throw _wrap(route, last);
+    throw AleoNodeException('$route timed out (overall budget exceeded)');
   }
 
-  Future<String> _getOnce(String route, {required int maxBytes}) async {
+  Future<String> _getOnce(String route,
+      {required int maxBytes, required Duration timeout}) async {
     final token = CancelToken();
     final timer = Timer(
-        requestTimeout, () => token.cancel('$route exceeded $requestTimeout'));
+        timeout, () => token.cancel('$route exceeded its time budget'));
     try {
       final resp = await _dio.get<ResponseBody>(
         '$base/$route',
         options: Options(responseType: ResponseType.stream),
         cancelToken: token,
       );
-      return await _readBounded(resp.data!, maxBytes: maxBytes);
+      return await _readBounded(resp.data!, maxBytes: maxBytes, token: token);
     } finally {
       timer.cancel();
     }
   }
 
-  /// Streams a response body, accumulating into memory but aborting (and
-  /// cancelling the request) the instant it passes [maxBytes], so a malicious
-  /// node cannot exhaust the heap with one giant body.
+  /// Streams a response body, accumulating into memory but **cancelling the
+  /// request and aborting** the instant it passes [maxBytes], so a malicious
+  /// node cannot exhaust the heap with one giant body (cancelling is what
+  /// actually closes the socket — throwing alone would leak the connection).
   Future<String> _readBounded(ResponseBody body,
-      {required int maxBytes}) async {
+      {required int maxBytes, CancelToken? token}) async {
     final builder = BytesBuilder(copy: false);
     await for (final Uint8List chunk in body.stream) {
       builder.add(chunk);
       if (builder.length > maxBytes) {
+        token?.cancel('response exceeded its $maxBytes-byte budget');
         throw AleoNodeException(
             'node response exceeded its $maxBytes-byte budget');
       }
     }
-    return utf8.decode(builder.takeBytes());
+    try {
+      return utf8.decode(builder.takeBytes());
+    } on FormatException catch (e) {
+      throw AleoNodeException('node response was not valid UTF-8: ${e.message}');
+    }
   }
 
   /// Retry only on errors a retry could actually fix: connection/timeout
   /// failures and 5xx (the public node's transient 522). A 4xx is the node
-  /// rejecting our input — retrying just repeats it.
+  /// rejecting our input — retrying just repeats it. A cancel (our overall
+  /// timeout) is never retryable: the overall deadline has passed.
   bool _isRetryable(DioException e) {
+    if (CancelToken.isCancel(e)) return false;
     switch (e.type) {
       case DioExceptionType.connectionError:
       case DioExceptionType.connectionTimeout:
@@ -319,7 +364,7 @@ class AleoNode {
 
   AleoNodeException _wrap(String route, DioException e) {
     if (CancelToken.isCancel(e)) {
-      return AleoNodeException('$route timed out after $requestTimeout');
+      return AleoNodeException('$route timed out (budget exceeded)');
     }
     final status = e.response?.statusCode;
     final suffix = status != null ? ' (HTTP $status)' : '';

--- a/packages/aleo_dart/lib/src/aleo_node.dart
+++ b/packages/aleo_dart/lib/src/aleo_node.dart
@@ -193,15 +193,18 @@ class AleoNode {
   /// A program's source at its current on-chain edition. The edition and source
   /// are read in that order (`/program/{id}/latest_edition`, then
   /// `/program/{id}/{edition}`) so they stay consistent across a concurrent
-  /// upgrade. The decoded source must not exceed [maxProgramSize].
+  /// upgrade. The decoded source must not exceed [maxProgramSize]. Both reads
+  /// share **one** [requestTimeout] budget — programSource is one logical read,
+  /// not two — so it cannot stretch to ~2× requestTimeout, matching the
+  /// single-request reads.
   Future<({int edition, String source})> programSource(String id) =>
-      _programSourceWithin(id, null);
+      _programSourceWithin(id, _Budget(requestTimeout));
 
-  /// [programSource] bounded by a shared monotonic [budget] (the closure walk
-  /// passes one across all its fetches; a standalone call passes `null`, giving
-  /// each fetch its own [requestTimeout]).
+  /// [programSource] bounded by a shared monotonic [budget] across both of its
+  /// reads (the standalone entry point passes a fresh `_Budget(requestTimeout)`;
+  /// the closure walk passes its own budget, shared across every fetch).
   Future<({int edition, String source})> _programSourceWithin(
-      String id, _Budget? budget) async {
+      String id, _Budget budget) async {
     final editionBody = await _getWithRetry('program/$id/latest_edition',
         maxBytes: maxHeightBytes, budget: budget);
     final edition = int.tryParse(_unquote(editionBody));

--- a/packages/aleo_dart/lib/src/aleo_programs.dart
+++ b/packages/aleo_dart/lib/src/aleo_programs.dart
@@ -3,18 +3,77 @@ import 'dart:convert';
 
 import 'package:path/path.dart' as path;
 
+import 'package:aleo_dart/src/aleo_node.dart';
 import 'package:aleo_dart/src/rust_lib/programs_rust_ffi.dart';
 import 'package:aleo_dart/src/rust_lib/utils.dart';
 import 'package:aleo_dart/src/aleo_utils.dart';
 
+/// Aleo program orchestration.
+///
+/// Phase 2 of the I/O-to-Dart migration: the one-call flows (`tryTransfer`,
+/// `tryJoin`, `buildTransaction`, `executeProgram`, `contractExecution`,
+/// `contractFeeExecution`) and the node-touching leaves (`executeProof`,
+/// `executeFeeProof`, `executeProgramProof`, `getBaseFee`,
+/// `executionFeeAuthorization`, `broadcast`) no longer call the blocking-HTTP
+/// FFI exports. They compose the pure phase-1 `*_static` primitives over data an
+/// [AleoNode] fetches in Dart (with real `CancelToken` cancellation), so the
+/// network I/O lives in a layer that can actually be cancelled and bounded.
+/// Public method signatures are unchanged.
+///
+/// The split-proof transfer flow mirrors the old in-Rust `full_transaction`
+/// exactly — authorize → prove execution → authorize fee → prove fee → assemble
+/// — but takes two independent inclusion snapshots (execution, then the fee,
+/// because a private fee spends its own record) and pins one consensus version
+/// across the whole transaction (a mid-flow upgrade discards everything and
+/// restarts).
 class AleoProgram {
   late ProgramsRustFFI programsRustFFI;
+
+  /// How many times the whole transfer flow restarts if a consensus upgrade
+  /// lands mid-build. A generous ceiling: upgrades are rare, so more than one
+  /// retry means something is badly wrong rather than a real version churn.
+  static const int _maxConsensusRetries = 3;
 
   AleoProgram(dyLib, [String network_raw = 'testnet']) {
     this.programsRustFFI = ProgramsRustFFI(dyLib, network_raw);
   }
 
+  /// A node bound to [url_raw] and this program's network, with the pure
+  /// `required_imports` helper wired in for the program-closure walk.
+  AleoNode _node(String url_raw) => AleoNode(
+        url_raw,
+        network: programsRustFFI.network,
+        parseImports: _requiredImports,
+      );
+
+  // --- one-call flows (compose primitives + node I/O) -----------------------
+
+  /// Builds and broadcasts a credits.aleo transfer, returning the node response.
   Future<String> tryTransfer(
+    String private_key_raw,
+    String recipient_raw,
+    String transfer_type_raw,
+    int amount_credits,
+    int fee_credits,
+    String url_raw,
+    String amount_record_raw,
+    String fee_record_raw,
+  ) async {
+    final transaction = await buildTransaction(
+      private_key_raw,
+      recipient_raw,
+      transfer_type_raw,
+      amount_credits,
+      fee_credits,
+      url_raw,
+      amount_record_raw,
+      fee_record_raw,
+    );
+    return _node(url_raw).broadcast(transaction);
+  }
+
+  /// Builds a complete credits.aleo transfer transaction (without broadcasting).
+  Future<String> buildTransaction(
     String private_key_raw,
     String recipient_raw,
     String transfer_type_raw,
@@ -26,35 +85,52 @@ class AleoProgram {
   ) async {
     AleoUtils.checkAmount(amount_credits, 'amount');
     AleoUtils.checkAmount(fee_credits, 'fee');
-    final private_key = dartStrToC(private_key_raw);
-    final transfer_type = dartStrToC(transfer_type_raw);
-    final recipient = dartStrToC(recipient_raw);
-    final url = dartStrToC(url_raw);
-    final amount_record = dartStrToC(amount_record_raw);
-    final fee_record = dartStrToC(fee_record_raw);
-    try {
-      final result = await programsRustFFI.transfer(
-          private_key,
-          recipient,
-          transfer_type,
-          amount_credits,
-          fee_credits,
-          url,
-          amount_record,
-          fee_record);
-      return takeNativeString(programsRustFFI.dyLib, result);
-    } finally {
-      freeAll([
-        private_key,
-        transfer_type,
-        recipient,
-        url,
-        amount_record,
-        fee_record
-      ]);
+    final node = _node(url_raw);
+
+    for (var attempt = 0;; attempt++) {
+      final height = await node.latestHeight();
+      final version = programsRustFFI.consensusVersionFor(height);
+
+      // (2) execution authorization — offline (credits.aleo is built in).
+      final execution = _require(
+          await executionAuthorization(private_key_raw, recipient_raw,
+              transfer_type_raw, amount_credits, url_raw, amount_record_raw),
+          'execution authorization');
+
+      // (3-4) execution snapshot + proof.
+      final executionProof = await _proveExecution(node, execution, height);
+
+      // (5) fee authorization — priority fee = fee_credits; public/private by
+      // fee_record. Empty program sources: credits.aleo is built in.
+      final feeAuth = _require(
+          await executionFeeAuthorizationStatic(private_key_raw, executionProof,
+              fee_credits, fee_record_raw, '', height),
+          'fee authorization');
+
+      // (6-7) fee snapshot + proof (its own commitments — a private fee spends
+      // its own record).
+      final feeProof = await _proveFee(node, feeAuth, height);
+
+      // (8) consistency gate: an upgrade landing mid-flow invalidates every
+      // proof bound to the old version, so discard all of them and restart.
+      if (programsRustFFI.consensusVersionFor(await node.latestHeight()) !=
+          version) {
+        if (attempt + 1 >= _maxConsensusRetries) {
+          throw AleoNodeException(
+              'consensus version changed on every one of $_maxConsensusRetries '
+              'transfer-build attempts');
+        }
+        continue;
+      }
+
+      // (9) assemble.
+      return _require(await buildTransactionOffline(executionProof, feeProof),
+          'transaction assembly');
     }
   }
 
+  /// Builds, proves, and broadcasts a credits.aleo `join` of two private
+  /// records, returning the node response.
   Future<String> tryJoin(
     String private_key_raw,
     String record_1_raw,
@@ -64,19 +140,203 @@ class AleoProgram {
     String url_raw,
   ) async {
     AleoUtils.checkAmount(fee_credits, 'fee');
-    final private_key = dartStrToC(private_key_raw);
-    final record_1 = dartStrToC(record_1_raw);
-    final record_2 = dartStrToC(record_2_raw);
-    final fee_record = dartStrToC(fee_record_raw);
-    final url = dartStrToC(url_raw);
-    try {
-      final result = await programsRustFFI.join(
-          private_key, record_1, record_2, fee_credits, fee_record, url);
-      return takeNativeString(programsRustFFI.dyLib, result);
-    } finally {
-      freeAll([private_key, record_1, record_2, fee_record, url]);
+    final node = _node(url_raw);
+
+    for (var attempt = 0;; attempt++) {
+      final height = await node.latestHeight();
+      final version = programsRustFFI.consensusVersionFor(height);
+
+      final joinAuth = _require(
+          await joinAuthorization(
+              private_key_raw, record_1_raw, record_2_raw, url_raw),
+          'join authorization');
+
+      // join spends two on-chain records, so this is a private flow.
+      final executionProof = await _proveExecution(node, joinAuth, height);
+
+      final feeAuth = _require(
+          await executionFeeAuthorizationStatic(private_key_raw, executionProof,
+              fee_credits, fee_record_raw, '', height),
+          'fee authorization');
+      final feeProof = await _proveFee(node, feeAuth, height);
+
+      if (programsRustFFI.consensusVersionFor(await node.latestHeight()) !=
+          version) {
+        if (attempt + 1 >= _maxConsensusRetries) {
+          throw AleoNodeException(
+              'consensus version changed on every one of $_maxConsensusRetries '
+              'join-build attempts');
+        }
+        continue;
+      }
+
+      final transaction = _require(
+          await buildTransactionOffline(executionProof, feeProof),
+          'transaction assembly');
+      return node.broadcast(transaction);
     }
   }
+
+  /// Executes an arbitrary program function and broadcasts the transaction,
+  /// returning the node response. The fee is public (no fee record).
+  Future<String> executeProgram(
+    String private_key_raw,
+    String program_id_raw,
+    String function_name_raw,
+    String arguments_raw,
+    int fee,
+    String url_raw,
+  ) async {
+    AleoUtils.checkAmount(fee, 'fee');
+    final node = _node(url_raw);
+
+    for (var attempt = 0;; attempt++) {
+      final height = await node.latestHeight();
+      final version = programsRustFFI.consensusVersionFor(height);
+
+      // Fetch the program's import closure once; it is needed to authorize, to
+      // prove, and to cost the fee (execution_cost reads each transition's
+      // program Stack).
+      final sources = await node.programClosure(program_id_raw);
+
+      final auth = _require(
+          await programAuthorizationStatic(private_key_raw, program_id_raw,
+              function_name_raw, arguments_raw, sources),
+          'program authorization');
+
+      final executionProof =
+          await _proveProgramExecution(node, auth, sources, height);
+
+      final feeAuth = _require(
+          await executionFeeAuthorizationStatic(
+              private_key_raw, executionProof, fee, '', sources, height),
+          'fee authorization');
+      final feeProof = await _proveFee(node, feeAuth, height);
+
+      if (programsRustFFI.consensusVersionFor(await node.latestHeight()) !=
+          version) {
+        if (attempt + 1 >= _maxConsensusRetries) {
+          throw AleoNodeException(
+              'consensus version changed on every one of $_maxConsensusRetries '
+              'program-execution attempts');
+        }
+        continue;
+      }
+
+      final transaction = _require(
+          await buildTransactionOffline(executionProof, feeProof),
+          'transaction assembly');
+      return node.broadcast(transaction);
+    }
+  }
+
+  /// Produces the execution proof for an arbitrary program function (split
+  /// proof; the fee follows via [contractFeeExecution]). Returns the serialized
+  /// execution.
+  Future<String> contractExecution(
+    String private_key_raw,
+    String program_id_raw,
+    String function_name_raw,
+    String arguments_raw,
+    String url_raw,
+  ) async {
+    final node = _node(url_raw);
+    final height = await node.latestHeight();
+    final sources = await node.programClosure(program_id_raw);
+    final auth = _require(
+        await programAuthorizationStatic(private_key_raw, program_id_raw,
+            function_name_raw, arguments_raw, sources),
+        'program authorization');
+    return _proveProgramExecution(node, auth, sources, height);
+  }
+
+  /// Produces the public fee proof for a contract execution. Returns the
+  /// serialized fee.
+  Future<String> contractFeeExecution(
+    String private_key_raw,
+    int fee,
+    String execution_raw,
+    String program_id_raw,
+    String url_raw,
+  ) async {
+    AleoUtils.checkAmount(fee, 'fee');
+    final node = _node(url_raw);
+    final height = await node.latestHeight();
+    final sources = await node.programClosure(program_id_raw);
+    final feeAuth = _require(
+        await executionFeeAuthorizationStatic(
+            private_key_raw, execution_raw, fee, '', sources, height),
+        'fee authorization');
+    return _proveFee(node, feeAuth, height);
+  }
+
+  // --- node-touching leaves (compose a static primitive over node I/O) ------
+
+  /// Generates the execution proof for a credits.aleo authorization. Fetches the
+  /// snapshot (height + state paths/root) and proves offline.
+  Future<String> executeProof(String url_raw, String authorization_raw) async {
+    final node = _node(url_raw);
+    final height = await node.latestHeight();
+    return _proveExecution(node, authorization_raw, height);
+  }
+
+  /// Generates the execution proof for an authorization that targets a
+  /// non-builtin program: its closure is fetched and supplied in-memory.
+  Future<String> executeProgramProof(String url_raw, String authorization_raw,
+      {String program_id_raw = 'credits.aleo'}) async {
+    final node = _node(url_raw);
+    final height = await node.latestHeight();
+    final sources = await node.programClosure(program_id_raw);
+    return _proveProgramExecution(node, authorization_raw, sources, height);
+  }
+
+  /// Generates the fee proof for a fee authorization.
+  Future<String> executeFeeProof(
+    String url_raw,
+    String authorization_raw,
+  ) async {
+    final node = _node(url_raw);
+    final height = await node.latestHeight();
+    return _proveFee(node, authorization_raw, height);
+  }
+
+  /// Base (minimum) fee in microcredits for a serialized credits.aleo
+  /// execution. Fetches the height that selects the consensus version.
+  Future<int> getBaseFee(
+    String url_raw,
+    String execution_raw,
+  ) async {
+    final height = await _node(url_raw).latestHeight();
+    return getBaseFeeStatic(execution_raw, '', height);
+  }
+
+  /// Builds the fee authorization for an execution. `transfer_type_raw` is kept
+  /// for signature stability but unused — public vs private fee is decided by
+  /// whether `fee_record_raw` is empty.
+  Future<String> executionFeeAuthorization(
+      String private_key_raw,
+      String transfer_type_raw,
+      int fee_credits,
+      String url_raw,
+      String fee_record_raw,
+      String execution_raw) async {
+    AleoUtils.checkAmount(fee_credits, 'fee');
+    final height = await _node(url_raw).latestHeight();
+    return executionFeeAuthorizationStatic(
+        private_key_raw, execution_raw, fee_credits, fee_record_raw, '', height);
+  }
+
+  /// Broadcasts a serialized transaction. `transfer_type_raw` is unused (kept
+  /// for signature stability).
+  Future<String> broadcast(
+    String transaction_raw,
+    String url_raw,
+    String transfer_type_raw,
+  ) async {
+    return _node(url_raw).broadcast(transaction_raw);
+  }
+
+  // --- offline authorize / assemble (unchanged; the FFI ignores url) --------
 
   Future<String> joinAuthorization(
     String private_key_raw,
@@ -114,64 +374,6 @@ class AleoProgram {
     }
   }
 
-  Future<String> buildTransaction(
-    String private_key_raw,
-    String recipient_raw,
-    String transfer_type_raw,
-    int amount_credits,
-    int fee_credits,
-    String url_raw,
-    String amount_record_raw,
-    String fee_record_raw,
-  ) async {
-    AleoUtils.checkAmount(amount_credits, 'amount');
-    AleoUtils.checkAmount(fee_credits, 'fee');
-    final private_key = dartStrToC(private_key_raw);
-    final transfer_type = dartStrToC(transfer_type_raw);
-    final recipient = dartStrToC(recipient_raw);
-    final url = dartStrToC(url_raw);
-    final amount_record = dartStrToC(amount_record_raw);
-    final fee_record = dartStrToC(fee_record_raw);
-    try {
-      final result = await programsRustFFI.buildTransaction(
-          private_key,
-          recipient,
-          transfer_type,
-          amount_credits,
-          fee_credits,
-          url,
-          amount_record,
-          fee_record);
-      return takeNativeString(programsRustFFI.dyLib, result);
-    } finally {
-      freeAll([
-        private_key,
-        transfer_type,
-        recipient,
-        url,
-        amount_record,
-        fee_record
-      ]);
-    }
-  }
-
-  Future<String> broadcast(
-    String transaction_raw,
-    String url_raw,
-    String transfer_type_raw,
-  ) async {
-    final transaction = dartStrToC(transaction_raw);
-    final url = dartStrToC(url_raw);
-    final transfer_type = dartStrToC(transfer_type_raw);
-    try {
-      final result =
-          await programsRustFFI.broadcast(transaction, url, transfer_type);
-      return takeNativeString(programsRustFFI.dyLib, result);
-    } finally {
-      freeAll([transaction, url, transfer_type]);
-    }
-  }
-
   Future<String> executionAuthorization(
     String private_key_raw,
     String recipient_raw,
@@ -192,67 +394,6 @@ class AleoProgram {
       return takeNativeString(programsRustFFI.dyLib, result);
     } finally {
       freeAll([private_key, transfer_type, recipient, url, amount_record]);
-    }
-  }
-
-  Future<String> executionFeeAuthorization(
-      String private_key_raw,
-      String transfer_type_raw,
-      int fee_credits,
-      String url_raw,
-      String fee_record_raw,
-      String execution_raw) async {
-    AleoUtils.checkAmount(fee_credits, 'fee');
-    final private_key = dartStrToC(private_key_raw);
-    final transfer_type = dartStrToC(transfer_type_raw);
-    final url = dartStrToC(url_raw);
-    final fee_record = dartStrToC(fee_record_raw);
-    final execution = dartStrToC(execution_raw);
-    try {
-      final result = await programsRustFFI.executionFeeAuthorization(
-          private_key, transfer_type, fee_credits, url, fee_record, execution);
-      return takeNativeString(programsRustFFI.dyLib, result);
-    } finally {
-      freeAll([private_key, transfer_type, url, fee_record, execution]);
-    }
-  }
-
-  Future<String> executeProof(String url_raw, String authorization_raw) async {
-    final url = dartStrToC(url_raw);
-    final authorization = dartStrToC(authorization_raw);
-    try {
-      final result = await programsRustFFI.executeProof(url, authorization);
-      return takeNativeString(programsRustFFI.dyLib, result);
-    } finally {
-      freeAll([url, authorization]);
-    }
-  }
-
-  Future<String> executeProgramProof(String url_raw, String authorization_raw,
-      {String program_id_raw = 'credits.aleo'}) async {
-    final url = dartStrToC(url_raw);
-    final authorization = dartStrToC(authorization_raw);
-    final program_id = dartStrToC(program_id_raw);
-    try {
-      final result = await programsRustFFI.executeProgramProof(
-          url, authorization, program_id);
-      return takeNativeString(programsRustFFI.dyLib, result);
-    } finally {
-      freeAll([url, authorization, program_id]);
-    }
-  }
-
-  Future<String> executeFeeProof(
-    String url_raw,
-    String authorization_raw,
-  ) async {
-    final url = dartStrToC(url_raw);
-    final authorization = dartStrToC(authorization_raw);
-    try {
-      final result = await programsRustFFI.executeFeeProof(url, authorization);
-      return takeNativeString(programsRustFFI.dyLib, result);
-    } finally {
-      freeAll([url, authorization]);
     }
   }
 
@@ -284,17 +425,232 @@ class AleoProgram {
     }
   }
 
-  Future<int> getBaseFee(
-    String url_raw,
-    String execution_raw,
+  // --- phase-1 pure primitives (Dart wrappers) ------------------------------
+
+  /// Proves [authorization] (a serialized fee authorization) against its own
+  /// pre-fetched snapshot.
+  Future<String> executeFeeProofStatic(
+    String authorization_raw,
+    int height,
+    String state_paths_json,
+    String public_state_root,
   ) async {
-    final execution = dartStrToC(execution_raw);
-    final url = dartStrToC(url_raw);
+    final authorization = dartStrToC(authorization_raw);
+    final statePaths = dartStrToC(state_paths_json);
+    final publicRoot = dartStrToC(public_state_root);
     try {
-      return await programsRustFFI.getBaseFee(url, execution);
+      return takeNativeString(
+          programsRustFFI.dyLib,
+          programsRustFFI.executeFeeProofStatic(
+              authorization, height, statePaths, publicRoot));
     } finally {
-      freeAll([execution, url]);
+      freeAll([authorization, statePaths, publicRoot]);
     }
+  }
+
+  /// Proves [authorization] against a StaticQuery built from pre-fetched node
+  /// data (no node RPC; proving may still download parameters on a cold cache).
+  Future<String> executeProofStatic(
+    String authorization_raw,
+    int height,
+    String state_paths_json,
+    String public_state_root,
+  ) async {
+    final authorization = dartStrToC(authorization_raw);
+    final statePaths = dartStrToC(state_paths_json);
+    final publicRoot = dartStrToC(public_state_root);
+    try {
+      return takeNativeString(
+          programsRustFFI.dyLib,
+          programsRustFFI.executeProofStatic(
+              authorization, height, statePaths, publicRoot));
+    } finally {
+      freeAll([authorization, statePaths, publicRoot]);
+    }
+  }
+
+  /// Like [executeProofStatic] but the program closure is supplied in-memory.
+  Future<String> executeProgramProofStatic(
+    String authorization_raw,
+    String program_sources_json,
+    int height,
+    String state_paths_json,
+    String public_state_root,
+  ) async {
+    final authorization = dartStrToC(authorization_raw);
+    final sources = dartStrToC(program_sources_json);
+    final statePaths = dartStrToC(state_paths_json);
+    final publicRoot = dartStrToC(public_state_root);
+    try {
+      return takeNativeString(
+          programsRustFFI.dyLib,
+          programsRustFFI.executeProgramProofStatic(
+              authorization, sources, height, statePaths, publicRoot));
+    } finally {
+      freeAll([authorization, sources, statePaths, publicRoot]);
+    }
+  }
+
+  /// Builds the fee authorization for a proven [execution] at [height].
+  Future<String> executionFeeAuthorizationStatic(
+    String private_key_raw,
+    String execution_raw,
+    int fee_credits,
+    String fee_record_raw,
+    String program_sources_json,
+    int height,
+  ) async {
+    AleoUtils.checkAmount(fee_credits, 'fee');
+    final private_key = dartStrToC(private_key_raw);
+    final execution = dartStrToC(execution_raw);
+    final fee_record = dartStrToC(fee_record_raw);
+    final sources = dartStrToC(program_sources_json);
+    try {
+      return takeNativeString(
+          programsRustFFI.dyLib,
+          programsRustFFI.executionFeeAuthorizationStatic(
+              private_key, execution, fee_credits, fee_record, sources, height));
+    } finally {
+      freeAll([private_key, execution, fee_record, sources]);
+    }
+  }
+
+  /// Builds an execution authorization for an arbitrary program function,
+  /// offline. [arguments_raw] is a JSON array of Aleo value strings.
+  Future<String> programAuthorizationStatic(
+    String private_key_raw,
+    String program_id_raw,
+    String function_name_raw,
+    String arguments_raw,
+    String program_sources_json,
+  ) async {
+    final private_key = dartStrToC(private_key_raw);
+    final program_id = dartStrToC(program_id_raw);
+    final function_name = dartStrToC(function_name_raw);
+    final arguments = dartStrToC(arguments_raw);
+    final sources = dartStrToC(program_sources_json);
+    try {
+      return takeNativeString(
+          programsRustFFI.dyLib,
+          programsRustFFI.programAuthorizationStatic(
+              private_key, program_id, function_name, arguments, sources));
+    } finally {
+      freeAll([private_key, program_id, function_name, arguments, sources]);
+    }
+  }
+
+  /// Base fee (microcredits) for [execution_raw] at [height]; [sources] supplies
+  /// the execution's program(s) (empty for credits.aleo). 0 on failure.
+  int getBaseFeeStatic(String execution_raw, String sources, int height) {
+    final execution = dartStrToC(execution_raw);
+    final programSources = dartStrToC(sources);
+    try {
+      return programsRustFFI.getBaseFeeStatic(execution, programSources, height);
+    } finally {
+      freeAll([execution, programSources]);
+    }
+  }
+
+  /// The global input-record commitments whose state paths must be fetched
+  /// before proving [authorization_raw]. Empty for a public flow.
+  List<String> requiredCommitments(String authorization_raw) {
+    final authorization = dartStrToC(authorization_raw);
+    try {
+      final raw = takeNativeString(programsRustFFI.dyLib,
+          programsRustFFI.requiredCommitments(authorization));
+      if (raw.isEmpty) {
+        throw AleoNodeException(
+            'required_commitments failed (malformed authorization)');
+      }
+      return (jsonDecode(raw) as List).cast<String>();
+    } finally {
+      freeAll([authorization]);
+    }
+  }
+
+  /// The consensus version active at [height] — pin one for a whole transaction
+  /// without hardcoding upgrade heights.
+  int consensusVersionFor(int height) =>
+      programsRustFFI.consensusVersionFor(height);
+
+  /// The shared global state root of a non-empty batch of state paths, or "".
+  String stateRootFromPaths(String state_paths_json) {
+    final statePaths = dartStrToC(state_paths_json);
+    try {
+      return takeNativeString(programsRustFFI.dyLib,
+          programsRustFFI.stateRootFromPaths(statePaths));
+    } finally {
+      freeAll([statePaths]);
+    }
+  }
+
+  /// The direct imports of [program_source], for the closure walk.
+  List<String> _requiredImports(String program_source) {
+    final source = dartStrToC(program_source);
+    try {
+      final raw = takeNativeString(
+          programsRustFFI.dyLib, programsRustFFI.requiredImports(source));
+      if (raw.isEmpty) {
+        throw AleoNodeException(
+            'required_imports failed (malformed program source)');
+      }
+      return (jsonDecode(raw) as List).cast<String>();
+    } finally {
+      freeAll([source]);
+    }
+  }
+
+  // --- internal snapshot+prove steps ----------------------------------------
+
+  /// Snapshot contract for a credits.aleo authorization: fetch the state paths
+  /// for its required commitments (empty for a public flow, in which case the
+  /// latest state root is fetched instead), then prove.
+  Future<String> _proveExecution(
+      AleoNode node, String authorization, int height) async {
+    final commitments = requiredCommitments(authorization);
+    final paths = await node.statePaths(commitments);
+    final publicRoot =
+        commitments.isEmpty ? await node.latestStateRoot() : '';
+    return _require(
+        await executeProofStatic(authorization, height, paths, publicRoot),
+        'execution proof');
+  }
+
+  /// Snapshot contract for a fee authorization (its own commitments — a private
+  /// fee spends its own record), then prove.
+  Future<String> _proveFee(
+      AleoNode node, String feeAuthorization, int height) async {
+    final commitments = requiredCommitments(feeAuthorization);
+    final paths = await node.statePaths(commitments);
+    final publicRoot =
+        commitments.isEmpty ? await node.latestStateRoot() : '';
+    return _require(
+        await executeFeeProofStatic(feeAuthorization, height, paths, publicRoot),
+        'fee proof');
+  }
+
+  /// Snapshot contract for an arbitrary-program authorization, proved with the
+  /// program closure supplied in-memory.
+  Future<String> _proveProgramExecution(
+      AleoNode node, String authorization, String sources, int height) async {
+    final commitments = requiredCommitments(authorization);
+    final paths = await node.statePaths(commitments);
+    final publicRoot =
+        commitments.isEmpty ? await node.latestStateRoot() : '';
+    return _require(
+        await executeProgramProofStatic(
+            authorization, sources, height, paths, publicRoot),
+        'program execution proof');
+  }
+
+  /// The phase-1 primitives return "" on failure (the FFI's single error
+  /// channel). Turn that into a descriptive throw so a failed proof never feeds
+  /// an empty string into the next step.
+  String _require(String value, String what) {
+    if (value.isEmpty) {
+      throw AleoNodeException('$what failed (empty FFI result)');
+    }
+    return value;
   }
 
   Future<void> downloadProvingKey({updateKey = false}) async {
@@ -317,71 +673,6 @@ class AleoProgram {
       await downloadFile(downLoadUrl, savePath);
     }
     return;
-  }
-
-  Future<String> contractExecution(
-    String private_key_raw,
-    String program_id_raw,
-    String function_name_raw,
-    String arguments_raw,
-    String url_raw,
-  ) async {
-    final private_key = dartStrToC(private_key_raw);
-    final program_id = dartStrToC(program_id_raw);
-    final function_name = dartStrToC(function_name_raw);
-    final arguments = dartStrToC(arguments_raw);
-    final url = dartStrToC(url_raw);
-    try {
-      final result = await programsRustFFI.contractExecution(
-          private_key, program_id, function_name, arguments, url);
-      return takeNativeString(programsRustFFI.dyLib, result);
-    } finally {
-      freeAll([private_key, program_id, function_name, arguments, url]);
-    }
-  }
-
-  Future<String> executeProgram(
-    String private_key_raw,
-    String program_id_raw,
-    String function_name_raw,
-    String arguments_raw,
-    int fee,
-    String url_raw,
-  ) async {
-    AleoUtils.checkAmount(fee, 'fee');
-    final private_key = dartStrToC(private_key_raw);
-    final program_id = dartStrToC(program_id_raw);
-    final function_name = dartStrToC(function_name_raw);
-    final arguments = dartStrToC(arguments_raw);
-    final url = dartStrToC(url_raw);
-    try {
-      final result = await programsRustFFI.executeProgram(
-          private_key, program_id, function_name, arguments, fee, url);
-      return takeNativeString(programsRustFFI.dyLib, result);
-    } finally {
-      freeAll([private_key, program_id, function_name, arguments, url]);
-    }
-  }
-
-  Future<String> contractFeeExecution(
-    String private_key_raw,
-    int fee,
-    String execution_raw,
-    String program_id_raw,
-    String url_raw,
-  ) async {
-    AleoUtils.checkAmount(fee, 'fee');
-    final private_key = dartStrToC(private_key_raw);
-    final execution = dartStrToC(execution_raw);
-    final program_id = dartStrToC(program_id_raw);
-    final url = dartStrToC(url_raw);
-    try {
-      final result = await programsRustFFI.contractFeeExecution(
-          private_key, fee, execution, program_id, url);
-      return takeNativeString(programsRustFFI.dyLib, result);
-    } finally {
-      freeAll([private_key, execution, program_id, url]);
-    }
   }
 
   String modifyAuthorization(

--- a/packages/aleo_dart/lib/src/aleo_programs.dart
+++ b/packages/aleo_dart/lib/src/aleo_programs.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 import 'dart:convert';
 
+import 'package:dio/dio.dart';
 import 'package:path/path.dart' as path;
 
 import 'package:aleo_dart/src/aleo_node.dart';
@@ -29,6 +30,12 @@ import 'package:aleo_dart/src/aleo_utils.dart';
 class AleoProgram {
   late ProgramsRustFFI programsRustFFI;
 
+  /// One HTTP client shared by every node operation, created lazily. Each
+  /// operation builds a fresh [AleoNode] but they all reuse this Dio, so we do
+  /// not spin up — and leak — a client (and its pooled keep-alive sockets) per
+  /// operation. Released by [dispose].
+  Dio? _httpClient;
+
   /// How many times the whole transfer flow restarts if a consensus upgrade
   /// lands mid-build. A generous ceiling: upgrades are rare, so more than one
   /// retry means something is badly wrong rather than a real version churn.
@@ -38,13 +45,24 @@ class AleoProgram {
     this.programsRustFFI = ProgramsRustFFI(dyLib, network_raw);
   }
 
-  /// A node bound to [url_raw] and this program's network, with the pure
-  /// `required_imports` helper wired in for the program-closure walk.
+  /// A node bound to [url_raw] and this program's network, reusing the shared
+  /// HTTP client and wiring in the pure `required_imports` helper for the
+  /// program-closure walk. The node does not own the Dio (this program does),
+  /// so node teardown is handled here via [dispose].
   AleoNode _node(String url_raw) => AleoNode(
         url_raw,
         network: programsRustFFI.network,
+        dio: _httpClient ??= AleoNode.defaultDio(),
         parseImports: _requiredImports,
       );
+
+  /// Releases the shared HTTP client and its keep-alive connections. Call when
+  /// the app is done with this AleoProgram; a later operation lazily recreates
+  /// the client.
+  void dispose() {
+    _httpClient?.close(force: true);
+    _httpClient = null;
+  }
 
   // --- one-call flows (compose primitives + node I/O) -----------------------
 

--- a/packages/aleo_dart/lib/src/rust_lib/programs_rust_ffi.dart
+++ b/packages/aleo_dart/lib/src/rust_lib/programs_rust_ffi.dart
@@ -147,6 +147,69 @@ typedef TypeContractFeeExecutionInDart = ffi.Pointer<Utf8> Function(
     ffi.Pointer<Utf8>,
     ffi.Pointer<Utf8>);
 
+// --- Phase-1 pure primitives (network I/O moved to AleoNode) -----------------
+// These take no `network` argument: they compute over pre-fetched data and
+// issue no node RPC. The `_static` proving variants still synchronously download
+// snarkVM proving parameters on a cold cache (a separate, phase-4 concern).
+
+/// One `Pointer<Utf8>` in, one out — the shape of `required_commitments`,
+/// `required_imports`, and `state_root_from_paths`.
+typedef TypeOneArgString = ffi.Pointer<Utf8> Function(ffi.Pointer<Utf8>);
+
+typedef TypeConsensusVersionForRust = ffi.Uint16 Function(ffi.Uint32);
+typedef TypeConsensusVersionForDart = int Function(int);
+
+// get_base_fee_static(execution, program_sources_json, height) -> u64
+typedef TypeGetBaseFeeStaticInRust = ffi.Uint64 Function(
+    ffi.Pointer<Utf8>, ffi.Pointer<Utf8>, ffi.Uint32);
+typedef TypeGetBaseFeeStaticInDart = int Function(
+    ffi.Pointer<Utf8>, ffi.Pointer<Utf8>, int);
+
+// execution_fee_authorization_static(
+//   private_key, execution, fee_credits, fee_record, program_sources_json, height)
+typedef TypeExecutionFeeAuthStaticInRust = ffi.Pointer<Utf8> Function(
+    ffi.Pointer<Utf8>,
+    ffi.Pointer<Utf8>,
+    ffi.Uint64,
+    ffi.Pointer<Utf8>,
+    ffi.Pointer<Utf8>,
+    ffi.Uint32);
+typedef TypeExecutionFeeAuthStaticInDart = ffi.Pointer<Utf8> Function(
+    ffi.Pointer<Utf8>,
+    ffi.Pointer<Utf8>,
+    int,
+    ffi.Pointer<Utf8>,
+    ffi.Pointer<Utf8>,
+    int);
+
+// execute_proof_static / execute_fee_proof_static(
+//   authorization, height, state_paths_json, public_state_root)
+typedef TypeExecuteProofStaticInRust = ffi.Pointer<Utf8> Function(
+    ffi.Pointer<Utf8>, ffi.Uint32, ffi.Pointer<Utf8>, ffi.Pointer<Utf8>);
+typedef TypeExecuteProofStaticInDart = ffi.Pointer<Utf8> Function(
+    ffi.Pointer<Utf8>, int, ffi.Pointer<Utf8>, ffi.Pointer<Utf8>);
+
+// execute_program_proof_static(
+//   authorization, program_sources_json, height, state_paths_json, public_state_root)
+typedef TypeExecuteProgramProofStaticInRust = ffi.Pointer<Utf8> Function(
+    ffi.Pointer<Utf8>,
+    ffi.Pointer<Utf8>,
+    ffi.Uint32,
+    ffi.Pointer<Utf8>,
+    ffi.Pointer<Utf8>);
+typedef TypeExecuteProgramProofStaticInDart = ffi.Pointer<Utf8> Function(
+    ffi.Pointer<Utf8>, ffi.Pointer<Utf8>, int, ffi.Pointer<Utf8>,
+    ffi.Pointer<Utf8>);
+
+// program_authorization_static(
+//   private_key, program_id, function_name, arguments, program_sources_json)
+typedef TypeProgramAuthStatic = ffi.Pointer<Utf8> Function(
+    ffi.Pointer<Utf8>,
+    ffi.Pointer<Utf8>,
+    ffi.Pointer<Utf8>,
+    ffi.Pointer<Utf8>,
+    ffi.Pointer<Utf8>);
+
 class ProgramsRustFFI {
   final ffi.DynamicLibrary dyLib;
   final String network;
@@ -400,5 +463,127 @@ class ProgramsRustFFI {
         TypeContractFeeExecutionInDart>('contract_fee_execution');
     return _withNetwork((network) =>
         rustFunction(private_key, fee, execution, program_id, url, network));
+  }
+
+  // --- Phase-1 pure primitives ----------------------------------------------
+  // Synchronous: they compute over caller-supplied data and pass no `network`.
+  // The string-returning ones hand back a Rust-allocated pointer the caller
+  // releases through `takeNativeString`, exactly like the older exports.
+
+  /// The global input-record commitments whose state paths the caller must
+  /// fetch before proving, as a JSON `[field]`. Empty for a public flow.
+  ffi.Pointer<Utf8> requiredCommitments(ffi.Pointer<Utf8> authorization) {
+    final fn = dyLib.lookupFunction<TypeOneArgString, TypeOneArgString>(
+        'required_commitments');
+    return fn(authorization);
+  }
+
+  /// The direct imports of a program source, as a JSON `[program_id]`, so the
+  /// closure walk knows what else to fetch.
+  ffi.Pointer<Utf8> requiredImports(ffi.Pointer<Utf8> programSource) {
+    final fn = dyLib.lookupFunction<TypeOneArgString, TypeOneArgString>(
+        'required_imports');
+    return fn(programSource);
+  }
+
+  /// The shared global state root of a non-empty batch of state paths (for
+  /// logging/caching; proving derives it itself). "" if empty or disagreeing.
+  ffi.Pointer<Utf8> stateRootFromPaths(ffi.Pointer<Utf8> statePathsJson) {
+    final fn = dyLib.lookupFunction<TypeOneArgString, TypeOneArgString>(
+        'state_root_from_paths');
+    return fn(statePathsJson);
+  }
+
+  /// The consensus version active at [height] — Dart pins one for a whole
+  /// transaction without hardcoding upgrade heights.
+  int consensusVersionFor(int height) {
+    final fn = dyLib.lookupFunction<TypeConsensusVersionForRust,
+        TypeConsensusVersionForDart>('consensus_version_for');
+    return fn(height);
+  }
+
+  /// Base fee (microcredits) for an [execution] at [height]. [programSources]
+  /// supplies the execution's root program (empty for credits.aleo).
+  int getBaseFeeStatic(
+    ffi.Pointer<Utf8> execution,
+    ffi.Pointer<Utf8> programSources,
+    int height,
+  ) {
+    final fn = dyLib.lookupFunction<TypeGetBaseFeeStaticInRust,
+        TypeGetBaseFeeStaticInDart>('get_base_fee_static');
+    return fn(execution, programSources, height);
+  }
+
+  /// Authorizes the fee for a proven [execution] at [height]. An empty
+  /// [feeRecord] is a public fee, otherwise a private fee spending that record.
+  ffi.Pointer<Utf8> executionFeeAuthorizationStatic(
+    ffi.Pointer<Utf8> privateKey,
+    ffi.Pointer<Utf8> execution,
+    int feeCredits,
+    ffi.Pointer<Utf8> feeRecord,
+    ffi.Pointer<Utf8> programSources,
+    int height,
+  ) {
+    final fn = dyLib.lookupFunction<TypeExecutionFeeAuthStaticInRust,
+        TypeExecutionFeeAuthStaticInDart>('execution_fee_authorization_static');
+    return fn(privateKey, execution, feeCredits, feeRecord, programSources,
+        height);
+  }
+
+  /// Proves an [authorization] against a StaticQuery built from pre-fetched
+  /// [height] / [statePathsJson] / [publicStateRoot].
+  ffi.Pointer<Utf8> executeProofStatic(
+    ffi.Pointer<Utf8> authorization,
+    int height,
+    ffi.Pointer<Utf8> statePathsJson,
+    ffi.Pointer<Utf8> publicStateRoot,
+  ) {
+    final fn = dyLib.lookupFunction<TypeExecuteProofStaticInRust,
+        TypeExecuteProofStaticInDart>('execute_proof_static');
+    return fn(authorization, height, statePathsJson, publicStateRoot);
+  }
+
+  /// Proves a fee [authorization] against its own pre-fetched snapshot (a
+  /// private fee spends its own record, so its paths differ from the execution's).
+  ffi.Pointer<Utf8> executeFeeProofStatic(
+    ffi.Pointer<Utf8> authorization,
+    int height,
+    ffi.Pointer<Utf8> statePathsJson,
+    ffi.Pointer<Utf8> publicStateRoot,
+  ) {
+    final fn = dyLib.lookupFunction<TypeExecuteProofStaticInRust,
+        TypeExecuteProofStaticInDart>('execute_fee_proof_static');
+    return fn(authorization, height, statePathsJson, publicStateRoot);
+  }
+
+  /// Like [executeProofStatic] but the referenced program (+ closure) is
+  /// supplied in-memory via [programSources] rather than fetched from a node.
+  ffi.Pointer<Utf8> executeProgramProofStatic(
+    ffi.Pointer<Utf8> authorization,
+    ffi.Pointer<Utf8> programSources,
+    int height,
+    ffi.Pointer<Utf8> statePathsJson,
+    ffi.Pointer<Utf8> publicStateRoot,
+  ) {
+    final fn = dyLib.lookupFunction<TypeExecuteProgramProofStaticInRust,
+        TypeExecuteProgramProofStaticInDart>('execute_program_proof_static');
+    return fn(
+        authorization, programSources, height, statePathsJson, publicStateRoot);
+  }
+
+  /// Builds an execution authorization for an arbitrary program function offline.
+  /// [arguments] is a JSON array of Aleo value strings (record inputs already
+  /// plaintext); [programSources] supplies the program (empty for credits.aleo).
+  ffi.Pointer<Utf8> programAuthorizationStatic(
+    ffi.Pointer<Utf8> privateKey,
+    ffi.Pointer<Utf8> programId,
+    ffi.Pointer<Utf8> functionName,
+    ffi.Pointer<Utf8> arguments,
+    ffi.Pointer<Utf8> programSources,
+  ) {
+    final fn =
+        dyLib.lookupFunction<TypeProgramAuthStatic, TypeProgramAuthStatic>(
+            'program_authorization_static');
+    return fn(privateKey, programId, functionName, arguments, programSources);
   }
 }

--- a/packages/aleo_dart/pubspec.yaml
+++ b/packages/aleo_dart/pubspec.yaml
@@ -9,12 +9,15 @@ environment:
 dependencies:
   bip39: ^1.0.6
   crypto: ^3.0.0
+  # Owns all node REST I/O for AleoProgram's orchestration (AleoNode), with real
+  # request cancellation via CancelToken. Previously the blocking HTTP lived
+  # inside the synchronous FFI calls; phase 2 moves it to this Dart layer.
+  dio: ^5.4.1
   ffi: ^2.1.4
   path: ^1.8.0
 
 dev_dependencies:
   convert: ^3.1.2
-  dio: ^5.4.1
   lints: ^3.0.0
   test: ^1.24.0
   web_socket_channel: ^2.4.0

--- a/packages/aleo_dart/test/aleo_node_test.dart
+++ b/packages/aleo_dart/test/aleo_node_test.dart
@@ -297,11 +297,44 @@ void main() {
     expect(sw.elapsed, lessThan(const Duration(seconds: 3)));
   });
 
-  test('a single closure request is capped at requestTimeout, not closureDeadline',
+  test('a per-request timeout inside a closure retries while budget remains',
       () async {
-    // closureDeadline is large (10s); requestTimeout is small (500ms). A
-    // stalling import must fail at ~requestTimeout, so one slow node cannot
-    // occupy the whole closure budget.
+    // b.aleo's first edition request stalls past requestTimeout, then succeeds.
+    // The per-attempt timeout must NOT be fatal while the closure budget has
+    // room — the request is retried and the closure completes.
+    var bEditionHits = 0;
+    node.handler = (req) async {
+      final id = req.uri.pathSegments[2];
+      final isEdition = req.uri.path.endsWith('/latest_edition');
+      if (id == 'a.aleo') {
+        await _reply(req, isEdition ? '1' : jsonEncode('program a.aleo;'));
+      } else if (isEdition) {
+        bEditionHits++;
+        if (bEditionHits == 1) {
+          await Future<void>.delayed(const Duration(seconds: 30));
+        }
+        await _reply(req, '1');
+      } else {
+        await _reply(req, jsonEncode('program b.aleo;'));
+      }
+    };
+    final node2 = AleoNode(node.url,
+        network: 'testnet',
+        requestTimeout: const Duration(milliseconds: 400),
+        closureDeadline: const Duration(seconds: 10),
+        parseImports: (src) =>
+            _idOf(src) == 'a.aleo' ? ['b.aleo'] : const []);
+    final closure = await node2.programClosure('a.aleo');
+    expect((jsonDecode(closure) as List), hasLength(2));
+    expect(bEditionHits, greaterThanOrEqualTo(2)); // first timed out, retried
+  });
+
+  test('a permanently stalling closure import is bounded by closureDeadline across retries',
+      () async {
+    // closureDeadline (2s) is the binding bound; each request is capped at
+    // requestTimeout (400ms) and retried, so the closure fails near
+    // closureDeadline — not the 30s stall — having made multiple attempts.
+    var bEditionHits = 0;
     node.handler = (req) async {
       final id = req.uri.pathSegments[2];
       if (id == 'a.aleo') {
@@ -311,22 +344,23 @@ void main() {
           await _reply(req, jsonEncode('program a.aleo;'));
         }
       } else {
+        if (req.uri.path.endsWith('/latest_edition')) bEditionHits++;
         await Future<void>.delayed(const Duration(seconds: 30));
         await _reply(req, '1');
       }
     };
     final node2 = AleoNode(node.url,
         network: 'testnet',
-        requestTimeout: const Duration(milliseconds: 500),
-        closureDeadline: const Duration(seconds: 10),
+        requestTimeout: const Duration(milliseconds: 400),
+        closureDeadline: const Duration(seconds: 2),
         parseImports: (src) =>
             _idOf(src) == 'a.aleo' ? ['b.aleo'] : const []);
     final sw = Stopwatch()..start();
     await expectLater(
         node2.programClosure('a.aleo'), throwsA(isA<AleoNodeException>()));
     sw.stop();
-    // ~500ms (the per-request cap), not the 10s closureDeadline / 30s stall.
-    expect(sw.elapsed, lessThan(const Duration(seconds: 3)));
+    expect(sw.elapsed, lessThan(const Duration(seconds: 4))); // ~2s, not 30s
+    expect(bEditionHits, greaterThan(1)); // capped per request + retried
   });
 
   test('latestHeight rejects a height past u32 range', () async {

--- a/packages/aleo_dart/test/aleo_node_test.dart
+++ b/packages/aleo_dart/test/aleo_node_test.dart
@@ -296,6 +296,44 @@ void main() {
     sw.stop();
     expect(sw.elapsed, lessThan(const Duration(seconds: 3)));
   });
+
+  test('a single closure request is capped at requestTimeout, not closureDeadline',
+      () async {
+    // closureDeadline is large (10s); requestTimeout is small (500ms). A
+    // stalling import must fail at ~requestTimeout, so one slow node cannot
+    // occupy the whole closure budget.
+    node.handler = (req) async {
+      final id = req.uri.pathSegments[2];
+      if (id == 'a.aleo') {
+        if (req.uri.path.endsWith('/latest_edition')) {
+          await _reply(req, '1');
+        } else {
+          await _reply(req, jsonEncode('program a.aleo;'));
+        }
+      } else {
+        await Future<void>.delayed(const Duration(seconds: 30));
+        await _reply(req, '1');
+      }
+    };
+    final node2 = AleoNode(node.url,
+        network: 'testnet',
+        requestTimeout: const Duration(milliseconds: 500),
+        closureDeadline: const Duration(seconds: 10),
+        parseImports: (src) =>
+            _idOf(src) == 'a.aleo' ? ['b.aleo'] : const []);
+    final sw = Stopwatch()..start();
+    await expectLater(
+        node2.programClosure('a.aleo'), throwsA(isA<AleoNodeException>()));
+    sw.stop();
+    // ~500ms (the per-request cap), not the 10s closureDeadline / 30s stall.
+    expect(sw.elapsed, lessThan(const Duration(seconds: 3)));
+  });
+
+  test('latestHeight rejects a height past u32 range', () async {
+    node.handler = (req) => _reply(req, '4294967296'); // 2^32, over u32::MAX
+    await expectLater(
+        aleo().latestHeight(), throwsA(isA<AleoNodeException>()));
+  });
 }
 
 /// Extracts the program id from our fake `program <id>;` source bodies.

--- a/packages/aleo_dart/test/aleo_node_test.dart
+++ b/packages/aleo_dart/test/aleo_node_test.dart
@@ -1,0 +1,219 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:aleo_dart/aleo.dart';
+import 'package:test/test.dart';
+
+/// A scriptable local node: each test installs a handler over the REST routes
+/// AleoNode calls, so the whole class is covered offline (no native lib, no real
+/// node). Records the requests it saw for assertions (retry counts, broadcast
+/// body, header).
+class _FakeNode {
+  late final HttpServer _server;
+  final List<HttpRequest> seen = [];
+  late Future<void> Function(HttpRequest req) handler;
+
+  Future<void> start() async {
+    _server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    _server.listen((req) async {
+      seen.add(req);
+      await handler(req);
+    });
+  }
+
+  String get url => 'http://127.0.0.1:${_server.port}';
+  Future<void> stop() => _server.close(force: true);
+}
+
+Future<void> _reply(HttpRequest req, String body, {int status = 200}) async {
+  req.response.statusCode = status;
+  req.response.write(body);
+  await req.response.close();
+}
+
+void main() {
+  late _FakeNode node;
+
+  setUp(() async {
+    node = _FakeNode();
+    await node.start();
+  });
+
+  tearDown(() => node.stop());
+
+  AleoNode aleo({Duration? timeout, List<String> Function(String)? imports}) =>
+      AleoNode(node.url,
+          network: 'testnet',
+          requestTimeout: timeout ?? const Duration(seconds: 5),
+          parseImports: imports);
+
+  test('latestHeight parses a bare integer body', () async {
+    node.handler = (req) => _reply(req, '123456');
+    expect(await aleo().latestHeight(), 123456);
+    expect(node.seen.single.uri.path, '/testnet/latest/height');
+  });
+
+  test('latestStateRoot strips the surrounding JSON quotes', () async {
+    const root = 'sr1dz06ur5spdgzkguh4pr42mvft6u3nwsg5drh9rdja9v8jpcz3czsls9geg';
+    node.handler = (req) => _reply(req, '"$root"');
+    expect(await aleo().latestStateRoot(), root);
+  });
+
+  test('a state root over the byte budget is rejected mid-stream', () async {
+    node.handler = (req) => _reply(req, '"${'a' * (AleoNode.maxStateRootBytes + 8)}"');
+    await expectLater(aleo().latestStateRoot(),
+        throwsA(isA<AleoNodeException>()));
+  });
+
+  test('statePaths returns [] for an empty set without hitting the node',
+      () async {
+    node.handler = (req) => _reply(req, 'should not be called', status: 500);
+    expect(await aleo().statePaths(const []), '[]');
+    expect(node.seen, isEmpty);
+  });
+
+  test('statePaths batches the commitments into one request', () async {
+    node.handler = (req) => _reply(req, '[{"x":1},{"x":2}]');
+    final body = await aleo().statePaths(['c1', 'c2']);
+    expect(jsonDecode(body), hasLength(2));
+    expect(node.seen.single.uri.path, '/testnet/statePaths');
+    expect(node.seen.single.uri.queryParameters['commitments'], 'c1,c2');
+  });
+
+  test('statePaths rejects more entries than the budget', () async {
+    final tooMany =
+        jsonEncode(List.generate(AleoNode.maxStatePaths + 1, (i) => {'x': i}));
+    node.handler = (req) => _reply(req, tooMany);
+    await expectLater(
+        aleo().statePaths(['c']), throwsA(isA<AleoNodeException>()));
+  });
+
+  test('programSource reads latest_edition then the source at that edition',
+      () async {
+    node.handler = (req) async {
+      if (req.uri.path.endsWith('/latest_edition')) {
+        await _reply(req, '3');
+      } else {
+        await _reply(req, jsonEncode('program token.aleo;'));
+      }
+    };
+    final src = await aleo().programSource('token.aleo');
+    expect(src.edition, 3);
+    expect(src.source, 'program token.aleo;');
+    expect(node.seen.map((r) => r.uri.path),
+        ['/testnet/program/token.aleo/latest_edition', '/testnet/program/token.aleo/3']);
+  });
+
+  test('programSource rejects an oversized program body', () async {
+    node.handler = (req) async {
+      if (req.uri.path.endsWith('/latest_edition')) {
+        await _reply(req, '1');
+      } else {
+        await _reply(req, jsonEncode('x' * (AleoNode.maxProgramSize + 1)));
+      }
+    };
+    await expectLater(aleo().programSource('big.aleo'),
+        throwsA(isA<AleoNodeException>()));
+  });
+
+  test('programClosure walks imports and skips credits.aleo', () async {
+    // a.aleo imports b.aleo and credits.aleo; b.aleo imports credits.aleo.
+    final imports = {
+      'a.aleo': ['b.aleo', 'credits.aleo'],
+      'b.aleo': ['credits.aleo'],
+    };
+    node.handler = (req) async {
+      final id = req.uri.pathSegments[2]; // /testnet/program/<id>/...
+      if (req.uri.path.endsWith('/latest_edition')) {
+        await _reply(req, '1');
+      } else {
+        await _reply(req, jsonEncode('program $id;'));
+      }
+    };
+    final closure =
+        await aleo(imports: (src) => imports[_idOf(src)] ?? const []).programClosure('a.aleo');
+    final decoded = (jsonDecode(closure) as List).cast<Map<String, dynamic>>();
+    expect(decoded.map((e) => e['id']).toSet(), {'a.aleo', 'b.aleo'});
+    expect(decoded.every((e) => e['edition'] == 1), isTrue);
+  });
+
+  test('programClosure terminates on an import cycle', () async {
+    // a -> b -> a: the dedup set must stop the walk rather than loop forever.
+    final imports = {
+      'a.aleo': ['b.aleo'],
+      'b.aleo': ['a.aleo'],
+    };
+    node.handler = (req) async {
+      final id = req.uri.pathSegments[2];
+      if (req.uri.path.endsWith('/latest_edition')) {
+        await _reply(req, '1');
+      } else {
+        await _reply(req, jsonEncode('program $id;'));
+      }
+    };
+    final closure = await aleo(imports: (src) => imports[_idOf(src)] ?? const [])
+        .programClosure('a.aleo')
+        .timeout(const Duration(seconds: 5));
+    expect((jsonDecode(closure) as List), hasLength(2));
+  });
+
+  test('broadcast posts the transaction as application/json and returns the id',
+      () async {
+    String? body;
+    String? contentType;
+    node.handler = (req) async {
+      body = await utf8.decodeStream(req);
+      contentType = req.headers.contentType?.mimeType;
+      await _reply(req, '"at1abcdef"');
+    };
+    final id = await aleo().broadcast('{"tx":"payload"}');
+    expect(id, 'at1abcdef');
+    expect(body, '{"tx":"payload"}');
+    expect(contentType, 'application/json');
+    expect(node.seen.single.uri.path, '/testnet/transaction/broadcast');
+  });
+
+  test('a GET retries a transient 5xx, then succeeds', () async {
+    var hits = 0;
+    node.handler = (req) async {
+      hits++;
+      if (hits < 3) {
+        await _reply(req, 'busy', status: 503);
+      } else {
+        await _reply(req, '777');
+      }
+    };
+    expect(await aleo().latestHeight(), 777);
+    expect(hits, 3);
+  });
+
+  test('a GET does not retry a 4xx', () async {
+    var hits = 0;
+    node.handler = (req) async {
+      hits++;
+      await _reply(req, 'bad', status: 400);
+    };
+    await expectLater(aleo().latestHeight(), throwsA(isA<AleoNodeException>()));
+    expect(hits, 1);
+  });
+
+  test('a stalled response is cancelled by the request timeout', () async {
+    node.handler = (req) async {
+      // Never reply; hold the socket open past the timeout.
+      await Future<void>.delayed(const Duration(seconds: 30));
+      await _reply(req, '0');
+    };
+    final stopwatch = Stopwatch()..start();
+    await expectLater(
+        aleo(timeout: const Duration(milliseconds: 300)).latestHeight(),
+        throwsA(isA<AleoNodeException>()));
+    stopwatch.stop();
+    // Cancellation actually fires (well under the server's 30s hold).
+    expect(stopwatch.elapsed, lessThan(const Duration(seconds: 5)));
+  });
+}
+
+/// Extracts the program id from our fake `program <id>;` source bodies.
+String _idOf(String source) =>
+    source.replaceFirst('program ', '').replaceFirst(';', '').trim();

--- a/packages/aleo_dart/test/aleo_node_test.dart
+++ b/packages/aleo_dart/test/aleo_node_test.dart
@@ -221,6 +221,28 @@ void main() {
         aleo().statePaths(['c1']), throwsA(isA<AleoNodeException>()));
   });
 
+  test('programSource shares one requestTimeout budget across both reads',
+      () async {
+    // Each of the two GETs (edition, then source) delays 600ms. They must share
+    // one ~800ms budget — programSource is one logical read — so the second runs
+    // out of time, rather than getting its own fresh 800ms (which would let the
+    // whole call succeed at ~1.2s, ~2× requestTimeout).
+    node.handler = (req) async {
+      await Future<void>.delayed(const Duration(milliseconds: 600));
+      if (req.uri.path.endsWith('/latest_edition')) {
+        await _reply(req, '1');
+      } else {
+        await _reply(req, jsonEncode('program x.aleo;'));
+      }
+    };
+    final sw = Stopwatch()..start();
+    await expectLater(
+        aleo(timeout: const Duration(milliseconds: 800)).programSource('x.aleo'),
+        throwsA(isA<AleoNodeException>()));
+    sw.stop();
+    expect(sw.elapsed, lessThan(const Duration(seconds: 1))); // ~800ms, not ~1.2s
+  });
+
   test('a malformed program source body surfaces as AleoNodeException',
       () async {
     node.handler = (req) async {

--- a/packages/aleo_dart/test/aleo_node_test.dart
+++ b/packages/aleo_dart/test/aleo_node_test.dart
@@ -212,6 +212,90 @@ void main() {
     // Cancellation actually fires (well under the server's 30s hold).
     expect(stopwatch.elapsed, lessThan(const Duration(seconds: 5)));
   });
+
+  // --- review fixes ---------------------------------------------------------
+
+  test('a malformed statePaths body surfaces as AleoNodeException', () async {
+    node.handler = (req) => _reply(req, 'not json at all {[');
+    await expectLater(
+        aleo().statePaths(['c1']), throwsA(isA<AleoNodeException>()));
+  });
+
+  test('a malformed program source body surfaces as AleoNodeException',
+      () async {
+    node.handler = (req) async {
+      if (req.uri.path.endsWith('/latest_edition')) {
+        await _reply(req, '1');
+      } else {
+        await _reply(req, 'definitely not json');
+      }
+    };
+    await expectLater(
+        aleo().programSource('x.aleo'), throwsA(isA<AleoNodeException>()));
+  });
+
+  test('a near-max program whose JSON wire form exceeds the decoded cap is accepted',
+      () async {
+    // 99000 newlines: decoded length 99000 (<= maxProgramSize), but the
+    // JSON-escaped wire body is ~198002 bytes — far past the old maxProgramSize+2
+    // streaming cap. The widened wire cap must let it through; the real bound is
+    // the decoded-length check.
+    final source = '\n' * 99000;
+    node.handler = (req) async {
+      if (req.uri.path.endsWith('/latest_edition')) {
+        await _reply(req, '1');
+      } else {
+        await _reply(req, jsonEncode(source));
+      }
+    };
+    final src = await aleo().programSource('big.aleo');
+    expect(src.source.length, 99000);
+  });
+
+  test('retries are bounded by the overall requestTimeout, not attempts × timeout',
+      () async {
+    // Always-retryable 503: without an overall budget this is ~3s of backoff
+    // (0.5+1.0+1.5) across 4 attempts; the overall deadline caps it near
+    // requestTimeout.
+    node.handler = (req) => _reply(req, 'busy', status: 503);
+    final sw = Stopwatch()..start();
+    await expectLater(
+        aleo(timeout: const Duration(milliseconds: 800)).latestHeight(),
+        throwsA(isA<AleoNodeException>()));
+    sw.stop();
+    expect(sw.elapsed, lessThan(const Duration(seconds: 2)));
+  });
+
+  test('programClosure is bounded by closureDeadline even when an import stalls',
+      () async {
+    // a.aleo resolves fast and imports b.aleo, which stalls forever. The
+    // deadline is threaded into the b.aleo fetch, so the closure fails near
+    // closureDeadline rather than the 10s requestTimeout / 30s stall.
+    node.handler = (req) async {
+      final id = req.uri.pathSegments[2];
+      if (id == 'a.aleo') {
+        if (req.uri.path.endsWith('/latest_edition')) {
+          await _reply(req, '1');
+        } else {
+          await _reply(req, jsonEncode('program a.aleo;'));
+        }
+      } else {
+        await Future<void>.delayed(const Duration(seconds: 30));
+        await _reply(req, '1');
+      }
+    };
+    final node2 = AleoNode(node.url,
+        network: 'testnet',
+        requestTimeout: const Duration(seconds: 10),
+        closureDeadline: const Duration(milliseconds: 600),
+        parseImports: (src) =>
+            _idOf(src) == 'a.aleo' ? ['b.aleo'] : const []);
+    final sw = Stopwatch()..start();
+    await expectLater(
+        node2.programClosure('a.aleo'), throwsA(isA<AleoNodeException>()));
+    sw.stop();
+    expect(sw.elapsed, lessThan(const Duration(seconds: 3)));
+  });
 }
 
 /// Extracts the program id from our fake `program <id>;` source bodies.

--- a/packages/aleo_dart/test/aleo_node_test.dart
+++ b/packages/aleo_dart/test/aleo_node_test.dart
@@ -368,6 +368,25 @@ void main() {
     await expectLater(
         aleo().latestHeight(), throwsA(isA<AleoNodeException>()));
   });
+
+  test('close() tears down a Dio the node created', () async {
+    node.handler = (req) => _reply(req, '1');
+    final owning = AleoNode(node.url, network: 'testnet');
+    expect(await owning.latestHeight(), 1); // works before close
+    owning.close();
+    // The created Dio (and its pooled client) is closed, so further use fails.
+    await expectLater(owning.latestHeight(), throwsA(anything));
+  });
+
+  test('close() leaves an injected Dio (owned by the caller) untouched',
+      () async {
+    node.handler = (req) => _reply(req, '7');
+    final injected = AleoNode.defaultDio();
+    final n = AleoNode(node.url, network: 'testnet', dio: injected);
+    n.close(); // no-op: the caller owns `injected`
+    expect(await n.latestHeight(), 7); // injected client still usable
+    injected.close(force: true);
+  });
 }
 
 /// Extracts the program id from our fake `program <id>;` source bodies.

--- a/packages/aleo_dart/test/aleo_node_test.dart
+++ b/packages/aleo_dart/test/aleo_node_test.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:aleo_dart/aleo.dart';
+import 'package:dio/dio.dart';
 import 'package:test/test.dart';
 
 /// A scriptable local node: each test installs a handler over the REST routes
@@ -408,6 +409,94 @@ void main() {
     n.close(); // no-op: the caller owns `injected`
     expect(await n.latestHeight(), 7); // injected client still usable
     injected.close(force: true);
+  });
+
+  test('broadcast does not retry (a POST is not idempotent)', () async {
+    var hits = 0;
+    node.handler = (req) async {
+      hits++;
+      await _reply(req, 'busy', status: 503);
+    };
+    await expectLater(
+        aleo().broadcast('{"tx":"x"}'), throwsA(isA<AleoNodeException>()));
+    expect(hits, 1); // posted once, surfaced the failure, never re-submitted
+  });
+
+  test('latestHeight rejects a non-integer body', () async {
+    node.handler = (req) => _reply(req, 'not-a-number');
+    await expectLater(
+        aleo().latestHeight(), throwsA(isA<AleoNodeException>()));
+  });
+
+  test('an invalid-UTF-8 body surfaces as AleoNodeException', () async {
+    node.handler = (req) async {
+      req.response.statusCode = 200;
+      req.response.add([0xC3, 0x28]); // invalid UTF-8 sequence
+      await req.response.close();
+    };
+    await expectLater(
+        aleo().latestStateRoot(), throwsA(isA<AleoNodeException>()));
+  });
+
+  test('programClosure rejects a chain past the program-count budget', () async {
+    // An endless distinct-program chain (prog0 -> prog1 -> ...): the count
+    // budget must stop it rather than fetch forever.
+    node.handler = (req) async {
+      final id = req.uri.pathSegments[2];
+      if (req.uri.path.endsWith('/latest_edition')) {
+        await _reply(req, '1');
+      } else {
+        await _reply(req, jsonEncode('program $id;'));
+      }
+    };
+    String next(String src) {
+      final n = int.parse(_idOf(src).replaceFirst('prog', '').replaceFirst('.aleo', ''));
+      return 'prog${n + 1}.aleo';
+    }
+    final node2 = AleoNode(node.url,
+        network: 'testnet', parseImports: (src) => [next(src)]);
+    await expectLater(node2.programClosure('prog0.aleo'),
+        throwsA(isA<AleoNodeException>()));
+  });
+
+  // The retry row of the request-lifecycle contract, table-driven so every
+  // failure × budget cell is pinned in one place (the dimension five review
+  // rounds each chipped at).
+  group('retryableGet contract', () {
+    final ro = RequestOptions(path: 'test');
+    DioException badResponse(int status) => DioException(
+        requestOptions: ro,
+        type: DioExceptionType.badResponse,
+        response: Response(requestOptions: ro, statusCode: status));
+    DioException typed(DioExceptionType t) =>
+        DioException(requestOptions: ro, type: t);
+    final cancel = DioException(requestOptions: ro, type: DioExceptionType.cancel);
+    final noStatus = DioException(
+        requestOptions: ro, type: DioExceptionType.badResponse);
+
+    // (label, exception, budgetRemains, expectedRetry)
+    final cases = <(String, DioException, bool, bool)>[
+      ('5xx with budget', badResponse(503), true, true),
+      ('500 with budget', badResponse(500), true, true),
+      ('5xx without budget', badResponse(503), false, false),
+      ('4xx never retries', badResponse(404), true, false),
+      ('400 never retries', badResponse(400), true, false),
+      ('badResponse without a status code', noStatus, true, false),
+      ('connectionError with budget', typed(DioExceptionType.connectionError), true, true),
+      ('connectionTimeout with budget', typed(DioExceptionType.connectionTimeout), true, true),
+      ('sendTimeout with budget', typed(DioExceptionType.sendTimeout), true, true),
+      ('receiveTimeout with budget', typed(DioExceptionType.receiveTimeout), true, true),
+      ('connectionError without budget', typed(DioExceptionType.connectionError), false, false),
+      ('per-attempt timeout (cancel) with budget', cancel, true, true),
+      ('per-attempt timeout (cancel) without budget', cancel, false, false),
+      ('unknown error never retries', typed(DioExceptionType.unknown), true, false),
+    ];
+
+    for (final (label, e, budget, expected) in cases) {
+      test('$label -> ${expected ? 'retry' : 'stop'}', () {
+        expect(AleoNode.retryableGet(e, budgetRemains: budget), expected);
+      });
+    }
   });
 }
 

--- a/packages/aleo_dart/test/aleo_required_commitments_test.dart
+++ b/packages/aleo_dart/test/aleo_required_commitments_test.dart
@@ -1,0 +1,47 @@
+import 'package:aleo_dart/aleo.dart';
+import 'package:test/test.dart';
+
+import 'support/test_dylib.dart';
+
+/// Offline coverage of `required_commitments` through the FFI boundary — the
+/// helper that tells the phase-2 orchestration which state paths to fetch.
+///
+/// This pins the cardinality contract the Rust exact-match (`checked_static_query`)
+/// then enforces at proving time: a single-record private transfer needs exactly
+/// one commitment, a public transfer none. The full field-value parity against a
+/// live node's proving path is the manual testnet run (transfer/aleo_phase2_e2e.dart).
+void main() {
+  final dyLib = tryLoadAleoLib();
+  if (dyLib == null) {
+    test('required_commitments', () {}, skip: nativeLibMissingReason);
+    return;
+  }
+  final rust = AleoProgram(dyLib, 'testnet');
+
+  // record[2] from test/_diff_records.dart, owned by ownerKey.
+  const ownerKey = 'APrivateKey1zkpC2CbihCvUyg8zcNXTngzGpmCzKTF8uZP4jfyu3LdfT8v';
+  const ownerAddress =
+      'aleo127c79p7k4jj9e2c8kwwqsn5qkavun07etkyqpr795eyrdnyh3uzqnf8nfn';
+  const testRecord =
+      'record1qyqspdn8f6lh4eum9a36l93mnxh5vcqssjsep9z4lp4vpya2efgmjdsvqyxx66trwfhkxun9v35hguerqqpqzq9yu3tvsnj4x0a7e2w9w204aya09thraeckdlsn59pve6fnnd3eqv0n7jpp5rsxn48jdjj3z55vhmp42f8hxp7vk5d2430vuvk3fzrsx0w9wqw';
+
+  // url is ignored by the offline credits.aleo authorize path.
+  const url = 'https://example.invalid';
+
+  test('a private transfer requires exactly its spent record commitment',
+      () async {
+    final auth = await rust.executionAuthorization(
+        ownerKey, ownerAddress, TransferMethod.private, 1, url, testRecord);
+    expect(auth, isNotEmpty, reason: 'offline authorize should succeed');
+    final commitments = rust.requiredCommitments(auth);
+    expect(commitments, hasLength(1));
+    expect(commitments.single, endsWith('field'));
+  });
+
+  test('a public transfer requires no commitments', () async {
+    final auth = await rust.executionAuthorization(
+        ownerKey, ownerAddress, TransferMethod.public, 1, url, '');
+    expect(auth, isNotEmpty);
+    expect(rust.requiredCommitments(auth), isEmpty);
+  });
+}

--- a/packages/aleo_dart/test/transfer/aleo_phase2_e2e.dart
+++ b/packages/aleo_dart/test/transfer/aleo_phase2_e2e.dart
@@ -1,0 +1,97 @@
+import 'package:aleo_dart/aleo.dart';
+import 'package:test/test.dart';
+
+import '../support/test_dylib.dart';
+
+/// Manual phase-2 end-to-end harness: the rewritten `AleoProgram` orchestration
+/// over a Dart [AleoNode], run against a live node. Excluded from CI by its
+/// filename (`*_e2e.dart`, not `*_test.dart`) — it needs the native library,
+/// proving keys/SRS, a funded testnet account, and network access.
+///
+/// Run manually:
+///   ALEO_NEW_LIB=/path/to/libaleo_rust.dylib \
+///     dart test test/transfer/aleo_phase2_e2e.dart --run-skipped
+///
+/// What it pins (the kickoff's MUST-add items):
+///   1. The full `tryTransfer` flow now routes node I/O through `AleoNode`.
+///   2. `required_commitments` parity vs the live proving path: for a *private*
+///      transfer, a successful end-to-end proof confirms the helper returned
+///      exactly the commitments snarkVM's proving asked for — the Rust
+///      `checked_static_query` guard rejects any extra path and proving fails on
+///      a missing one, so "the proof verifies" == "the set was exact".
+///   3. The private fee's own inclusion snapshot (a private fee spends its own
+///      record), distinct from the execution snapshot.
+void main() async {
+  final dyLib = tryLoadAleoLib();
+  if (dyLib == null) {
+    test('phase-2 e2e', () {}, skip: nativeLibMissingReason);
+    return;
+  }
+  final rust = AleoProgram(dyLib, 'testnet');
+
+  // Public testnet (network-0 protocol under a /testnet REST path).
+  const url = 'https://api.explorer.provable.com/v1';
+  // Funded test account (see the aleo-gpl-removal-plan memory).
+  const privateKey =
+      'APrivateKey1zkpC2CbihCvUyg8zcNXTngzGpmCzKTF8uZP4jfyu3LdfT8v';
+  const recipient =
+      'aleo127c79p7k4jj9e2c8kwwqsn5qkavun07etkyqpr795eyrdnyh3uzqnf8nfn';
+
+  test('AleoNode reads the node directly', () async {
+    final node = AleoNode(url, network: 'testnet');
+    final height = await node.latestHeight();
+    final root = await node.latestStateRoot();
+    print('height=$height root=$root version=${rust.consensusVersionFor(height)}');
+    expect(height, greaterThan(0));
+    expect(root, startsWith('sr1'));
+  }, skip: 'manual: requires network');
+
+  test('public transfer: build via AleoNode-backed orchestration', () async {
+    // No record spent -> required_commitments is empty -> public snapshot path.
+    final tx = await rust.buildTransaction(privateKey, recipient,
+        TransferMethod.public, 1000000, 10000, url, '', '');
+    expect(tx, isNotEmpty);
+    print('assembled public transfer tx (${tx.length} bytes)');
+    // Broadcast is left commented so the harness never submits unattended.
+    // print(await rust.broadcast(tx, url, TransferMethod.public));
+  }, skip: 'manual: requires network + proving keys');
+
+  test('private transfer: end-to-end proof pins required_commitments parity',
+      () async {
+    // A spendable on-chain record owned by privateKey, fetched out-of-band.
+    const amountRecord = '<paste a spendable record1... ciphertext>';
+    const feeRecord = ''; // public fee; set to a record for a private fee.
+
+    final node = AleoNode(url, network: 'testnet');
+    final height = await node.latestHeight();
+
+    final auth = await rust.executionAuthorization(privateKey, recipient,
+        TransferMethod.private, 1, url, amountRecord);
+    expect(auth, isNotEmpty);
+
+    final commitments = rust.requiredCommitments(auth);
+    expect(commitments, hasLength(1),
+        reason: 'a single-record private transfer spends one record');
+
+    final paths = await node.statePaths(commitments);
+    // checked_static_query enforces paths' set == required_commitments, so a
+    // proof only succeeds when the helper was exact.
+    final proof = await rust.executeProofStatic(auth, height, paths, '');
+    expect(proof, isNotEmpty, reason: 'private execution proof must verify');
+
+    final feeAuth = await rust.executionFeeAuthorizationStatic(
+        privateKey, proof, 10000, feeRecord, '', height);
+    expect(feeAuth, isNotEmpty);
+    // The fee has its own snapshot (empty here for a public fee).
+    final feeCommitments = rust.requiredCommitments(feeAuth);
+    final feePaths = await node.statePaths(feeCommitments);
+    final feeRoot = feeCommitments.isEmpty ? await node.latestStateRoot() : '';
+    final feeProof =
+        await rust.executeFeeProofStatic(feeAuth, height, feePaths, feeRoot);
+    expect(feeProof, isNotEmpty, reason: 'private-flow fee proof must verify');
+
+    final tx = await rust.buildTransactionOffline(proof, feeProof);
+    expect(tx, isNotEmpty);
+    print('assembled private transfer tx (${tx.length} bytes)');
+  }, skip: 'manual: requires a funded testnet record + proving keys');
+}

--- a/rust/aleo_ffi/docs/network-io-to-dart.md
+++ b/rust/aleo_ffi/docs/network-io-to-dart.md
@@ -1,7 +1,12 @@
 # Design: move network I/O out of `aleo_ffi` into Dart
 
-Status: **phase 1 implemented** (the `_static` exports + helpers; old exports
-untouched). Phases 2–4 not started.
+Status: **phase 2 implemented** — phase 1 shipped the `_static` exports +
+helpers (old exports untouched); phase 2 adds the Dart `AleoNode` (all node I/O,
+with `dio` + real `CancelToken` cancellation), rewrites the `AleoProgram`
+orchestration onto the pure primitives, and lands the Rust exact-match guard
+(`checked_static_query`: the supplied state paths must equal exactly
+`required_commitments`). Phases 3–4 (delete the old in-Rust network code; drop
+the proving-parameter `curl`/OpenSSL download) not started.
 Owner: aleo_ffi
 Supersedes: the in-Rust HTTP hardening accreted across PR #51 review rounds 5–13.
 
@@ -52,11 +57,14 @@ don't cover it.
 The following are **intentionally deferred** — surfaced by a high-effort
 self-review, none blocking, all sequenced to a later phase:
 
-- **No exact-match of state paths to `required_commitments`.** The proving
-  primitives rely on a byte+entry budget plus `StaticQuery`'s missing-path
-  fail-closed, not this spec's "the parsed paths' commitment set exactly equals
-  `required_commitments`". Pinned by the phase-2 parity test before the old node
-  path is deleted.
+- ~~**No exact-match of state paths to `required_commitments`.**~~ **Done in
+  phase 2.** The three proving primitives now build their query through
+  `checked_static_query`, which requires the supplied paths' commitment set to
+  equal exactly `global_commitment_set(authorization)` — rejecting an *extra*
+  padded path (the budget bounds size, not relevance) as well as a missing one.
+  Covered offline by `checked_static_query_*` Rust tests (real sampled
+  `StatePath`s keyed by a private transfer's actual commitment) and, through the
+  FFI, by `aleo_required_commitments_test.dart`.
 - **End-to-end SNARK proving is only partly covered.** `execute_proof_static`
   for a *public* transfer is proved end-to-end (the `#[ignore]`d
   `execute_proof_static_public_transfer_end_to_end`, run with proving keys), and
@@ -225,12 +233,13 @@ response buffer or Rust's serde. Bounds, both sides:
   most any execution can require). `public_state_root` is length-checked before
   parsing. A missing path fails closed (proving's `get_state_path_for_commitment`
   errors).
-- *Rust (parse side), phase-2 target (not yet implemented):* additionally require
-  the parsed paths' commitment set to **exactly equal
-  `required_commitments(authorization)`** — no extra, no missing. This is a
+- *Rust (parse side), phase 2 (implemented):* `checked_static_query`
+  additionally requires the parsed paths' commitment set to **exactly equal
+  `global_commitment_set(authorization)`** — no extra, no missing. This is a
   stronger correctness check (prove inclusion for exactly the spent records) and
-  a tighter, protocol-grounded bound. Pinned by the phase-2 parity test before the
-  old node path is deleted (see deferred items).
+  a tighter, protocol-grounded bound. The Dart fetch side asks for exactly
+  `required_commitments`, so the two agree by construction; the guard is what
+  stops an untrusted node from padding the response.
 
 `program_sources_json`: a JSON array of `{id, edition, source}` the caller has
 already fetched (closure included, any order). Rust validates ids, loads
@@ -445,9 +454,17 @@ behaviour.
    resource budgets, and `program_authorization_static` (the pure authorize
    primitive for arbitrary programs). The old `execute_proof` etc. stay exactly
    as they are, so CI and current Dart keep working.
-2. **Move orchestration to Dart**: implement `AleoNode` + rewrite `AleoProgram`
-   orchestration onto the pure primitives; keep method signatures stable.
-   Parity-test new Dart pipeline vs the old FFI one against testnet.
+2. **Move orchestration to Dart** *(done)*: `AleoNode`
+   (`packages/aleo_dart/lib/src/aleo_node.dart`) owns all node I/O with `dio` +
+   `CancelToken`; `AleoProgram` (`aleo_programs.dart`) composes the pure
+   primitives over it, pinning one consensus version across the whole transfer
+   (a mid-flow upgrade restarts the build). Public method signatures unchanged.
+   Plus the Rust exact-match guard (above). Offline-tested: `aleo_node_test.dart`
+   (the whole node class against a local `HttpServer`), `aleo_required_commitments_test.dart`,
+   and the `checked_static_query_*` Rust tests. End-to-end SNARK proving (the
+   private flow, fee, program paths) and the full live-node parity remain a
+   manual run (`test/transfer/aleo_phase2_e2e.dart`), still blocked on a live
+   testnet with includable transactions.
 3. **Delete the in-Rust network code** and the now-unused exports once Dart no
    longer calls them; drop `ureq`.
 4. **Remove the proving-parameter network dependency + re-point cross-compile**:

--- a/rust/aleo_ffi/src/lib.rs
+++ b/rust/aleo_ffi/src/lib.rs
@@ -1622,6 +1622,34 @@ fn static_query(
     Ok(StaticQuery::new(height, state_root, state_paths))
 }
 
+/// [`static_query`] with the phase-2 exact-match guard: the supplied state
+/// paths' commitment set must equal exactly the commitments `authorization`
+/// will prove inclusion for (`global_commitment_set`) — no missing path (proving
+/// would fail anyway) and, crucially, no *extra* one. Without this, an untrusted
+/// node could pad the response with unrelated valid state paths; the byte/entry
+/// budget bounds size but not relevance. This is the tighter, protocol-grounded
+/// bound the phase-1 primitives deferred to phase 2.
+fn checked_static_query(
+    authorization: &Authorization<Net>,
+    height: u32,
+    state_paths_json: &str,
+    public_state_root: &str,
+) -> anyhow::Result<StaticQuery<Net>> {
+    let expected: HashSet<String> = global_commitment_set(authorization).into_iter().collect();
+    let actual: HashSet<String> = parse_state_paths(state_paths_json)?
+        .iter()
+        .map(|path| path.transition_leaf().id().to_string())
+        .collect();
+    anyhow::ensure!(
+        actual == expected,
+        "state paths' commitment set ({} entries) does not match the authorization's \
+         {} required commitment(s)",
+        actual.len(),
+        expected.len()
+    );
+    static_query(height, state_paths_json, public_state_root)
+}
+
 /// Base (minimum) fee in microcredits for an execution at the given height. The
 /// pure analogue of [`base_fee_for`]: `height` selects the consensus version
 /// instead of a node fetch. `program_sources_json` supplies the execution's root
@@ -1788,6 +1816,36 @@ fn global_input_commitments(transitions: &[(Vec<String>, Vec<String>)]) -> Vec<S
     global
 }
 
+/// The global input-record commitments an authorization will prove inclusion
+/// for — exactly the keys `static_query`'s map must contain. Shared by the
+/// [`required_commitments`] export (what Dart fetches state paths for) and the
+/// proving primitives' exact-match guard (so a node can supply neither extra nor
+/// missing paths). The `tcm` pairing + execution-order local filter mirror
+/// `Inclusion::insert_transition`; see [`required_commitments`].
+fn global_commitment_set(authorization: &Authorization<Net>) -> Vec<String> {
+    let mut inputs_by_tcm: HashMap<String, Vec<String>> = HashMap::new();
+    for request in authorization.to_vec_deque() {
+        let entry = inputs_by_tcm.entry(request.tcm().to_string()).or_default();
+        for input_id in request.input_ids() {
+            if let InputID::Record(commitment, ..) = input_id {
+                entry.push(commitment.to_string());
+            }
+        }
+    }
+    let mut ordered = Vec::new();
+    for (_, transition) in authorization.transitions() {
+        let inputs =
+            inputs_by_tcm.get(&transition.tcm().to_string()).cloned().unwrap_or_default();
+        let outputs = transition
+            .outputs()
+            .iter()
+            .filter_map(|output| output.commitment().map(|commitment| commitment.to_string()))
+            .collect();
+        ordered.push((inputs, outputs));
+    }
+    global_input_commitments(&ordered)
+}
+
 /// The input-record commitments whose state paths the caller must fetch before
 /// proving this authorization. Empty for public flows (no record inputs).
 /// Pure: read from the authorization itself, no VM/synthesis or network.
@@ -1810,32 +1868,7 @@ fn global_input_commitments(transitions: &[(Vec<String>, Vec<String>)]) -> Vec<S
 pub unsafe extern "C" fn required_commitments(authorization: *const c_char) -> *mut c_char {
     let inner = || -> anyhow::Result<String> {
         let authorization: Authorization<Net> = serde_json::from_str(read_str(authorization))?;
-        // Pair each request's record-input commitments with its transition by
-        // tcm: requests are pre-order and transitions execution-order, so they
-        // can't be zipped positionally.
-        let mut inputs_by_tcm: HashMap<String, Vec<String>> = HashMap::new();
-        for request in authorization.to_vec_deque() {
-            let entry = inputs_by_tcm.entry(request.tcm().to_string()).or_default();
-            for input_id in request.input_ids() {
-                if let InputID::Record(commitment, ..) = input_id {
-                    entry.push(commitment.to_string());
-                }
-            }
-        }
-        // Walk transitions in execution order, building (inputs, outputs) per
-        // transition for the order-sensitive local filter.
-        let mut ordered = Vec::new();
-        for (_, transition) in authorization.transitions() {
-            let inputs =
-                inputs_by_tcm.get(&transition.tcm().to_string()).cloned().unwrap_or_default();
-            let outputs = transition
-                .outputs()
-                .iter()
-                .filter_map(|output| output.commitment().map(|commitment| commitment.to_string()))
-                .collect();
-            ordered.push((inputs, outputs));
-        }
-        Ok(serde_json::to_string(&global_input_commitments(&ordered))?)
+        Ok(serde_json::to_string(&global_commitment_set(&authorization))?)
     };
     match inner() {
         Ok(commitments) => to_cstring(commitments),
@@ -1986,7 +2019,12 @@ pub unsafe extern "C" fn execute_proof_static(
 ) -> *mut c_char {
     let inner = || -> anyhow::Result<String> {
         let authorization: Authorization<Net> = serde_json::from_str(read_str(authorization))?;
-        let query = static_query(height, read_str(state_paths_json), read_str(public_state_root))?;
+        let query = checked_static_query(
+            &authorization,
+            height,
+            read_str(state_paths_json),
+            read_str(public_state_root),
+        )?;
         let vm = new_vm()?;
         let (execution, _response) =
             vm.execute_authorization_raw(authorization, &query, &mut rand::thread_rng())?;
@@ -2015,7 +2053,12 @@ pub unsafe extern "C" fn execute_fee_proof_static(
 ) -> *mut c_char {
     let inner = || -> anyhow::Result<String> {
         let authorization: Authorization<Net> = serde_json::from_str(read_str(authorization))?;
-        let query = static_query(height, read_str(state_paths_json), read_str(public_state_root))?;
+        let query = checked_static_query(
+            &authorization,
+            height,
+            read_str(state_paths_json),
+            read_str(public_state_root),
+        )?;
         let vm = new_vm()?;
         let fee = vm.execute_fee_authorization_raw(authorization, &query, &mut rand::thread_rng())?;
         Ok(serde_json::to_string(&fee)?)
@@ -2045,7 +2088,12 @@ pub unsafe extern "C" fn execute_program_proof_static(
         let authorization: Authorization<Net> = serde_json::from_str(read_str(authorization))?;
         let vm = new_vm()?;
         add_programs_from_sources(&vm, read_str(program_sources_json))?;
-        let query = static_query(height, read_str(state_paths_json), read_str(public_state_root))?;
+        let query = checked_static_query(
+            &authorization,
+            height,
+            read_str(state_paths_json),
+            read_str(public_state_root),
+        )?;
         let (execution, _response) =
             vm.execute_authorization_raw(authorization, &query, &mut rand::thread_rng())?;
         Ok(serde_json::to_string(&execution)?)
@@ -2726,6 +2774,80 @@ mod tests {
         let json = serde_json::to_string(&vec![path.clone(), path]).unwrap();
         let error = static_query(1, &json, "").map(|_| ()).unwrap_err();
         assert!(error.to_string().contains("duplicate state path"), "got: {error}");
+    }
+
+    // An offline credits.aleo authorization for one of the test account's
+    // private records — the spent record's commitment is the single member of
+    // its `global_commitment_set`, which the exact-match guard pins.
+    fn private_transfer_authorization() -> Authorization<Net> {
+        let owner = owner();
+        let recipient = Address::<Net>::try_from(&other_key()).unwrap().to_string();
+        let inputs =
+            transfer_inputs("transfer_private", &recipient, 1, TEST_RECORD, &owner).unwrap();
+        let vm = new_vm().unwrap();
+        vm.authorize(&owner, "credits.aleo", "transfer_private", inputs, &mut TestRng::default())
+            .unwrap()
+    }
+
+    // The phase-2 exact-match: the supplied state paths' commitment set must be
+    // exactly the authorization's required commitments — a matching single path
+    // is accepted.
+    #[test]
+    fn checked_static_query_accepts_exact_match() {
+        let mut rng = TestRng::default();
+        let auth = private_transfer_authorization();
+        let commitments = global_commitment_set(&auth);
+        assert_eq!(commitments.len(), 1, "transfer_private spends exactly one record");
+        let commitment = Field::<Net>::from_str(&commitments[0]).unwrap();
+        let path = sample_global_state_path::<Net>(Some(commitment), &mut rng).unwrap();
+        let json = serde_json::to_string(&vec![path]).unwrap();
+        assert!(checked_static_query(&auth, 100, &json, "").is_ok());
+    }
+
+    // An *extra* unrelated path (which the size budget alone would let through)
+    // is rejected: a node cannot pad the snapshot with irrelevant inclusions.
+    #[test]
+    fn checked_static_query_rejects_extra_path() {
+        let mut rng = TestRng::default();
+        let auth = private_transfer_authorization();
+        let commitment = Field::<Net>::from_str(&global_commitment_set(&auth)[0]).unwrap();
+        let wanted = sample_global_state_path::<Net>(Some(commitment), &mut rng).unwrap();
+        let extra = sample_global_state_path::<Net>(None, &mut rng).unwrap();
+        let json = serde_json::to_string(&vec![wanted, extra]).unwrap();
+        let error = checked_static_query(&auth, 100, &json, "").map(|_| ()).unwrap_err();
+        assert!(error.to_string().contains("does not match"), "got: {error}");
+    }
+
+    // A missing path (here, none at all) is likewise rejected up front, rather
+    // than relying on proving to fail later.
+    #[test]
+    fn checked_static_query_rejects_missing_path() {
+        let auth = private_transfer_authorization();
+        assert_eq!(global_commitment_set(&auth).len(), 1);
+        let error = checked_static_query(&auth, 100, "[]", "").map(|_| ()).unwrap_err();
+        assert!(error.to_string().contains("does not match"), "got: {error}");
+    }
+
+    // A public transfer has no record inputs, so its required set is empty: the
+    // matching call passes empty paths + a root, and any path is an extra.
+    #[test]
+    fn checked_static_query_public_flow_is_empty_set() {
+        let mut rng = TestRng::default();
+        let owner = owner();
+        let recipient = Address::<Net>::try_from(&other_key()).unwrap().to_string();
+        let inputs = transfer_inputs("transfer_public", &recipient, 1, "", &owner).unwrap();
+        let vm = new_vm().unwrap();
+        let auth = vm
+            .authorize(&owner, "credits.aleo", "transfer_public", inputs, &mut TestRng::default())
+            .unwrap();
+        assert!(global_commitment_set(&auth).is_empty());
+        let root = "sr1dz06ur5spdgzkguh4pr42mvft6u3nwsg5drh9rdja9v8jpcz3czsls9geg";
+        assert!(checked_static_query(&auth, 1, "", root).is_ok());
+        // Any path supplied for a public flow is an unexpected extra.
+        let path = sample_global_state_path::<Net>(None, &mut rng).unwrap();
+        let json = serde_json::to_string(&vec![path]).unwrap();
+        let error = checked_static_query(&auth, 1, &json, "").map(|_| ()).unwrap_err();
+        assert!(error.to_string().contains("does not match"), "got: {error}");
     }
 
     // The state-paths byte budget rejects an oversized blob before parsing.

--- a/rust/aleo_ffi/src/lib.rs
+++ b/rust/aleo_ffi/src/lib.rs
@@ -1578,13 +1578,23 @@ fn static_query(
     state_paths_json: &str,
     public_state_root: &str,
 ) -> anyhow::Result<StaticQuery<Net>> {
+    static_query_from_paths(height, parse_state_paths(state_paths_json)?, public_state_root)
+}
+
+/// [`static_query`] over already-parsed paths, so a caller that parsed the JSON
+/// once (the exact-match guard) does not pay the serde cost twice on a
+/// budget-sized blob.
+fn static_query_from_paths(
+    height: u32,
+    paths: Vec<StatePath<Net>>,
+    public_state_root: &str,
+) -> anyhow::Result<StaticQuery<Net>> {
     let public_state_root = public_state_root.trim();
     anyhow::ensure!(
         public_state_root.len() <= MAX_STATE_ROOT_BYTES,
         "public_state_root is {} bytes, over the {MAX_STATE_ROOT_BYTES}-byte budget",
         public_state_root.len()
     );
-    let paths = parse_state_paths(state_paths_json)?;
 
     if paths.is_empty() {
         anyhow::ensure!(
@@ -1636,10 +1646,11 @@ fn checked_static_query(
     public_state_root: &str,
 ) -> anyhow::Result<StaticQuery<Net>> {
     let expected: HashSet<String> = global_commitment_set(authorization).into_iter().collect();
-    let actual: HashSet<String> = parse_state_paths(state_paths_json)?
-        .iter()
-        .map(|path| path.transition_leaf().id().to_string())
-        .collect();
+    // Parse once, here, and hand the parsed paths to `static_query_from_paths`
+    // (rather than `static_query`, which would re-parse the budget-sized blob).
+    let paths = parse_state_paths(state_paths_json)?;
+    let actual: HashSet<String> =
+        paths.iter().map(|path| path.transition_leaf().id().to_string()).collect();
     anyhow::ensure!(
         actual == expected,
         "state paths' commitment set ({} entries) does not match the authorization's \
@@ -1647,7 +1658,7 @@ fn checked_static_query(
         actual.len(),
         expected.len()
     );
-    static_query(height, state_paths_json, public_state_root)
+    static_query_from_paths(height, paths, public_state_root)
 }
 
 /// Base (minimum) fee in microcredits for an execution at the given height. The


### PR DESCRIPTION
Phase 2 of moving Aleo node I/O out of the synchronous FFI and into Dart (spec: `rust/aleo_ffi/docs/network-io-to-dart.md`). Branches off the merged phase-1 epic (merge 84c559b). Phase 1 added the pure `*_static` primitives + helpers alongside the untouched old exports; **phase 2 builds the Dart layer on top and lands the Rust exact-match guard.**

## What's in this PR

### Dart `AleoNode` (`packages/aleo_dart/lib/src/aleo_node.dart`)
Owns all node REST I/O — the four reads (height, state root, state paths, program source + import-closure walk) and the broadcast write.
- **Real cancellation**: every request carries a `dio` `CancelToken`; an outer timeout `cancel()`s it, aborting the socket. `Future.timeout` only stops *awaiting* — that would recreate the abandoned-worker leak we're leaving Rust to escape.
- **Untrusted responses are budget-checked on the fetch side**, mirroring the Rust parser's caps (state-path byte + entry caps, program-size cap, closure count/byte/wall-clock budget), and **streamed** so an oversized body is rejected before it buffers.
- `dio` moves from a dev- to a runtime dependency (it now backs library code).

### `AleoProgram` orchestration rewritten onto the pure primitives
The one-call flows (`tryTransfer` / `tryJoin` / `executeProgram` / `contractExecution` / `contractFeeExecution` / `buildTransaction`) and the node-touching leaves (`executeProof` / `executeFeeProof` / `executeProgramProof` / `getBaseFee` / `executionFeeAuthorization` / `broadcast`) **no longer call the blocking-HTTP exports** — they compose the phase-1 `*_static` primitives over an `AleoNode`. **Public method signatures are unchanged.**

The split-proof transfer mirrors the old in-Rust `full_transaction` (authorize → prove → fee-authorize → prove-fee → assemble) but:
- takes **two independent inclusion snapshots** (a private fee spends its own record), and
- **pins one consensus version across the whole transaction** — a mid-flow upgrade discards every proof and restarts (bounded retry).

### Rust exact-match guard (the deferred phase-2 target)
`checked_static_query` requires the supplied state paths' commitment set to equal **exactly** `global_commitment_set(authorization)` — rejecting an *extra* padded path (the size budget bounds size, not relevance) as well as a missing one. `global_commitment_set` is extracted from `required_commitments`, so the set Dart fetches by and the set proving enforces share one definition.

## Tests
- **`aleo_node_test.dart`** — drives the whole node class against a local `HttpServer`: routes, empty-set short-circuit, byte/entry budgets, retry-on-5xx, no-retry-on-4xx, real cancellation, import-closure walk + cycle termination. Fully offline, CI-safe.
- **`aleo_required_commitments_test.dart`** — `required_commitments` through the FFI: a single-record private transfer needs exactly one commitment, a public transfer none.
- **Rust `checked_static_query_*`** (4) — real sampled `StatePath`s keyed by a private transfer's actual commitment: accept exact match, reject extra, reject missing, public = empty set. `cargo test --lib` = 53 passing.
- Release cdylib builds; all 41 FFI symbols still exported (no ABI change); the existing Dart FFI suite passes against it.

## Deferred / still blocked (explicit)
- **End-to-end SNARK proving of the private/fee/program paths and full live-node parity** stay a manual harness (`test/transfer/aleo_phase2_e2e.dart`) — still blocked on a live testnet that includes transactions (sampled blocks have none). A successful private-flow proof there *is* the `required_commitments` parity check, since `checked_static_query` rejects any extra path and proving fails on a missing one.
- **Phase 3** (delete the old in-Rust network exports + drop `ureq`) and **phase 4** (vendor `snarkvm-parameters` to drop the proving-parameter `curl`/OpenSSL download — the real no-OpenSSL mobile prerequisite) are separate follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)