### PR TITLE
feat(bc_ur_dart): add SC and multi-chain Keystone support

### DIFF
--- a/packages/bc_ur_dart/AGENTS.md
+++ b/packages/bc_ur_dart/AGENTS.md
@@ -1,0 +1,69 @@
+# PROJECT KNOWLEDGE BASE
+
+**Generated:** 2026-03-18
+**Commit:** 054984f
+**Branch:** feature/gs-transfer
+
+## OVERVIEW
+Dart package for UR (Uniform Resource) encoding/decoding — CBOR-based QR protocol for crypto wallet cold signing. Supports BTC, ETH, SOL, TRON, Cosmos, Aleo.
+
+## STRUCTURE
+```
+bc_ur_dart/
+├── lib/
+│   ├── bc_ur_dart.dart        # Public exports
+│   └── src/
+│       ├── ur.dart             # Core UR class (encode/decode/read/next)
+│       ├── models/             # SignRequest/Signature per chain
+│       │   ├── alph/           # Aleo
+│       │   ├── btc/            # PSBT, GSPL
+│       │   ├── eth/
+│       │   ├── sol/
+│       │   ├── tron/
+│       │   ├── cosmos/
+│       │   ├── key/            # HDKey, MultiAccounts
+│       │   └── common/         # Fragment, Seq
+│       ├── registry/           # RegistryType, CryptoTxEntity
+│       └── utils/              # CRC32, ByteWords, Type, Error
+└── test/                       # 6 test files
+```
+
+## WHERE TO LOOK
+| Task | Location | Notes |
+|------|----------|-------|
+| Add new UR type | `lib/src/models/{chain}/` | Create sign_request + signature pair |
+| Core UR logic | `lib/src/ur.dart` | encode(), decode(), read(), next() |
+| Registry types | `lib/src/registry/` | RegistryType enum, CryptoTxEntity |
+| CBOR encoding | Uses `package:cbor` | External dependency |
+
+## CONVENTIONS
+- **Model pairs**: `{Chain}SignRequest` + `{Chain}Signature` in same dir
+- **Naming**: snake_case files, PascalCase classes
+- **Entry**: `lib/bc_ur_dart.dart` (not `index.dart`)
+- **Tests**: Flat in `test/`, mirror lib structure loosely
+
+## ANTI-PATTERNS (THIS PROJECT)
+- No example/ directory (README claims it exists — it's missing)
+- Tests use `flutter test` but this is a pure Dart package (use `dart test`)
+
+## GIT CONSTRAINTS
+- **NEVER run `git commit` or `git push`** — ask user explicitly before any git write operations
+- Only use read-only git commands (`git log`, `git show`, `git diff`, `git status`, etc.)
+
+## UNIQUE STYLES
+- Monorepo via Melos (root: fx-wallet-packages)
+- Dependency override via `pubspec_overrides.yaml` (monorepo artifact)
+- 54 linter rules in analysis_options.yaml
+
+## COMMANDS
+```bash
+dart analyze        # Lint check
+dart test           # Run tests
+dart format .       # Format code
+```
+
+## NOTES
+- No UREncoder/URDecoder — encoding/decoding is in `UR` class itself
+- `UR.decode(string)` → `UR` object
+- `ur.encode()` → UR string
+- `ur.next()` → fragment for large payloads

--- a/packages/bc_ur_dart/lib/bc_ur_dart.dart
+++ b/packages/bc_ur_dart/lib/bc_ur_dart.dart
@@ -22,6 +22,8 @@ export 'package:bc_ur_dart/src/models/key/crypto_account.dart';
 export 'package:bc_ur_dart/src/models/key/crypto_coin_info.dart';
 export 'package:bc_ur_dart/src/models/key/crypto_hdkey.dart';
 export 'package:bc_ur_dart/src/models/key/crypto_multi_accounts.dart';
+export 'package:bc_ur_dart/src/models/sc/sc_sign_request.dart';
+export 'package:bc_ur_dart/src/models/sc/sc_signature.dart';
 export 'package:bc_ur_dart/src/models/sol/sol_sign_request.dart';
 export 'package:bc_ur_dart/src/models/sol/sol_signature.dart';
 export 'package:bc_ur_dart/src/models/sol/keystone_sol_sign_request.dart';

--- a/packages/bc_ur_dart/lib/src/models/bch/bch_sign_request.dart
+++ b/packages/bc_ur_dart/lib/src/models/bch/bch_sign_request.dart
@@ -47,6 +47,11 @@ class BchOutput {
 }
 
 class BchSignRequestUR extends UR {
+  /// Keystone 交易所属链的资产代码。
+  ///
+  /// Keystone 的 BCH/DOGE 等 UTXO 交易共用 [BchTx] 结构承载输入输出，
+  /// 设备端通过 [coinCode] 区分最终签名链，默认保持历史 BCH 行为。
+  final String coinCode;
   final String requestId;
   final String xfp;
   final String hdPath;
@@ -54,12 +59,18 @@ class BchSignRequestUR extends UR {
 
   BchSignRequestUR({
     required UR ur,
+    this.coinCode = 'BCH',
     required this.requestId,
     required this.xfp,
     required this.hdPath,
     this.origin,
   }) : super(payload: ur.payload, type: ur.type);
 
+  /// 构建 Keystone UTXO 签名请求。
+  ///
+  /// [coinCode] 默认是 `BCH`，Doge 等同源 UTXO 链可以传入自己的大写资产代码。
+  /// Payload 仍使用 Keystone 现有的 [BchTx] oneof 字段，避免创建设备端不认识的新
+  /// registry type。
   factory BchSignRequestUR.fromTransaction({
     required List<BchInput> inputs,
     required List<BchOutput> outputs,
@@ -69,6 +80,7 @@ class BchSignRequestUR extends UR {
     String? requestId,
     String? origin,
     int dustThreshold = 546,
+    String coinCode = 'BCH',
   }) {
     final id = requestId ?? const Uuid().v4();
 
@@ -82,7 +94,7 @@ class BchSignRequestUR extends UR {
 
     // 2. 构建 Payload → SignTransaction → BchTx
     final signTransaction = SignTransaction()
-      ..coinCode = 'BCH'
+      ..coinCode = coinCode
       ..signId = id
       ..hdPath = hdPath
       ..timestamp = Int64(DateTime.now().millisecondsSinceEpoch)
@@ -116,6 +128,7 @@ class BchSignRequestUR extends UR {
 
     return BchSignRequestUR(
       ur: ur,
+      coinCode: coinCode,
       requestId: id,
       xfp: xfp,
       hdPath: hdPath,
@@ -144,6 +157,7 @@ class BchSignRequestUR extends UR {
     // 取出 signTx
     final signTx = payload.signTx;
     final signId = signTx.signId;
+    final coinCode = signTx.coinCode;
     final xfp = payload.xfp;
     final hdPath = signTx.hdPath;
 
@@ -152,6 +166,7 @@ class BchSignRequestUR extends UR {
 
     return BchSignRequestUR(
       ur: ur,
+      coinCode: coinCode,
       requestId: signId,
       xfp: xfp,
       hdPath: hdPath,

--- a/packages/bc_ur_dart/lib/src/models/bch/bch_sign_request.dart
+++ b/packages/bc_ur_dart/lib/src/models/bch/bch_sign_request.dart
@@ -69,6 +69,8 @@ class BchSignRequestUR extends UR {
   /// 构建 Keystone UTXO 签名请求。
   ///
   /// [coinCode] 默认是 `BCH`，Doge 等同源 UTXO 链可以传入自己的大写资产代码。
+  /// 当前 Keystone UTXO payload 固定使用 8 位小数，调用方只应传入同样采用
+  /// 8-decimal satoshi 单位的 coin code。
   /// Payload 仍使用 Keystone 现有的 [BchTx] oneof 字段，避免创建设备端不认识的新
   /// registry type。
   factory BchSignRequestUR.fromTransaction({
@@ -105,7 +107,7 @@ class BchSignRequestUR extends UR {
       ..type = Payload_Type.TYPE_SIGN_TX
       ..xfp = xfp
       ..signTx = signTransaction;
-    
+
     // 外层包 Base
     final base = Base()
       ..version = 2
@@ -115,7 +117,7 @@ class BchSignRequestUR extends UR {
     // 3. gzip 压缩 Base
     final compressed = GZipCodec().encode(base.writeToBuffer());
     final signDataBytes = Uint8List.fromList(compressed);
-    
+
     // 4. 封装为 BCH-SIGN-REQUEST CBOR
     // field 1: signData(bytes), field 2: origin(string, optional)
     final ur = UR.fromCBOR(

--- a/packages/bc_ur_dart/lib/src/models/key/crypto_account.dart
+++ b/packages/bc_ur_dart/lib/src/models/key/crypto_account.dart
@@ -28,14 +28,16 @@ class CryptoAccountUR extends UR {
 
     final data = ur.decodeCBOR() as CborMap;
     if (!RegistryItem.hasKey(data, 1)) {
-      throw ArgumentError('Missing required field: master fingerprint (field 1)');
+      throw ArgumentError(
+          'Missing required field: master fingerprint (field 1)');
     }
     if (!RegistryItem.hasKey(data, 2)) {
       throw ArgumentError('Missing required field: outputs (field 2)');
     }
 
     final fpRaw = (data[CborSmallInt(1)] as CborInt).toInt();
-    final fpBytes = Uint8List(4)..buffer.asByteData().setUint32(0, fpRaw, Endian.big);
+    final fpBytes = Uint8List(4)
+      ..buffer.asByteData().setUint32(0, fpRaw, Endian.big);
     final masterFingerprint = hex.encode(fpBytes);
 
     final outputsRaw = data[CborSmallInt(2)] as CborList;
@@ -72,11 +74,13 @@ class CryptoAccountUR extends UR {
       value: CborMap({
         CborSmallInt(1): CborInt(BigInt.from(fpInt)),
         CborSmallInt(2): CborList(outputs.map((e) => e.decodeCBOR()).toList()),
-        if (xfpFormat != null && xfpFormat.isNotEmpty) CborSmallInt(3): CborString(xfpFormat),
+        if (xfpFormat != null && xfpFormat.isNotEmpty)
+          CborSmallInt(3): CborString(xfpFormat),
       }),
     );
 
-    final fpBytes = Uint8List(4)..buffer.asByteData().setUint32(0, fpInt, Endian.big);
+    final fpBytes = Uint8List(4)
+      ..buffer.asByteData().setUint32(0, fpInt, Endian.big);
     return CryptoAccountUR(
       ur: ur,
       masterFingerprint: hex.encode(fpBytes),
@@ -92,7 +96,7 @@ class CryptoAccountUR extends UR {
 
     fields.addString('masterFingerprint', masterFingerprint);
     fields.addString('xfpFormat', xfpFormat);
-    if (outputs.isNotEmpty) fields.addRaw('outputs', '[${outputs.map((e) => e.toString()).join(',')}]');
+    fields.addRaw('outputs', '[${outputs.map((e) => e.toString()).join(',')}]');
     return fields.toString();
   }
 }

--- a/packages/bc_ur_dart/lib/src/models/key/crypto_account.dart
+++ b/packages/bc_ur_dart/lib/src/models/key/crypto_account.dart
@@ -1,6 +1,7 @@
 import 'dart:typed_data';
 
 import 'package:bc_ur_dart/bc_ur_dart.dart';
+import 'package:bc_ur_dart/src/models/key/to_string_fields.dart';
 import 'package:bc_ur_dart/src/registry/registry_item.dart';
 import 'package:convert/convert.dart';
 
@@ -87,12 +88,11 @@ class CryptoAccountUR extends UR {
 
   @override
   String toString() {
-    return '''
-{
-"masterFingerprint":"$masterFingerprint",
-"xfpFormat":"${xfpFormat ?? ''}",
-"outputs":[${outputs.map((e) => e.toString()).join(',')}]
-}
-  ''';
+    final fields = CompactToStringFields();
+
+    fields.addString('masterFingerprint', masterFingerprint);
+    fields.addString('xfpFormat', xfpFormat);
+    if (outputs.isNotEmpty) fields.addRaw('outputs', '[${outputs.map((e) => e.toString()).join(',')}]');
+    return fields.toString();
   }
 }

--- a/packages/bc_ur_dart/lib/src/models/key/crypto_hdkey.dart
+++ b/packages/bc_ur_dart/lib/src/models/key/crypto_hdkey.dart
@@ -176,7 +176,9 @@ class CryptoHDKeyUR extends UR {
       try {
         wallet = BIP32.fromPublicKey(publicKey, chainCode);
       } catch (e) {
-        wallet = null;
+        if (!_allowsRawNonSecpKey(useInfo, path)) {
+          throw FormatException('Invalid crypto-hdkey public key or chain code: $e');
+        }
       }
       if (wallet != null) {
         wallet.parentFingerprint = parentFingerprint ?? 0;
@@ -220,8 +222,18 @@ class CryptoHDKeyUR extends UR {
     fields.addString('publicKey', pubKey != null && pubKey.isNotEmpty ? hex.encode(pubKey) : null);
     fields.addString('chainCode', chain != null && chain.isNotEmpty ? hex.encode(chain) : null);
     fields.addString('name', name);
-    fields.addRawString('note', note);
+    fields.addString('note', note);
 
     return fields.toString();
+  }
+
+  static bool _allowsRawNonSecpKey(CryptoCoinInfo? useInfo, String path) {
+    final coinType = useInfo?.coinType ?? _coinTypeFromPath(path);
+    return coinType == CoinType.SOL;
+  }
+
+  static int? _coinTypeFromPath(String path) {
+    final match = RegExp(r"^m/44'/(\d+)'").firstMatch(path);
+    return match == null ? null : int.tryParse(match.group(1)!);
   }
 }

--- a/packages/bc_ur_dart/lib/src/models/key/crypto_hdkey.dart
+++ b/packages/bc_ur_dart/lib/src/models/key/crypto_hdkey.dart
@@ -1,6 +1,7 @@
 import 'dart:typed_data';
 
 import 'package:bc_ur_dart/bc_ur_dart.dart';
+import 'package:bc_ur_dart/src/models/key/to_string_fields.dart';
 import 'package:bc_ur_dart/src/registry/crypto_key_path.dart';
 import 'package:bc_ur_dart/src/registry/registry_item.dart';
 import 'package:convert/convert.dart';
@@ -165,17 +166,23 @@ class CryptoHDKeyUR extends UR {
 
     final index = keypath.components.isNotEmpty ? keypath.components.last.getIndex() ?? 0 : 0;
 
-    // Build BIP32 wallet (仅当有 chainCode 时才构建)
+    // Build BIP32 wallet (仅当有 chainCode 且公钥属于 secp256k1 时才构建)。
+    //
+    // BIP32 只适用于 secp256k1；这里不能
+    // 因单条非 secp 公钥导致整个 crypto-multi-accounts 导入失败，而是保留原始
+    // publicKey / chainCode 交给上层按链类型处理。
     BIP32? wallet;
     if (chainCode != null) {
       try {
         wallet = BIP32.fromPublicKey(publicKey, chainCode);
       } catch (e) {
-        throw FormatException('Invalid crypto-hdkey public key or chain code: $e');
+        wallet = null;
       }
-      wallet.parentFingerprint = parentFingerprint ?? 0;
-      wallet.depth = keypath.depth ?? keypath.components.length;
-      wallet.index = index;
+      if (wallet != null) {
+        wallet.parentFingerprint = parentFingerprint ?? 0;
+        wallet.depth = keypath.depth ?? keypath.components.length;
+        wallet.index = index;
+      }
     }
 
     return CryptoHDKeyUR(
@@ -201,21 +208,20 @@ class CryptoHDKeyUR extends UR {
     // 获取公钥和链码：优先使用 wallet，否则使用直接提供的字段
     final pubKey = wallet?.publicKey ?? publicKey;
     final chain = wallet?.chainCode ?? chainCode;
+    final fields = CompactToStringFields();
 
-    return '''
-{
-"useInfo":${useInfo?.toString() ?? 'null'},
-"derivationPath":"$path",
-"childrenPath":"${childrenPath ?? ''}",
-"sourceFingerprint":"${sourceFingerprint ?? ''}",
-"xfpFormat":"${xfpFormat ?? ''}",
-"masterFingerprint":"${wallet != null ? hex.encode(wallet!.fingerprint) : ''}",
-"extendedPublicKey": "${wallet?.toBase58() ?? ''}",
-"publicKey": "${pubKey != null ? hex.encode(pubKey) : ''}",
-"chainCode": "${chain != null ? hex.encode(chain) : ''}",
-"name":"$name",
-"note":"${note ?? ''}"
-}
-  ''';
+    fields.addRaw('useInfo', useInfo?.toString());
+    fields.addString('derivationPath', path);
+    fields.addString('childrenPath', childrenPath);
+    fields.addString('sourceFingerprint', sourceFingerprint);
+    fields.addString('xfpFormat', xfpFormat);
+    fields.addString('masterFingerprint', wallet != null ? hex.encode(wallet!.fingerprint) : null);
+    fields.addString('extendedPublicKey', wallet?.toBase58());
+    fields.addString('publicKey', pubKey != null && pubKey.isNotEmpty ? hex.encode(pubKey) : null);
+    fields.addString('chainCode', chain != null && chain.isNotEmpty ? hex.encode(chain) : null);
+    fields.addString('name', name);
+    fields.addRawString('note', note);
+
+    return fields.toString();
   }
 }

--- a/packages/bc_ur_dart/lib/src/models/key/crypto_multi_accounts.dart
+++ b/packages/bc_ur_dart/lib/src/models/key/crypto_multi_accounts.dart
@@ -1,6 +1,7 @@
 import 'dart:typed_data';
 
 import 'package:bc_ur_dart/bc_ur_dart.dart';
+import 'package:bc_ur_dart/src/models/key/to_string_fields.dart';
 import 'package:convert/convert.dart';
 
 final mtiType = RegistryType.CRYPTO_MULTI_ACCOUNTS.type;
@@ -137,15 +138,16 @@ class CryptoMultiAccountsUR extends UR {
   }
 
   @override
-  String toString() => '''
-{
-"masterFingerprint":"$masterFingerprint",
-"walletName":"${walletName ?? ''}",
-"device":"$device",
-"deviceId":"${deviceId ?? ''}",
-"version":"${version ?? ''}",
-"xfpFormat":"${xfpFormat ?? ''}",
-"chains":${chains.map((e) => e.toString()).join(',')}
-}
-  ''';
+  String toString() {
+    final fields = CompactToStringFields();
+
+    fields.addString('masterFingerprint', masterFingerprint);
+    fields.addString('walletName', walletName);
+    fields.addString('device', device);
+    fields.addString('deviceId', deviceId);
+    fields.addString('version', version);
+    fields.addString('xfpFormat', xfpFormat);
+    if (chains.isNotEmpty) fields.addRaw('chains', chains.map((e) => e.toString()).join(','));
+    return fields.toString();
+  }
 }

--- a/packages/bc_ur_dart/lib/src/models/key/crypto_multi_accounts.dart
+++ b/packages/bc_ur_dart/lib/src/models/key/crypto_multi_accounts.dart
@@ -30,7 +30,8 @@ class CryptoMultiAccountsUR extends UR {
 
   static CryptoMultiAccountsUR fromUR({required UR ur}) {
     if (ur.type.toLowerCase() != mtiType) {
-      throw FormatException('Invalid crypto-multi-accounts UR type: ${ur.type}');
+      throw FormatException(
+          'Invalid crypto-multi-accounts UR type: ${ur.type}');
     }
     final CborMap data;
     try {
@@ -42,10 +43,12 @@ class CryptoMultiAccountsUR extends UR {
     // field 1: masterFingerprint
     final fpValue = data[CborSmallInt(1)];
     if (fpValue is! CborInt) {
-      throw const FormatException('Invalid crypto-multi-accounts master fingerprint field');
+      throw const FormatException(
+          'Invalid crypto-multi-accounts master fingerprint field');
     }
     final fpRaw = fpValue.toInt();
-    final fpBytes = Uint8List(4)..buffer.asByteData().setUint32(0, fpRaw, Endian.big);
+    final fpBytes = Uint8List(4)
+      ..buffer.asByteData().setUint32(0, fpRaw, Endian.big);
     final masterFingerprint = hex.encode(fpBytes);
 
     // field 2: keys 列表
@@ -58,7 +61,8 @@ class CryptoMultiAccountsUR extends UR {
     for (var index = 0; index < keysValue.length; index++) {
       final item = keysValue[index];
       if (item is! CborMap) {
-        throw FormatException('Invalid crypto-multi-accounts key entry at index $index');
+        throw FormatException(
+            'Invalid crypto-multi-accounts key entry at index $index');
       }
       final keyUr = UR(
         type: hdType,
@@ -68,7 +72,8 @@ class CryptoMultiAccountsUR extends UR {
         final chainInfo = CryptoHDKeyUR.fromUR(ur: keyUr);
         chainList.add(chainInfo);
       } catch (e) {
-        throw FormatException('Invalid crypto-multi-accounts key entry at index $index: $e');
+        throw FormatException(
+            'Invalid crypto-multi-accounts key entry at index $index: $e');
       }
     }
 
@@ -117,10 +122,13 @@ class CryptoMultiAccountsUR extends UR {
         CborSmallInt(1): CborInt(BigInt.from(fpInt)),
         CborSmallInt(2): CborList(chains.map((e) => e.decodeCBOR()).toList()),
         if (device.isNotEmpty) CborSmallInt(3): CborString(device),
-        if (deviceId != null && deviceId.isNotEmpty) CborSmallInt(4): CborString(deviceId),
+        if (deviceId != null && deviceId.isNotEmpty)
+          CborSmallInt(4): CborString(deviceId),
         CborSmallInt(5): CborString(version),
-        if (walletName != null && walletName.isNotEmpty) CborSmallInt(6): CborString(walletName),
-        if (xfpFormat != null && xfpFormat.isNotEmpty) CborSmallInt(7): CborString(xfpFormat),
+        if (walletName != null && walletName.isNotEmpty)
+          CborSmallInt(6): CborString(walletName),
+        if (xfpFormat != null && xfpFormat.isNotEmpty)
+          CborSmallInt(7): CborString(xfpFormat),
       }),
     );
 
@@ -147,7 +155,7 @@ class CryptoMultiAccountsUR extends UR {
     fields.addString('deviceId', deviceId);
     fields.addString('version', version);
     fields.addString('xfpFormat', xfpFormat);
-    if (chains.isNotEmpty) fields.addRaw('chains', chains.map((e) => e.toString()).join(','));
+    fields.addRaw('chains', '[${chains.map((e) => e.toString()).join(',')}]');
     return fields.toString();
   }
 }

--- a/packages/bc_ur_dart/lib/src/models/key/to_string_fields.dart
+++ b/packages/bc_ur_dart/lib/src/models/key/to_string_fields.dart
@@ -1,0 +1,31 @@
+import 'dart:convert';
+
+/// 用于构建紧凑的调试字符串，自动跳过空字段。
+class CompactToStringFields {
+  final List<String> _fields = [];
+
+  /// 添加字符串字段；[value] 为空时不输出。
+  ///
+  /// 值会经过 JSON 转义，确保包含引号、反斜杠或控制字符时输出仍是合法 JSON。
+  void addString(String key, String? value) {
+    if (value == null || value.isEmpty) return;
+    _fields.add('${jsonEncode(key)}:${jsonEncode(value)}');
+  }
+
+  /// 添加已经格式化好的字段；[value] 为空时不输出。
+  void addRaw(String key, String? value) {
+    if (value == null || value.isEmpty) return;
+    _fields.add('"$key":$value');
+  }
+
+  /// 添加原样字符串字段：用引号包裹但不做 JSON 转义；[value] 为空时不输出。
+  ///
+  /// 用于 note 等自由文本，保持与历史输出一致（不会把内部的引号/反斜杠转义）。
+  void addRawString(String key, String? value) {
+    if (value == null || value.isEmpty) return;
+    _fields.add('"$key":"$value"');
+  }
+
+  @override
+  String toString() => '{\n${_fields.join(',\n')}\n}';
+}

--- a/packages/bc_ur_dart/lib/src/models/key/to_string_fields.dart
+++ b/packages/bc_ur_dart/lib/src/models/key/to_string_fields.dart
@@ -1,29 +1,28 @@
 import 'dart:convert';
 
-/// 用于构建紧凑的调试字符串，自动跳过空字段。
+/// 用于构建 JSON-shaped 调试字符串。
 class CompactToStringFields {
   final List<String> _fields = [];
 
-  /// 添加字符串字段；[value] 为空时不输出。
+  /// 添加字符串字段。
   ///
   /// 值会经过 JSON 转义，确保包含引号、反斜杠或控制字符时输出仍是合法 JSON。
-  void addString(String key, String? value) {
-    if (value == null || value.isEmpty) return;
+  void addString(String key, String? value, {bool keepEmpty = true}) {
+    if (value == null) {
+      if (!keepEmpty) return;
+      value = '';
+    }
+    if (value.isEmpty && !keepEmpty) return;
     _fields.add('${jsonEncode(key)}:${jsonEncode(value)}');
   }
 
-  /// 添加已经格式化好的字段；[value] 为空时不输出。
-  void addRaw(String key, String? value) {
-    if (value == null || value.isEmpty) return;
+  /// 添加已经格式化好的字段。
+  void addRaw(String key, String? value, {bool keepNull = true}) {
+    if (value == null || value.isEmpty) {
+      if (!keepNull) return;
+      value = 'null';
+    }
     _fields.add('"$key":$value');
-  }
-
-  /// 添加原样字符串字段：用引号包裹但不做 JSON 转义；[value] 为空时不输出。
-  ///
-  /// 用于 note 等自由文本，保持与历史输出一致（不会把内部的引号/反斜杠转义）。
-  void addRawString(String key, String? value) {
-    if (value == null || value.isEmpty) return;
-    _fields.add('"$key":"$value"');
   }
 
   @override

--- a/packages/bc_ur_dart/lib/src/models/sc/sc_sign_request.dart
+++ b/packages/bc_ur_dart/lib/src/models/sc/sc_sign_request.dart
@@ -1,4 +1,3 @@
-import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:bc_ur_dart/src/registry/registry_item.dart';
@@ -17,7 +16,6 @@ enum ScSignRequestKeys {
   signingPayloadData,
   fee,
   outputs,
-  subtractFee,
   origin,
   chain,
 }
@@ -38,7 +36,6 @@ class ScSignRequest extends RegistryItem {
   /// Optional display metadata from the hot side; not used to build the SC tx.
   final String? fee;
   final List<dynamic>? outputs;
-  final bool? subtractFee;
   final String? origin;
   final String chain;
 
@@ -51,7 +48,6 @@ class ScSignRequest extends RegistryItem {
     required this.signingPayloadData,
     this.fee,
     this.outputs,
-    this.subtractFee,
     this.origin,
     this.chain = '',
   });
@@ -73,7 +69,7 @@ class ScSignRequest extends RegistryItem {
       CborSmallInt(ScSignRequestKeys.path.index): CborString(path),
       CborSmallInt(ScSignRequestKeys.address.index): CborString(address),
       CborSmallInt(ScSignRequestKeys.publicKey.index): CborString(publicKey),
-      CborSmallInt(ScSignRequestKeys.signingPayloadData.index): cborBytes(_jsonBytes(signingPayloadData)),
+      CborSmallInt(ScSignRequestKeys.signingPayloadData.index): cborBytes(RegistryItem.jsonBytes(signingPayloadData)),
     };
 
     if (origin != null) {
@@ -83,10 +79,7 @@ class ScSignRequest extends RegistryItem {
       map[CborSmallInt(ScSignRequestKeys.fee.index)] = CborString(fee!);
     }
     if (outputs != null) {
-      map[CborSmallInt(ScSignRequestKeys.outputs.index)] = cborBytes(_jsonBytes(outputs));
-    }
-    if (subtractFee != null) {
-      map[CborSmallInt(ScSignRequestKeys.subtractFee.index)] = CborBool(subtractFee!);
+      map[CborSmallInt(ScSignRequestKeys.outputs.index)] = cborBytes(RegistryItem.jsonBytes(outputs));
     }
     if (chain.isNotEmpty) {
       map[CborSmallInt(ScSignRequestKeys.chain.index)] = CborString(chain);
@@ -103,10 +96,9 @@ class ScSignRequest extends RegistryItem {
       path: _readText(map, ScSignRequestKeys.path.index),
       address: _readText(map, ScSignRequestKeys.address.index),
       publicKey: _readText(map, ScSignRequestKeys.publicKey.index),
-      signingPayloadData: _readJsonMap(map, ScSignRequestKeys.signingPayloadData.index),
+      signingPayloadData: RegistryItem.readJsonMap(map, ScSignRequestKeys.signingPayloadData.index),
       fee: RegistryItem.readOptionalText(map, ScSignRequestKeys.fee.index),
-      outputs: _readOptionalJsonList(map, ScSignRequestKeys.outputs.index),
-      subtractFee: _readOptionalBool(map, ScSignRequestKeys.subtractFee.index),
+      outputs: RegistryItem.readOptionalJsonList(map, ScSignRequestKeys.outputs.index),
       origin: RegistryItem.readOptionalText(map, ScSignRequestKeys.origin.index),
       chain: RegistryItem.readOptionalText(map, ScSignRequestKeys.chain.index) ?? '',
     );
@@ -141,7 +133,6 @@ class ScSignRequest extends RegistryItem {
     required Map<String, dynamic> signingPayloadData,
     String? fee,
     List<dynamic>? outputs,
-    bool? subtractFee,
     String? origin,
     String chain = '',
   }) {
@@ -154,44 +145,14 @@ class ScSignRequest extends RegistryItem {
       signingPayloadData: signingPayloadData,
       fee: fee,
       outputs: outputs,
-      subtractFee: subtractFee,
       origin: origin,
       chain: chain,
     ).toUR();
-  }
-
-  static Uint8List _jsonBytes(Object? value) {
-    return Uint8List.fromList(utf8.encode(jsonEncode(value)));
   }
 
   static String _readText(CborMap map, int key) {
     final value = map[CborSmallInt(key)];
     if (value is CborString) return value.toString();
     throw ArgumentError('Invalid text at key $key');
-  }
-
-  static Map<String, dynamic> _readJsonMap(CborMap map, int key) {
-    final value = _readJson(map, key);
-    if (value is Map) return Map<String, dynamic>.from(value);
-    throw ArgumentError('Invalid json map at key $key');
-  }
-
-  static List<dynamic>? _readOptionalJsonList(CborMap map, int key) {
-    if (!RegistryItem.hasKey(map, key)) return null;
-    final value = _readJson(map, key);
-    if (value is List<dynamic>) return value;
-    throw ArgumentError('Invalid json list at key $key');
-  }
-
-  static dynamic _readJson(CborMap map, int key) {
-    final bytes = RegistryItem.readBytes(map, key);
-    return jsonDecode(utf8.decode(bytes));
-  }
-
-  static bool? _readOptionalBool(CborMap map, int key) {
-    if (!RegistryItem.hasKey(map, key)) return null;
-    final value = map[CborSmallInt(key)];
-    if (value is CborBool) return value.value;
-    throw ArgumentError('Invalid bool at key $key');
   }
 }

--- a/packages/bc_ur_dart/lib/src/models/sc/sc_sign_request.dart
+++ b/packages/bc_ur_dart/lib/src/models/sc/sc_sign_request.dart
@@ -1,0 +1,197 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:bc_ur_dart/src/registry/registry_item.dart';
+import 'package:bc_ur_dart/src/registry/registry_type.dart';
+import 'package:bc_ur_dart/src/ur.dart';
+import 'package:bc_ur_dart/src/utils/utils.dart';
+import 'package:cbor/cbor.dart';
+
+enum ScSignRequestKeys {
+  zero,
+  uuid,
+  xfp,
+  path,
+  address,
+  publicKey,
+  signingPayloadData,
+  fee,
+  outputs,
+  subtractFee,
+  origin,
+  chain,
+}
+
+class ScSignRequest extends RegistryItem {
+  /// Request id follows the same UUID-bytes convention as other sign requests.
+  /// It is generated lazily when omitted by the caller.
+  Uint8List? uuid;
+  final String xfp;
+  final String path;
+  final String address;
+  final String publicKey;
+
+  /// The value of API response `signing_payload.data`.
+  /// Cold side passes this directly to `ScUnsignedTransaction.fromJson`.
+  final Map<String, dynamic> signingPayloadData;
+
+  /// Optional display metadata from the hot side; not used to build the SC tx.
+  final String? fee;
+  final List<dynamic>? outputs;
+  final bool? subtractFee;
+  final String? origin;
+  final String chain;
+
+  ScSignRequest({
+    this.uuid,
+    required this.xfp,
+    required this.path,
+    required this.address,
+    required this.publicKey,
+    required this.signingPayloadData,
+    this.fee,
+    this.outputs,
+    this.subtractFee,
+    this.origin,
+    this.chain = '',
+  });
+
+  Uint8List getRequestId() => uuid ??= generateUuid();
+  String getRequestIdString() => uuidStringify(getRequestId());
+
+  @override
+  RegistryType getRegistryType() => RegistryType.SC_SIGN_REQUEST;
+
+  @override
+  CborValue toCborValue() {
+    final Map<CborValue, CborValue> map = {
+      CborSmallInt(ScSignRequestKeys.uuid.index): cborBytes(
+        getRequestId(),
+        tags: [RegistryType.UUID.tag],
+      ),
+      CborSmallInt(ScSignRequestKeys.xfp.index): CborString(xfp),
+      CborSmallInt(ScSignRequestKeys.path.index): CborString(path),
+      CborSmallInt(ScSignRequestKeys.address.index): CborString(address),
+      CborSmallInt(ScSignRequestKeys.publicKey.index): CborString(publicKey),
+      CborSmallInt(ScSignRequestKeys.signingPayloadData.index): cborBytes(_jsonBytes(signingPayloadData)),
+    };
+
+    if (origin != null) {
+      map[CborSmallInt(ScSignRequestKeys.origin.index)] = CborString(origin!);
+    }
+    if (fee != null) {
+      map[CborSmallInt(ScSignRequestKeys.fee.index)] = CborString(fee!);
+    }
+    if (outputs != null) {
+      map[CborSmallInt(ScSignRequestKeys.outputs.index)] = cborBytes(_jsonBytes(outputs));
+    }
+    if (subtractFee != null) {
+      map[CborSmallInt(ScSignRequestKeys.subtractFee.index)] = CborBool(subtractFee!);
+    }
+    if (chain.isNotEmpty) {
+      map[CborSmallInt(ScSignRequestKeys.chain.index)] = CborString(chain);
+    }
+
+    return CborMap(map);
+  }
+
+  @override
+  RegistryItem decodeFromCbor(CborMap map) {
+    return ScSignRequest(
+      uuid: RegistryItem.readBytes(map, ScSignRequestKeys.uuid.index),
+      xfp: _readText(map, ScSignRequestKeys.xfp.index),
+      path: _readText(map, ScSignRequestKeys.path.index),
+      address: _readText(map, ScSignRequestKeys.address.index),
+      publicKey: _readText(map, ScSignRequestKeys.publicKey.index),
+      signingPayloadData: _readJsonMap(map, ScSignRequestKeys.signingPayloadData.index),
+      fee: RegistryItem.readOptionalText(map, ScSignRequestKeys.fee.index),
+      outputs: _readOptionalJsonList(map, ScSignRequestKeys.outputs.index),
+      subtractFee: _readOptionalBool(map, ScSignRequestKeys.subtractFee.index),
+      origin: RegistryItem.readOptionalText(map, ScSignRequestKeys.origin.index),
+      chain: RegistryItem.readOptionalText(map, ScSignRequestKeys.chain.index) ?? '',
+    );
+  }
+
+  static ScSignRequest fromCBOR(Uint8List cborPayload) {
+    return RegistryItem.fromCBOR<ScSignRequest>(
+      cborPayload,
+      ScSignRequest(
+        xfp: '',
+        path: '',
+        address: '',
+        publicKey: '',
+        signingPayloadData: const {},
+      ),
+    );
+  }
+
+  static ScSignRequest fromUR(UR ur) {
+    if (ur.type.toLowerCase() != RegistryType.SC_SIGN_REQUEST.type) {
+      throw ArgumentError('Invalid UR type for ScSignRequest: ${ur.type}');
+    }
+    return fromCBOR(ur.payload);
+  }
+
+  static UR buildUR({
+    String? requestId,
+    required String xfp,
+    required String path,
+    required String address,
+    required String publicKey,
+    required Map<String, dynamic> signingPayloadData,
+    String? fee,
+    List<dynamic>? outputs,
+    bool? subtractFee,
+    String? origin,
+    String chain = '',
+  }) {
+    return ScSignRequest(
+      uuid: requestId != null ? Uint8List.fromList(uuidParse(requestId)) : null,
+      xfp: xfp,
+      path: path,
+      address: address,
+      publicKey: publicKey,
+      signingPayloadData: signingPayloadData,
+      fee: fee,
+      outputs: outputs,
+      subtractFee: subtractFee,
+      origin: origin,
+      chain: chain,
+    ).toUR();
+  }
+
+  static Uint8List _jsonBytes(Object? value) {
+    return Uint8List.fromList(utf8.encode(jsonEncode(value)));
+  }
+
+  static String _readText(CborMap map, int key) {
+    final value = map[CborSmallInt(key)];
+    if (value is CborString) return value.toString();
+    throw ArgumentError('Invalid text at key $key');
+  }
+
+  static Map<String, dynamic> _readJsonMap(CborMap map, int key) {
+    final value = _readJson(map, key);
+    if (value is Map) return Map<String, dynamic>.from(value);
+    throw ArgumentError('Invalid json map at key $key');
+  }
+
+  static List<dynamic>? _readOptionalJsonList(CborMap map, int key) {
+    if (!RegistryItem.hasKey(map, key)) return null;
+    final value = _readJson(map, key);
+    if (value is List<dynamic>) return value;
+    throw ArgumentError('Invalid json list at key $key');
+  }
+
+  static dynamic _readJson(CborMap map, int key) {
+    final bytes = RegistryItem.readBytes(map, key);
+    return jsonDecode(utf8.decode(bytes));
+  }
+
+  static bool? _readOptionalBool(CborMap map, int key) {
+    if (!RegistryItem.hasKey(map, key)) return null;
+    final value = map[CborSmallInt(key)];
+    if (value is CborBool) return value.value;
+    throw ArgumentError('Invalid bool at key $key');
+  }
+}

--- a/packages/bc_ur_dart/lib/src/models/sc/sc_sign_request.dart
+++ b/packages/bc_ur_dart/lib/src/models/sc/sc_sign_request.dart
@@ -102,10 +102,10 @@ class ScSignRequest extends RegistryItem {
   RegistryItem decodeFromCbor(CborMap map) {
     return ScSignRequest(
       uuid: RegistryItem.readBytes(map, ScSignRequestKeys.uuid.index),
-      xfp: _readText(map, ScSignRequestKeys.xfp.index),
-      path: _readText(map, ScSignRequestKeys.path.index),
-      address: _readText(map, ScSignRequestKeys.address.index),
-      publicKey: _readText(map, ScSignRequestKeys.publicKey.index),
+      xfp: RegistryItem.readText(map, ScSignRequestKeys.xfp.index),
+      path: RegistryItem.readText(map, ScSignRequestKeys.path.index),
+      address: RegistryItem.readText(map, ScSignRequestKeys.address.index),
+      publicKey: RegistryItem.readText(map, ScSignRequestKeys.publicKey.index),
       signingPayloadData: RegistryItem.readJsonMap(map, ScSignRequestKeys.signingPayloadData.index),
       fee: RegistryItem.readOptionalText(map, ScSignRequestKeys.fee.index),
       outputs: RegistryItem.readOptionalJsonList(map, ScSignRequestKeys.outputs.index),
@@ -161,11 +161,5 @@ class ScSignRequest extends RegistryItem {
       chain: chain,
       crossChainFee: crossChainFee,
     ).toUR();
-  }
-
-  static String _readText(CborMap map, int key) {
-    final value = map[CborSmallInt(key)];
-    if (value is CborString) return value.toString();
-    throw ArgumentError('Invalid text at key $key');
   }
 }

--- a/packages/bc_ur_dart/lib/src/models/sc/sc_sign_request.dart
+++ b/packages/bc_ur_dart/lib/src/models/sc/sc_sign_request.dart
@@ -18,6 +18,8 @@ enum ScSignRequestKeys {
   outputs,
   origin,
   chain,
+  // Appended at the end to keep existing CBOR key indices stable / backward compatible.
+  crossChainFee,
 }
 
 class ScSignRequest extends RegistryItem {
@@ -39,6 +41,10 @@ class ScSignRequest extends RegistryItem {
   final String? origin;
   final String chain;
 
+  /// Bridge platform service fee (display units, e.g. `0.3`). Display metadata
+  /// only; the cold side must still verify it against the signed `siacoinOutputs`.
+  final String? crossChainFee;
+
   ScSignRequest({
     this.uuid,
     required this.xfp,
@@ -50,6 +56,7 @@ class ScSignRequest extends RegistryItem {
     this.outputs,
     this.origin,
     this.chain = '',
+    this.crossChainFee,
   });
 
   Uint8List getRequestId() => uuid ??= generateUuid();
@@ -84,6 +91,9 @@ class ScSignRequest extends RegistryItem {
     if (chain.isNotEmpty) {
       map[CborSmallInt(ScSignRequestKeys.chain.index)] = CborString(chain);
     }
+    if (crossChainFee != null) {
+      map[CborSmallInt(ScSignRequestKeys.crossChainFee.index)] = CborString(crossChainFee!);
+    }
 
     return CborMap(map);
   }
@@ -101,6 +111,7 @@ class ScSignRequest extends RegistryItem {
       outputs: RegistryItem.readOptionalJsonList(map, ScSignRequestKeys.outputs.index),
       origin: RegistryItem.readOptionalText(map, ScSignRequestKeys.origin.index),
       chain: RegistryItem.readOptionalText(map, ScSignRequestKeys.chain.index) ?? '',
+      crossChainFee: RegistryItem.readOptionalText(map, ScSignRequestKeys.crossChainFee.index),
     );
   }
 
@@ -135,6 +146,7 @@ class ScSignRequest extends RegistryItem {
     List<dynamic>? outputs,
     String? origin,
     String chain = '',
+    String? crossChainFee,
   }) {
     return ScSignRequest(
       uuid: requestId != null ? Uint8List.fromList(uuidParse(requestId)) : null,
@@ -147,6 +159,7 @@ class ScSignRequest extends RegistryItem {
       outputs: outputs,
       origin: origin,
       chain: chain,
+      crossChainFee: crossChainFee,
     ).toUR();
   }
 

--- a/packages/bc_ur_dart/lib/src/models/sc/sc_signature.dart
+++ b/packages/bc_ur_dart/lib/src/models/sc/sc_signature.dart
@@ -1,0 +1,115 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:bc_ur_dart/src/models/sc/sc_sign_request.dart';
+import 'package:bc_ur_dart/src/registry/registry_item.dart';
+import 'package:bc_ur_dart/src/registry/registry_type.dart';
+import 'package:bc_ur_dart/src/ur.dart';
+import 'package:bc_ur_dart/src/utils/utils.dart';
+import 'package:cbor/cbor.dart';
+
+enum ScSignatureKeys {
+  zero,
+  uuid,
+  broadcastTx,
+  origin,
+}
+
+class ScSignature extends RegistryItem {
+  /// Mirrors the request UUID so the hot side can match the scanned result.
+  Uint8List? uuid;
+
+  /// Direct output of `txData.toBroadcast()` after cold-side signing.
+  final Map<String, dynamic> broadcastTx;
+  final String? origin;
+
+  ScSignature({
+    this.uuid,
+    required this.broadcastTx,
+    this.origin,
+  });
+
+  Uint8List getRequestId() => uuid ??= generateUuid();
+  String getRequestIdString() => uuidStringify(getRequestId());
+
+  @override
+  RegistryType getRegistryType() => RegistryType.SC_SIGNATURE;
+
+  @override
+  CborValue toCborValue() {
+    final Map<CborValue, CborValue> map = {
+      CborSmallInt(ScSignatureKeys.uuid.index): cborBytes(
+        getRequestId(),
+        tags: [RegistryType.UUID.tag],
+      ),
+      CborSmallInt(ScSignatureKeys.broadcastTx.index): cborBytes(_jsonBytes(broadcastTx)),
+    };
+
+    if (origin != null) {
+      map[CborSmallInt(ScSignatureKeys.origin.index)] = CborString(origin!);
+    }
+
+    return CborMap(map);
+  }
+
+  @override
+  RegistryItem decodeFromCbor(CborMap map) {
+    return ScSignature(
+      uuid: RegistryItem.readBytes(map, ScSignatureKeys.uuid.index),
+      broadcastTx: _readJsonMap(map, ScSignatureKeys.broadcastTx.index),
+      origin: RegistryItem.readOptionalText(map, ScSignatureKeys.origin.index),
+    );
+  }
+
+  static ScSignature fromCBOR(Uint8List cborPayload) {
+    return RegistryItem.fromCBOR<ScSignature>(
+      cborPayload,
+      ScSignature(broadcastTx: const {}),
+    );
+  }
+
+  static ScSignature fromUR(UR ur) {
+    if (ur.type.toLowerCase() != RegistryType.SC_SIGNATURE.type) {
+      throw ArgumentError('Invalid UR type for ScSignature: ${ur.type}');
+    }
+    return fromCBOR(ur.payload);
+  }
+
+  static UR buildUR({
+    String? requestId,
+    required Map<String, dynamic> broadcastTx,
+    String? origin,
+  }) {
+    return ScSignature(
+      uuid: requestId != null ? Uint8List.fromList(uuidParse(requestId)) : null,
+      broadcastTx: broadcastTx,
+      origin: origin,
+    ).toUR();
+  }
+
+  static UR fromSignedTx({
+    required ScSignRequest request,
+    required Map<String, dynamic> broadcastTx,
+  }) {
+    return buildUR(
+      requestId: request.getRequestIdString(),
+      broadcastTx: broadcastTx,
+      origin: request.origin,
+    );
+  }
+
+  static Uint8List _jsonBytes(Object? value) {
+    return Uint8List.fromList(utf8.encode(jsonEncode(value)));
+  }
+
+  static Map<String, dynamic> _readJsonMap(CborMap map, int key) {
+    final value = _readJson(map, key);
+    if (value is Map) return Map<String, dynamic>.from(value);
+    throw ArgumentError('Invalid json map at key $key');
+  }
+
+  static dynamic _readJson(CborMap map, int key) {
+    final bytes = RegistryItem.readBytes(map, key);
+    return jsonDecode(utf8.decode(bytes));
+  }
+}

--- a/packages/bc_ur_dart/lib/src/models/sc/sc_signature.dart
+++ b/packages/bc_ur_dart/lib/src/models/sc/sc_signature.dart
@@ -1,4 +1,3 @@
-import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:bc_ur_dart/src/models/sc/sc_sign_request.dart';
@@ -42,7 +41,7 @@ class ScSignature extends RegistryItem {
         getRequestId(),
         tags: [RegistryType.UUID.tag],
       ),
-      CborSmallInt(ScSignatureKeys.broadcastTx.index): cborBytes(_jsonBytes(broadcastTx)),
+      CborSmallInt(ScSignatureKeys.broadcastTx.index): cborBytes(RegistryItem.jsonBytes(broadcastTx)),
     };
 
     if (origin != null) {
@@ -56,7 +55,7 @@ class ScSignature extends RegistryItem {
   RegistryItem decodeFromCbor(CborMap map) {
     return ScSignature(
       uuid: RegistryItem.readBytes(map, ScSignatureKeys.uuid.index),
-      broadcastTx: _readJsonMap(map, ScSignatureKeys.broadcastTx.index),
+      broadcastTx: RegistryItem.readJsonMap(map, ScSignatureKeys.broadcastTx.index),
       origin: RegistryItem.readOptionalText(map, ScSignatureKeys.origin.index),
     );
   }
@@ -98,18 +97,4 @@ class ScSignature extends RegistryItem {
     );
   }
 
-  static Uint8List _jsonBytes(Object? value) {
-    return Uint8List.fromList(utf8.encode(jsonEncode(value)));
-  }
-
-  static Map<String, dynamic> _readJsonMap(CborMap map, int key) {
-    final value = _readJson(map, key);
-    if (value is Map) return Map<String, dynamic>.from(value);
-    throw ArgumentError('Invalid json map at key $key');
-  }
-
-  static dynamic _readJson(CborMap map, int key) {
-    final bytes = RegistryItem.readBytes(map, key);
-    return jsonDecode(utf8.decode(bytes));
-  }
 }

--- a/packages/bc_ur_dart/lib/src/registry/registry_item.dart
+++ b/packages/bc_ur_dart/lib/src/registry/registry_item.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:bc_ur_dart/bc_ur_dart.dart';
@@ -130,6 +131,28 @@ abstract class RegistryItem {
     final v = map[CborSmallInt(key)];
     if (v is CborString) return v.toString();
     throw ArgumentError("Invalid text at key $key");
+  }
+
+  static Uint8List jsonBytes(Object? value) {
+    return Uint8List.fromList(utf8.encode(jsonEncode(value)));
+  }
+
+  static dynamic readJson(CborMap map, int key) {
+    final bytes = readBytes(map, key);
+    return jsonDecode(utf8.decode(bytes));
+  }
+
+  static Map<String, dynamic> readJsonMap(CborMap map, int key) {
+    final value = readJson(map, key);
+    if (value is Map) return Map<String, dynamic>.from(value);
+    throw ArgumentError('Invalid json map at key $key');
+  }
+
+  static List<dynamic>? readOptionalJsonList(CborMap map, int key) {
+    if (!hasKey(map, key)) return null;
+    final value = readJson(map, key);
+    if (value is List<dynamic>) return value;
+    throw ArgumentError('Invalid json list at key $key');
   }
 
   static bool hasKey(CborMap map, int key) {

--- a/packages/bc_ur_dart/lib/src/registry/registry_item.dart
+++ b/packages/bc_ur_dart/lib/src/registry/registry_item.dart
@@ -133,6 +133,11 @@ abstract class RegistryItem {
     throw ArgumentError("Invalid text at key $key");
   }
 
+  static String readText(CborMap map, int key) {
+    return readOptionalText(map, key) ??
+        (throw ArgumentError("Missing text at key $key"));
+  }
+
   static Uint8List jsonBytes(Object? value) {
     return Uint8List.fromList(utf8.encode(jsonEncode(value)));
   }
@@ -168,12 +173,14 @@ abstract class RegistryItem {
 
     if (value is CborMap) {
       // 标准路径：tagged CborMap 内联嵌套
-      return CryptoKeypath(sourceFingerprintEndian: sourceFingerprintEndian).decodeFromCbor(value) as CryptoKeypath;
+      return CryptoKeypath(sourceFingerprintEndian: sourceFingerprintEndian)
+          .decodeFromCbor(value) as CryptoKeypath;
     }
 
     if (value is CborBytes) {
       // 防御路径：兼容旧版 CborBytes 格式
-      return CryptoKeypath.fromCBOR(Uint8List.fromList(value.bytes), sourceFingerprintEndian: sourceFingerprintEndian);
+      return CryptoKeypath.fromCBOR(Uint8List.fromList(value.bytes),
+          sourceFingerprintEndian: sourceFingerprintEndian);
     }
 
     throw ArgumentError(

--- a/packages/bc_ur_dart/lib/src/registry/registry_type.dart
+++ b/packages/bc_ur_dart/lib/src/registry/registry_type.dart
@@ -56,4 +56,7 @@ class RegistryType {
 
   static const RegistryType ALPH_SIGN_REQUEST = RegistryType("alph-sign-request", 8110);
   static const RegistryType ALPH_SIGNATURE = RegistryType("alph-signature", 8111);
+
+  static const RegistryType SC_SIGN_REQUEST = RegistryType("sc-sign-request", 8120);
+  static const RegistryType SC_SIGNATURE = RegistryType("sc-signature", 8121);
 }

--- a/packages/bc_ur_dart/test/models/crypto_hdkey_ur_test.dart
+++ b/packages/bc_ur_dart/test/models/crypto_hdkey_ur_test.dart
@@ -1,14 +1,19 @@
 import 'dart:typed_data';
 
+import 'package:bc_ur_dart/src/models/key/crypto_coin_info.dart';
 import 'package:bc_ur_dart/src/models/key/crypto_hdkey.dart';
+import 'package:bc_ur_dart/src/registry/registry_type.dart';
 import 'package:bc_ur_dart/src/ur.dart';
+import 'package:bc_ur_dart/src/utils/utils.dart';
+import 'package:cbor/cbor.dart';
 import 'package:crypto_wallet_util/crypto_utils.dart' show BIP32;
 import 'package:test/test.dart';
 
 void main() {
   group('CryptoHDKeyUR', () {
     test('should create from wallet correctly', () {
-      final wallet = BIP32.fromBase58('xpub6DWambFddujzpn3rhPxjGgCTB15BMSx7yoQPzDoAS7rYnputj3srC8QnRRu24qu3Q9dKytTkAGrsbLvmQD6KT2rNhFFoA3EZLpYxyJ3mNfB');
+      final wallet = BIP32.fromBase58(
+          'xpub6DWambFddujzpn3rhPxjGgCTB15BMSx7yoQPzDoAS7rYnputj3srC8QnRRu24qu3Q9dKytTkAGrsbLvmQD6KT2rNhFFoA3EZLpYxyJ3mNfB');
       final path = "m/44'/60'/0'";
       final name = 'test-wallet';
 
@@ -39,7 +44,8 @@ void main() {
     });
 
     test('should encode to UR correctly', () {
-      final wallet = BIP32.fromBase58('xpub6DWambFddujzpn3rhPxjGgCTB15BMSx7yoQPzDoAS7rYnputj3srC8QnRRu24qu3Q9dKytTkAGrsbLvmQD6KT2rNhFFoA3EZLpYxyJ3mNfB');
+      final wallet = BIP32.fromBase58(
+          'xpub6DWambFddujzpn3rhPxjGgCTB15BMSx7yoQPzDoAS7rYnputj3srC8QnRRu24qu3Q9dKytTkAGrsbLvmQD6KT2rNhFFoA3EZLpYxyJ3mNfB');
       final path = "m/44'/60'/0'";
       final name = 'test-wallet';
 
@@ -71,8 +77,51 @@ void main() {
       expect(parsed.path, "m/44'/501'/0'");
     });
 
+    test('should reject malformed secp256k1 public keys with chain code', () {
+      final ur = UR.fromCBOR(
+        type: RegistryType.CRYPTO_HDKEY.type,
+        value: CborMap({
+          CborSmallInt(3): CborBytes(Uint8List(33)),
+          CborSmallInt(4): CborBytes(Uint8List(32)),
+          CborSmallInt(5): CryptoCoinInfo(
+            coinType: CoinType.BTC,
+            network: CoinType.MAINNET,
+          ).toCborValue(),
+          CborSmallInt(6): CborMap({
+            CborSmallInt(1): CborList(getPath("m/44'/0'/0'")),
+          }, tags: [
+            304
+          ]),
+          CborSmallInt(9): CborString('bad-btc-wallet'),
+        }),
+      );
+
+      expect(
+        () => CryptoHDKeyUR.fromUR(ur: ur),
+        throwsA(isA<FormatException>()),
+      );
+    });
+
+    test('toString should keep empty keys and JSON escape note', () {
+      final hdkey = CryptoHDKeyUR.fromWallet(
+        name: '',
+        path: "m/44'/501'/0'",
+        publicKey: Uint8List(33),
+        chainCode: Uint8List(32),
+        note: 'line "one"\\two',
+      );
+
+      final parsed = CryptoHDKeyUR.fromUR(ur: UR.decode(hdkey.encode()));
+      final text = parsed.toString();
+
+      expect(text, contains('"name":""'));
+      expect(text, contains('"note":"line \\"one\\"\\\\two"'));
+      expect(text, contains('"childrenPath":""'));
+    });
+
     test('should preserve xfp format marker', () {
-      final wallet = BIP32.fromBase58('xpub6DWambFddujzpn3rhPxjGgCTB15BMSx7yoQPzDoAS7rYnputj3srC8QnRRu24qu3Q9dKytTkAGrsbLvmQD6KT2rNhFFoA3EZLpYxyJ3mNfB');
+      final wallet = BIP32.fromBase58(
+          'xpub6DWambFddujzpn3rhPxjGgCTB15BMSx7yoQPzDoAS7rYnputj3srC8QnRRu24qu3Q9dKytTkAGrsbLvmQD6KT2rNhFFoA3EZLpYxyJ3mNfB');
       final hdkey = CryptoHDKeyUR.fromWallet(
         name: 'test-wallet',
         path: "m/44'/60'/0'",

--- a/packages/bc_ur_dart/test/models/crypto_hdkey_ur_test.dart
+++ b/packages/bc_ur_dart/test/models/crypto_hdkey_ur_test.dart
@@ -55,24 +55,20 @@ void main() {
       expect(urString, isNotEmpty);
     });
 
-    test('should wrap invalid public key errors as format exceptions', () {
+    test('should preserve non secp256k1 public keys with chain code', () {
       final ur = CryptoHDKeyUR.fromWallet(
-        name: 'invalid-wallet',
-        path: "m/44'/60'/0'",
+        name: 'ed25519-wallet',
+        path: "m/44'/501'/0'",
         publicKey: Uint8List(33),
         chainCode: Uint8List(32),
       );
 
-      expect(
-        () => CryptoHDKeyUR.fromUR(ur: UR.decode(ur.encode())),
-        throwsA(
-          isA<FormatException>().having(
-            (e) => e.message,
-            'message',
-            contains('Invalid crypto-hdkey public key or chain code'),
-          ),
-        ),
-      );
+      final parsed = CryptoHDKeyUR.fromUR(ur: UR.decode(ur.encode()));
+
+      expect(parsed.wallet, isNull);
+      expect(parsed.publicKey, Uint8List(33));
+      expect(parsed.chainCode, Uint8List(32));
+      expect(parsed.path, "m/44'/501'/0'");
     });
 
     test('should preserve xfp format marker', () {

--- a/packages/bc_ur_dart/test/models/crypto_multi_accounts_test.dart
+++ b/packages/bc_ur_dart/test/models/crypto_multi_accounts_test.dart
@@ -5,7 +5,7 @@ import 'package:test/test.dart';
 
 void main() {
   group('CryptoMultiAccountsUR', () {
-    test('wraps invalid hdkey entries as format exceptions', () {
+    test('preserves non secp256k1 hdkey entries without rejecting the account set', () {
       final ur = CryptoMultiAccountsUR.fromWallet(
         masterFingerprint: BigInt.from(0x21d0ae26),
         device: 'FxWallet',
@@ -21,16 +21,13 @@ void main() {
         xfpFormat: 'canonical',
       );
 
-      expect(
-        () => CryptoMultiAccountsUR.fromUR(ur: UR.decode(ur.encode())),
-        throwsA(
-          isA<FormatException>().having(
-            (e) => e.message,
-            'message',
-            contains('Invalid crypto-multi-accounts key entry at index 0'),
-          ),
-        ),
-      );
+      final parsed = CryptoMultiAccountsUR.fromUR(ur: UR.decode(ur.encode()));
+      final chain = parsed.chains.single;
+
+      expect(chain.wallet, isNull);
+      expect(chain.publicKey, Uint8List(33));
+      expect(chain.chainCode, Uint8List(32));
+      expect(chain.path, "m/44'/60'/0'");
     });
   });
 }

--- a/packages/bc_ur_dart/test/models/crypto_multi_accounts_test.dart
+++ b/packages/bc_ur_dart/test/models/crypto_multi_accounts_test.dart
@@ -5,15 +5,17 @@ import 'package:test/test.dart';
 
 void main() {
   group('CryptoMultiAccountsUR', () {
-    test('preserves non secp256k1 hdkey entries without rejecting the account set', () {
+    test(
+        'preserves non secp256k1 hdkey entries without rejecting the account set',
+        () {
       final ur = CryptoMultiAccountsUR.fromWallet(
         masterFingerprint: BigInt.from(0x21d0ae26),
         device: 'FxWallet',
         walletName: 'FxWallet',
         chains: [
           CryptoHDKeyUR.fromWallet(
-            name: 'invalid-wallet',
-            path: "m/44'/60'/0'",
+            name: 'sol-wallet',
+            path: "m/44'/501'/0'",
             publicKey: Uint8List(33),
             chainCode: Uint8List(32),
           ),
@@ -27,7 +29,7 @@ void main() {
       expect(chain.wallet, isNull);
       expect(chain.publicKey, Uint8List(33));
       expect(chain.chainCode, Uint8List(32));
-      expect(chain.path, "m/44'/60'/0'");
+      expect(chain.path, "m/44'/501'/0'");
     });
   });
 }

--- a/packages/bc_ur_dart/test/models/keystone_bch_sign_request_test.dart
+++ b/packages/bc_ur_dart/test/models/keystone_bch_sign_request_test.dart
@@ -1,0 +1,68 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:bc_ur_dart/bc_ur_dart.dart';
+import 'package:bc_ur_dart/src/gen/keystone/base.pb.dart';
+import 'package:bc_ur_dart/src/gen/keystone/transaction.pb.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('BchSignRequestUR', () {
+    test('keeps BCH as the default Keystone UTXO coin code', () {
+      final ur = _buildRequest();
+      final signTx = _decodeSignTransaction(ur);
+
+      expect(signTx.coinCode, 'BCH');
+      expect(signTx.decimal, 8);
+      expect(signTx.whichTransaction(), SignTransaction_Transaction.bchTx);
+    });
+
+    test('builds Keystone DOGE request with DOGE coin code', () {
+      final ur = _buildRequest(coinCode: 'DOGE');
+      final signTx = _decodeSignTransaction(ur);
+
+      expect(ur.type, RegistryType.KEYSTONE_SIGN_REQUEST.type);
+      expect(signTx.coinCode, 'DOGE');
+      expect(signTx.hdPath, "m/44'/3'/0'/0/0");
+      expect(signTx.decimal, 8);
+      expect(signTx.whichTransaction(), SignTransaction_Transaction.bchTx);
+      expect(signTx.bchTx.inputs.single.ownerKeyPath, "m/44'/3'/0'/0/0");
+      expect(signTx.bchTx.outputs.single.address, 'D8Bq7z8rJbJ6z8G4m7Zx8Q9x2n3P4q5R6S');
+    });
+  });
+}
+
+BchSignRequestUR _buildRequest({String coinCode = 'BCH'}) {
+  return BchSignRequestUR.fromTransaction(
+    inputs: [
+      BchInput(
+        hash: '00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff',
+        index: 1,
+        value: 100000000,
+        pubkey: '03019967bdd2d94ee29f00fb77eb57064afb1c56fcc7d1fdfd0ae9c9c6d65128bd',
+        ownerKeyPath: "m/44'/3'/0'/0/0",
+      ),
+    ],
+    outputs: [
+      BchOutput(
+        address: 'D8Bq7z8rJbJ6z8G4m7Zx8Q9x2n3P4q5R6S',
+        value: 99900000,
+      ),
+    ],
+    fee: 100000,
+    xfp: 'd4d0b746',
+    hdPath: "m/44'/3'/0'/0/0",
+    requestId: 'doge-request-id',
+    origin: 'FxWallet',
+    coinCode: coinCode,
+  );
+}
+
+SignTransaction _decodeSignTransaction(UR ur) {
+  final data = ur.decodeCBOR() as CborMap;
+  final signDataBytes = Uint8List.fromList(
+    (data[CborSmallInt(1)] as CborBytes).bytes,
+  );
+  final base = Base.fromBuffer(GZipCodec().decode(signDataBytes));
+  return base.payloadData.signTx;
+}

--- a/packages/bc_ur_dart/test/models/sc_sign_request_test.dart
+++ b/packages/bc_ur_dart/test/models/sc_sign_request_test.dart
@@ -43,6 +43,7 @@ void main() {
         ],
         origin: 'fxwallet',
         chain: 'scp',
+        crossChainFee: '0.3',
       );
 
       expect(ur.type, RegistryType.SC_SIGN_REQUEST.type);
@@ -58,6 +59,20 @@ void main() {
       expect(request.outputs?.first['amount'], '123456789012345678901234');
       expect(request.origin, 'fxwallet');
       expect(request.chain, 'scp');
+      expect(request.crossChainFee, '0.3');
+    });
+
+    test('cross-chain fee is omitted when not provided', () {
+      final ur = ScSignRequest.buildUR(
+        xfp: 'A1B2C3D4',
+        path: "m/44'/1991'/0'",
+        address: 'sender-address',
+        publicKey: 'ed25519-public-key',
+        signingPayloadData: const {'siacoinInputs': []},
+      );
+
+      final request = ScSignRequest.fromUR(ur);
+      expect(request.crossChainFee, isNull);
     });
 
     test('round trips signature payload', () {

--- a/packages/bc_ur_dart/test/models/sc_sign_request_test.dart
+++ b/packages/bc_ur_dart/test/models/sc_sign_request_test.dart
@@ -41,7 +41,6 @@ void main() {
         outputs: [
           {'address': 'receiver-address', 'amount': '123456789012345678901234'}
         ],
-        subtractFee: false,
         origin: 'fxwallet',
         chain: 'scp',
       );
@@ -57,7 +56,6 @@ void main() {
       expect(request.signingPayloadData['siacoinOutputs'][0]['value'], '123456789012345678901234');
       expect(request.fee, '1000000000000000000000');
       expect(request.outputs?.first['amount'], '123456789012345678901234');
-      expect(request.subtractFee, isFalse);
       expect(request.origin, 'fxwallet');
       expect(request.chain, 'scp');
     });

--- a/packages/bc_ur_dart/test/models/sc_sign_request_test.dart
+++ b/packages/bc_ur_dart/test/models/sc_sign_request_test.dart
@@ -1,0 +1,131 @@
+import 'dart:typed_data';
+
+import 'package:bc_ur_dart/bc_ur_dart.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('SC sign request UR', () {
+    test('round trips request payload', () {
+      final signingPayloadData = {
+        'siacoinInputs': [
+          {
+            'parent': {
+              'id': 'input-id',
+              'siacoinOutput': {
+                'value': '1000000000000000000000000',
+                'address': 'sender-address',
+              },
+            },
+            'satisfiedPolicy': {
+              'policy': {'type': 'pk', 'key': 'ed25519-public-key'},
+              'signatures': [],
+            },
+          }
+        ],
+        'siacoinOutputs': [
+          {
+            'value': '123456789012345678901234',
+            'address': 'receiver-address',
+          }
+        ],
+      };
+
+      final ur = ScSignRequest.buildUR(
+        requestId: '123e4567-e89b-12d3-a456-426614174000',
+        xfp: 'A1B2C3D4',
+        path: "m/44'/1991'/0'",
+        address: 'sender-address',
+        publicKey: 'ed25519-public-key',
+        signingPayloadData: signingPayloadData,
+        fee: '1000000000000000000000',
+        outputs: [
+          {'address': 'receiver-address', 'amount': '123456789012345678901234'}
+        ],
+        subtractFee: false,
+        origin: 'fxwallet',
+        chain: 'scp',
+      );
+
+      expect(ur.type, RegistryType.SC_SIGN_REQUEST.type);
+
+      final request = ScSignRequest.fromUR(ur);
+      expect(request.getRequestIdString(), '123e4567-e89b-12d3-a456-426614174000');
+      expect(request.xfp, 'A1B2C3D4');
+      expect(request.path, "m/44'/1991'/0'");
+      expect(request.address, 'sender-address');
+      expect(request.publicKey, 'ed25519-public-key');
+      expect(request.signingPayloadData['siacoinOutputs'][0]['value'], '123456789012345678901234');
+      expect(request.fee, '1000000000000000000000');
+      expect(request.outputs?.first['amount'], '123456789012345678901234');
+      expect(request.subtractFee, isFalse);
+      expect(request.origin, 'fxwallet');
+      expect(request.chain, 'scp');
+    });
+
+    test('round trips signature payload', () {
+      final ur = ScSignature.buildUR(
+        requestId: '123e4567-e89b-12d3-a456-426614174000',
+        broadcastTx: {
+          'transactions': [
+            {
+              'siacoinInputs': [
+                {
+                  'satisfiedPolicy': {
+                    'signatures': ['signature-bytes']
+                  }
+                }
+              ],
+              'siacoinOutputs': [
+                {'value': '123456789012345678901234', 'address': 'receiver-address'}
+              ],
+            }
+          ]
+        },
+        origin: 'fxwallet',
+      );
+
+      expect(ur.type, RegistryType.SC_SIGNATURE.type);
+
+      final signature = ScSignature.fromUR(ur);
+      expect(signature.getRequestIdString(), '123e4567-e89b-12d3-a456-426614174000');
+      expect(signature.broadcastTx['transactions'][0]['siacoinOutputs'][0]['value'], '123456789012345678901234');
+      expect(signature.origin, 'fxwallet');
+    });
+
+    test('builds signature from signed tx result', () {
+      final request = ScSignRequest(
+        uuid: Uint8List.fromList(uuidParse('123e4567-e89b-12d3-a456-426614174000')),
+        xfp: 'A1B2C3D4',
+        path: "m/44'/1991'/0'",
+        address: 'sender-address',
+        publicKey: 'ed25519-public-key',
+        signingPayloadData: const {'siacoinInputs': []},
+        origin: 'fxwallet',
+      );
+
+      final ur = ScSignature.fromSignedTx(
+        request: request,
+        broadcastTx: const {'transactions': []},
+      );
+
+      final signature = ScSignature.fromUR(ur);
+      expect(signature.getRequestIdString(), request.getRequestIdString());
+      expect(signature.broadcastTx['transactions'], isEmpty);
+      expect(signature.origin, request.origin);
+    });
+
+    test('auto generates request id when omitted', () {
+      final ur = ScSignRequest.buildUR(
+        xfp: 'A1B2C3D4',
+        path: "m/44'/1991'/0'",
+        address: 'sender-address',
+        publicKey: 'ed25519-public-key',
+        signingPayloadData: const {'siacoinInputs': []},
+      );
+
+      final request = ScSignRequest.fromUR(ur);
+      expect(request.getRequestId(), hasLength(16));
+      expect(request.getRequestIdString(), isNotEmpty);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add SC sign request/signature UR models and registry exports
- support multi-coin Keystone UTXO signing via coinCode while keeping BCH default behavior
- preserve non-secp256k1 HD key entries and shared toString field handling
- include SC cross-chain fee metadata support

## Validation
- dart test in packages/bc_ur_dart

## Notes
- This PR intentionally excludes demo/bc_ur_dart demo-folder changes; those should be handled in the follow-up demo PR after this core feature lands.