### PR TITLE
feat(aleo_dart): parameter provisioning + checked-proving orchestration (Phase 4 PR2, part 2b)

### DIFF
--- a/packages/aleo_dart/lib/aleo.dart
+++ b/packages/aleo_dart/lib/aleo.dart
@@ -3,6 +3,7 @@ library aleo_dart;
 export 'package:aleo_dart/src/aleo_account.dart';
 export 'package:aleo_dart/src/aleo_node.dart';
 export 'package:aleo_dart/src/aleo_programs.dart';
+export 'package:aleo_dart/src/aleo_provisioning.dart';
 export 'package:aleo_dart/src/aleo_record.dart';
 export 'package:aleo_dart/src/aleo_transaction.dart';
 export 'package:aleo_dart/src/rust_lib/dyLib.dart';

--- a/packages/aleo_dart/lib/src/aleo_programs.dart
+++ b/packages/aleo_dart/lib/src/aleo_programs.dart
@@ -671,28 +671,6 @@ class AleoProgram {
     return value;
   }
 
-  Future<void> downloadProvingKey({updateKey = false}) async {
-    late final rootPath;
-    if (Platform.isLinux) {
-      var rootDirectory = Directory.current;
-      var parts = path.split(rootDirectory.path);
-      rootPath = parts[0] + parts[1] + '/' + parts[2] + '/';
-    }
-    final savePath = rootPath + '.aleo/resources/inclusion.prover.cd85cc5';
-
-    final file = File(savePath);
-
-    if (file.existsSync() || !updateKey) {
-      return;
-    } else {
-      print('start downloading');
-      const downLoadUrl =
-          'https://s3-us-west-1.amazonaws.com/testnet.parameters/inclusion.prover.cd85cc5';
-      await downloadFile(downLoadUrl, savePath);
-    }
-    return;
-  }
-
   String modifyAuthorization(
     String authorizationJson,
   ) {
@@ -714,30 +692,3 @@ class AleoProgram {
   }
 }
 
-Future<void> downloadFile(String url, String savePath) async {
-  final httpClient = HttpClient();
-  final request =
-      await httpClient.getUrl(Uri.parse(url)).timeout(Duration(minutes: 3));
-  final response = await request.close();
-  final file = File(savePath);
-  await file.create(recursive: true);
-  final output = file.openWrite();
-
-  int totalBytes = response.contentLength;
-  int receivedBytes = 0;
-
-  await response.forEach((data) {
-    output.add(data);
-    receivedBytes += data.length;
-    print('downing: ${(receivedBytes / totalBytes * 100).toStringAsFixed(2)}%');
-  }).timeout(Duration(minutes: 3), onTimeout: () {
-    throw Exception('timeout');
-  }).catchError((error) {
-    print('downing error: $error');
-    output.close();
-    file.deleteSync();
-    throw error;
-  });
-
-  await output.close();
-}

--- a/packages/aleo_dart/lib/src/aleo_programs.dart
+++ b/packages/aleo_dart/lib/src/aleo_programs.dart
@@ -689,4 +689,3 @@ class AleoProgram {
     return json.encode(data);
   }
 }
-

--- a/packages/aleo_dart/lib/src/aleo_programs.dart
+++ b/packages/aleo_dart/lib/src/aleo_programs.dart
@@ -338,8 +338,8 @@ class AleoProgram {
       String execution_raw) async {
     AleoUtils.checkAmount(fee_credits, 'fee');
     final height = await _node(url_raw).latestHeight();
-    return executionFeeAuthorizationStatic(private_key_raw, execution_raw,
-        fee_credits, fee_record_raw, '', height);
+    return executionFeeAuthorizationStatic(
+        private_key_raw, execution_raw, fee_credits, fee_record_raw, '', height);
   }
 
   /// Broadcasts a serialized transaction. `transfer_type_raw` is unused (kept
@@ -524,8 +524,8 @@ class AleoProgram {
     try {
       return takeNativeString(
           programsRustFFI.dyLib,
-          programsRustFFI.executionFeeAuthorizationStatic(private_key,
-              execution, fee_credits, fee_record, sources, height));
+          programsRustFFI.executionFeeAuthorizationStatic(
+              private_key, execution, fee_credits, fee_record, sources, height));
     } finally {
       freeAll([private_key, execution, fee_record, sources]);
     }
@@ -561,8 +561,7 @@ class AleoProgram {
     final execution = dartStrToC(execution_raw);
     final programSources = dartStrToC(sources);
     try {
-      return programsRustFFI.getBaseFeeStatic(
-          execution, programSources, height);
+      return programsRustFFI.getBaseFeeStatic(execution, programSources, height);
     } finally {
       freeAll([execution, programSources]);
     }
@@ -626,7 +625,8 @@ class AleoProgram {
       AleoNode node, String authorization, int height) async {
     final commitments = requiredCommitments(authorization);
     final paths = await node.statePaths(commitments);
-    final publicRoot = commitments.isEmpty ? await node.latestStateRoot() : '';
+    final publicRoot =
+        commitments.isEmpty ? await node.latestStateRoot() : '';
     return _require(
         await executeProofStatic(authorization, height, paths, publicRoot),
         'execution proof');
@@ -638,10 +638,10 @@ class AleoProgram {
       AleoNode node, String feeAuthorization, int height) async {
     final commitments = requiredCommitments(feeAuthorization);
     final paths = await node.statePaths(commitments);
-    final publicRoot = commitments.isEmpty ? await node.latestStateRoot() : '';
+    final publicRoot =
+        commitments.isEmpty ? await node.latestStateRoot() : '';
     return _require(
-        await executeFeeProofStatic(
-            feeAuthorization, height, paths, publicRoot),
+        await executeFeeProofStatic(feeAuthorization, height, paths, publicRoot),
         'fee proof');
   }
 
@@ -651,7 +651,8 @@ class AleoProgram {
       AleoNode node, String authorization, String sources, int height) async {
     final commitments = requiredCommitments(authorization);
     final paths = await node.statePaths(commitments);
-    final publicRoot = commitments.isEmpty ? await node.latestStateRoot() : '';
+    final publicRoot =
+        commitments.isEmpty ? await node.latestStateRoot() : '';
     return _require(
         await executeProgramProofStatic(
             authorization, sources, height, paths, publicRoot),
@@ -688,3 +689,4 @@ class AleoProgram {
     return json.encode(data);
   }
 }
+

--- a/packages/aleo_dart/lib/src/aleo_programs.dart
+++ b/packages/aleo_dart/lib/src/aleo_programs.dart
@@ -1,8 +1,6 @@
-import 'dart:io';
 import 'dart:convert';
 
 import 'package:dio/dio.dart';
-import 'package:path/path.dart' as path;
 
 import 'package:aleo_dart/src/aleo_node.dart';
 import 'package:aleo_dart/src/rust_lib/programs_rust_ffi.dart';
@@ -340,8 +338,8 @@ class AleoProgram {
       String execution_raw) async {
     AleoUtils.checkAmount(fee_credits, 'fee');
     final height = await _node(url_raw).latestHeight();
-    return executionFeeAuthorizationStatic(
-        private_key_raw, execution_raw, fee_credits, fee_record_raw, '', height);
+    return executionFeeAuthorizationStatic(private_key_raw, execution_raw,
+        fee_credits, fee_record_raw, '', height);
   }
 
   /// Broadcasts a serialized transaction. `transfer_type_raw` is unused (kept
@@ -526,8 +524,8 @@ class AleoProgram {
     try {
       return takeNativeString(
           programsRustFFI.dyLib,
-          programsRustFFI.executionFeeAuthorizationStatic(
-              private_key, execution, fee_credits, fee_record, sources, height));
+          programsRustFFI.executionFeeAuthorizationStatic(private_key,
+              execution, fee_credits, fee_record, sources, height));
     } finally {
       freeAll([private_key, execution, fee_record, sources]);
     }
@@ -563,7 +561,8 @@ class AleoProgram {
     final execution = dartStrToC(execution_raw);
     final programSources = dartStrToC(sources);
     try {
-      return programsRustFFI.getBaseFeeStatic(execution, programSources, height);
+      return programsRustFFI.getBaseFeeStatic(
+          execution, programSources, height);
     } finally {
       freeAll([execution, programSources]);
     }
@@ -627,8 +626,7 @@ class AleoProgram {
       AleoNode node, String authorization, int height) async {
     final commitments = requiredCommitments(authorization);
     final paths = await node.statePaths(commitments);
-    final publicRoot =
-        commitments.isEmpty ? await node.latestStateRoot() : '';
+    final publicRoot = commitments.isEmpty ? await node.latestStateRoot() : '';
     return _require(
         await executeProofStatic(authorization, height, paths, publicRoot),
         'execution proof');
@@ -640,10 +638,10 @@ class AleoProgram {
       AleoNode node, String feeAuthorization, int height) async {
     final commitments = requiredCommitments(feeAuthorization);
     final paths = await node.statePaths(commitments);
-    final publicRoot =
-        commitments.isEmpty ? await node.latestStateRoot() : '';
+    final publicRoot = commitments.isEmpty ? await node.latestStateRoot() : '';
     return _require(
-        await executeFeeProofStatic(feeAuthorization, height, paths, publicRoot),
+        await executeFeeProofStatic(
+            feeAuthorization, height, paths, publicRoot),
         'fee proof');
   }
 
@@ -653,8 +651,7 @@ class AleoProgram {
       AleoNode node, String authorization, String sources, int height) async {
     final commitments = requiredCommitments(authorization);
     final paths = await node.statePaths(commitments);
-    final publicRoot =
-        commitments.isEmpty ? await node.latestStateRoot() : '';
+    final publicRoot = commitments.isEmpty ? await node.latestStateRoot() : '';
     return _require(
         await executeProgramProofStatic(
             authorization, sources, height, paths, publicRoot),
@@ -691,4 +688,3 @@ class AleoProgram {
     return json.encode(data);
   }
 }
-

--- a/packages/aleo_dart/lib/src/aleo_provisioning.dart
+++ b/packages/aleo_dart/lib/src/aleo_provisioning.dart
@@ -79,10 +79,22 @@ class ParameterProvisioner {
   final Directory paramDir;
 
   final Dio _dio;
+  final bool _ownsDio;
   bool _dirSet = false;
 
-  /// Process-global poison latch (Contract 3). Once a `restart_required` is seen,
-  /// every provisioner fail-fasts until the OS process restarts.
+  /// Poison latch (§8 Contract 3). Tripped when a checked-proving call returns
+  /// `restart_required` (a corrupt/missing parameter poisoned snarkVM's
+  /// process-global static, which only an OS-process restart clears).
+  ///
+  /// This `static` is **isolate-local**, so it is only a fast-path: a long-lived
+  /// isolate stops touching the FFI after the first poison. It is NOT the
+  /// cross-isolate guarantee — the authoritative guard is the Rust side. Every
+  /// checked export is `catch_unwind`-wrapped, so a fresh isolate that calls the
+  /// already-poisoned FFI gets `restart_required` back cheaply (a poisoned
+  /// `lazy_static` re-deref is an immediate caught panic, not a re-download) and
+  /// self-latches. Proving therefore never crashes and never silently succeeds
+  /// after a poison, in any isolate; it just isn't byte-for-byte FFI-free across
+  /// isolates.
   static bool _provingDisabled = false;
   static bool get provingDisabled => _provingDisabled;
 
@@ -91,7 +103,8 @@ class ParameterProvisioner {
     this.network,
     this.paramDir, {
     Dio? dio,
-  }) : _dio = dio ??
+  })  : _ownsDio = dio == null,
+        _dio = dio ??
             Dio(BaseOptions(receiveTimeout: const Duration(minutes: 30)));
 
   // ── FFI ────────────────────────────────────────────────────────────────────
@@ -153,6 +166,40 @@ class ParameterProvisioner {
         authorization,
         statePaths,
         publicStateRoot);
+  }
+
+  String _callExecuteProgramProofChecked(
+      String authorization,
+      String programSources,
+      int height,
+      String statePaths,
+      String publicStateRoot) {
+    final fn = _lib.lookupFunction<
+        ffi.Pointer<Utf8> Function(
+            ffi.Pointer<Utf8>,
+            ffi.Pointer<Utf8>,
+            ffi.Pointer<Utf8>,
+            ffi.Uint32,
+            ffi.Pointer<Utf8>,
+            ffi.Pointer<Utf8>),
+        ffi.Pointer<Utf8> Function(
+            ffi.Pointer<Utf8>,
+            ffi.Pointer<Utf8>,
+            ffi.Pointer<Utf8>,
+            int,
+            ffi.Pointer<Utf8>,
+            ffi.Pointer<Utf8>)>('execute_program_proof_checked');
+    final net = network.toNativeUtf8();
+    final auth = authorization.toNativeUtf8();
+    final sources = programSources.toNativeUtf8();
+    final paths = statePaths.toNativeUtf8();
+    final root = publicStateRoot.toNativeUtf8();
+    try {
+      return takeNativeString(
+          _lib, fn(net, auth, sources, height, paths, root));
+    } finally {
+      freeAll([net, auth, sources, paths, root]);
+    }
   }
 
   /// Shared input marshalling for the 4-pointer checked proving exports.
@@ -242,10 +289,17 @@ class ParameterProvisioner {
 
   // ── Download (atomic, single-flight, locked) ────────────────────────────────
 
-  /// In-process per-file mutex. `RandomAccessFile.lock` is POSIX `fcntl`, which
-  /// coordinates ACROSS processes but not within one (a process never conflicts
-  /// with its own locks, and isolates don't share statics either way), so
-  /// same-isolate concurrent provisions of one file are serialized here.
+  /// Per-file mutex within ONE isolate. `RandomAccessFile.lock` is POSIX `fcntl`,
+  /// which coordinates ACROSS processes but not within one (a process never
+  /// conflicts with its own locks), so this serializes same-isolate concurrent
+  /// provisions; the flock serializes other processes.
+  ///
+  /// Gap (documented, not closed): two isolates of the SAME process are coordinated
+  /// by neither layer — this map is isolate-local, and fcntl doesn't conflict
+  /// intra-process — so both could download the same file. That only wastes
+  /// bandwidth: each verifies size+SHA-256 and atomically renames, so the result is
+  /// still correct. Dart offers no intra-process cross-isolate file lock; closing
+  /// it would need explicit isolate coordination (out of scope).
   static final Map<String, Future<void>> _inProcessLocks = {};
 
   Future<T> _withInProcessLock<T>(String key, Future<T> Function() body) async {
@@ -417,7 +471,27 @@ class ParameterProvisioner {
           () => _callExecuteFeeProofChecked(
               authorization, height, statePaths, publicStateRoot));
 
-  void close() => _dio.close(force: true);
+  /// preflight → download → prove an execution through the program path. v1 is
+  /// credits-only, so a non-empty [programSources] (a custom program) is rejected
+  /// by the native side with `unsupported_feature`. Returns the serialized execution.
+  Future<String> provisionAndProveProgram({
+    required String authorization,
+    required int height,
+    required int consensusVersion,
+    String programSources = '',
+    String statePaths = '',
+    String publicStateRoot = '',
+  }) =>
+      _provisionAndProve(
+          consensusVersion,
+          () => _callExecuteProgramProofChecked(authorization, programSources,
+              height, statePaths, publicStateRoot));
+
+  /// Closes the internally-created Dio. A caller-injected Dio is left open — the
+  /// caller owns its lifecycle (mirrors `AleoNode`).
+  void close() {
+    if (_ownsDio) _dio.close(force: true);
+  }
 
   // ── Test hooks (the download / envelope / latch logic is otherwise private) ──
 
@@ -428,6 +502,14 @@ class ParameterProvisioner {
 
   /// Exposes the fail-closed envelope parser.
   Map<String, dynamic> parseEnvelopeForTest(String json) => _ok(json);
+
+  /// Exposes the program checked-proof binding (bypassing provisioning) so its
+  /// typedef can be exercised; a non-empty closure returns `unsupported_feature`
+  /// before any parameter load.
+  String callProgramProofForTest(String authorization, String programSources,
+          int height, String statePaths, String publicStateRoot) =>
+      _callExecuteProgramProofChecked(
+          authorization, programSources, height, statePaths, publicStateRoot);
 
   /// Clears the process-global poison latch between tests.
   static void resetLatchForTest() => _provingDisabled = false;

--- a/packages/aleo_dart/lib/src/aleo_provisioning.dart
+++ b/packages/aleo_dart/lib/src/aleo_provisioning.dart
@@ -1,0 +1,411 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:ffi' as ffi;
+import 'dart:io';
+import 'dart:math';
+
+import 'package:crypto/crypto.dart';
+import 'package:dio/dio.dart';
+import 'package:ffi/ffi.dart';
+import 'package:path/path.dart' as p;
+
+import 'rust_lib/utils.dart';
+
+/// Thrown when the native side reports `restart_required`: a proving parameter is
+/// missing/corrupt and snarkVM's process-global `lazy_static` is poisoned. Only an
+/// OS-process restart clears it — recreating a Dart isolate does NOT, because
+/// isolates share the loaded library and its statics. Once this is thrown the
+/// [ParameterProvisioner] latch fail-fasts every later proving call without
+/// touching the FFI, and the app should prompt the user to restart.
+class ProvingDisabledException implements Exception {
+  final String message;
+  ProvingDisabledException(this.message);
+  @override
+  String toString() => 'ProvingDisabledException: $message';
+}
+
+/// A non-`restart_required` failure envelope (or any provisioning failure).
+class ProvisioningException implements Exception {
+  final String code;
+  final String message;
+  ProvisioningException(this.code, this.message);
+  @override
+  String toString() => 'ProvisioningException($code): $message';
+}
+
+/// One missing/corrupt proving-key file reported by `parameter_preflight`.
+class MissingParam {
+  final String function;
+  final String relativePath;
+  final List<String> urls;
+  final int size;
+  final String checksum;
+  final String reason; // absent | wrong_size | wrong_checksum | unreadable
+
+  MissingParam({
+    required this.function,
+    required this.relativePath,
+    required this.urls,
+    required this.size,
+    required this.checksum,
+    required this.reason,
+  });
+
+  factory MissingParam.fromJson(Map<String, dynamic> j) => MissingParam(
+        function: j['function'] as String,
+        relativePath: j['relativePath'] as String,
+        urls: (j['urls'] as List).cast<String>(),
+        size: j['size'] as int,
+        checksum: j['checksum'] as String,
+        reason: j['reason'] as String,
+      );
+}
+
+/// Provisions the credits proving keys for one network into the parameter
+/// directory (preflight → download missing → prove), coordinating concurrent
+/// callers and other processes through advisory file locks (`dart:io`
+/// `RandomAccessFile.lock`).
+///
+/// Additive: this is a new path exercised by tests via `ALEO_NEW_LIB`; it does NOT
+/// replace `AleoProgram`'s existing proving methods (that switch lands with the
+/// redistributed library in PR4).
+class ParameterProvisioner {
+  final ffi.DynamicLibrary _lib;
+
+  /// `"mainnet"` or `"testnet"`.
+  final String network;
+
+  /// The directory proving keys live under (mobile app sandbox; desktop `~/.aleo`).
+  final Directory paramDir;
+
+  final Dio _dio;
+  bool _dirSet = false;
+
+  /// Process-global poison latch (Contract 3). Once a `restart_required` is seen,
+  /// every provisioner fail-fasts until the OS process restarts.
+  static bool _provingDisabled = false;
+  static bool get provingDisabled => _provingDisabled;
+
+  ParameterProvisioner(
+    this._lib,
+    this.network,
+    this.paramDir, {
+    Dio? dio,
+  }) : _dio = dio ?? Dio(BaseOptions(receiveTimeout: const Duration(minutes: 30)));
+
+  // ── FFI ────────────────────────────────────────────────────────────────────
+
+  String _callPreflight(int consensusVersion) {
+    final fn = _lib.lookupFunction<
+        ffi.Pointer<Utf8> Function(ffi.Pointer<Utf8>, ffi.Uint16),
+        ffi.Pointer<Utf8> Function(ffi.Pointer<Utf8>, int)>('parameter_preflight');
+    final net = network.toNativeUtf8();
+    try {
+      return takeNativeString(_lib, fn(net, consensusVersion));
+    } finally {
+      malloc.free(net);
+    }
+  }
+
+  String _callSetParameterDir(String path) {
+    final fn = _lib.lookupFunction<
+        ffi.Pointer<Utf8> Function(ffi.Pointer<Utf8>),
+        ffi.Pointer<Utf8> Function(ffi.Pointer<Utf8>)>('ffi_set_parameter_dir');
+    final ptr = path.toNativeUtf8();
+    try {
+      return takeNativeString(_lib, fn(ptr));
+    } finally {
+      malloc.free(ptr);
+    }
+  }
+
+  String _callAleoDir() {
+    final fn = _lib.lookupFunction<ffi.Pointer<Utf8> Function(),
+        ffi.Pointer<Utf8> Function()>('ffi_aleo_dir');
+    return takeNativeString(_lib, fn());
+  }
+
+  String _callExecuteProofChecked(
+      String authorization, int height, String statePaths, String publicStateRoot) {
+    final fn = _lib.lookupFunction<
+        ffi.Pointer<Utf8> Function(ffi.Pointer<Utf8>, ffi.Pointer<Utf8>, ffi.Uint32,
+            ffi.Pointer<Utf8>, ffi.Pointer<Utf8>),
+        ffi.Pointer<Utf8> Function(ffi.Pointer<Utf8>, ffi.Pointer<Utf8>, int,
+            ffi.Pointer<Utf8>, ffi.Pointer<Utf8>)>('execute_proof_checked');
+    return _callProving(
+        (net, auth, paths, root) => fn(net, auth, height, paths, root),
+        authorization, statePaths, publicStateRoot);
+  }
+
+  String _callExecuteFeeProofChecked(
+      String authorization, int height, String statePaths, String publicStateRoot) {
+    final fn = _lib.lookupFunction<
+        ffi.Pointer<Utf8> Function(ffi.Pointer<Utf8>, ffi.Pointer<Utf8>, ffi.Uint32,
+            ffi.Pointer<Utf8>, ffi.Pointer<Utf8>),
+        ffi.Pointer<Utf8> Function(ffi.Pointer<Utf8>, ffi.Pointer<Utf8>, int,
+            ffi.Pointer<Utf8>, ffi.Pointer<Utf8>)>('execute_fee_proof_checked');
+    return _callProving(
+        (net, auth, paths, root) => fn(net, auth, height, paths, root),
+        authorization, statePaths, publicStateRoot);
+  }
+
+  /// Shared input marshalling for the 4-pointer checked proving exports.
+  String _callProving(
+    ffi.Pointer<Utf8> Function(ffi.Pointer<Utf8>, ffi.Pointer<Utf8>,
+            ffi.Pointer<Utf8>, ffi.Pointer<Utf8>)
+        call,
+    String authorization,
+    String statePaths,
+    String publicStateRoot,
+  ) {
+    final net = network.toNativeUtf8();
+    final auth = authorization.toNativeUtf8();
+    final paths = statePaths.toNativeUtf8();
+    final root = publicStateRoot.toNativeUtf8();
+    try {
+      return takeNativeString(_lib, call(net, auth, paths, root));
+    } finally {
+      freeAll([net, auth, paths, root]);
+    }
+  }
+
+  // ── Envelope parsing (fail-closed) ──────────────────────────────────────────
+
+  /// Parses a native envelope. Anything that is not `{"ok": true}` throws; a
+  /// `restart_required` code trips the latch first.
+  Map<String, dynamic> _ok(String json) {
+    dynamic decoded;
+    try {
+      decoded = jsonDecode(json);
+    } catch (_) {
+      throw ProvisioningException('invalid_envelope', 'native returned non-JSON: $json');
+    }
+    if (decoded is! Map || decoded['ok'] != true) {
+      final code = (decoded is Map ? decoded['code'] : null) ?? 'invalid_envelope';
+      final message = (decoded is Map ? decoded['message'] : null) ?? json;
+      if (code == 'restart_required') {
+        _provingDisabled = true;
+        throw ProvingDisabledException(message.toString());
+      }
+      throw ProvisioningException(code.toString(), message.toString());
+    }
+    return decoded.cast<String, dynamic>();
+  }
+
+  void _ensureNotDisabled() {
+    if (_provingDisabled) {
+      throw ProvingDisabledException(
+          'proving is disabled until the app restarts (a parameter was corrupt)');
+    }
+  }
+
+  /// Points the native param loader at [paramDir] (idempotent / set-once).
+  void _ensureParameterDir() {
+    if (_dirSet) return;
+    final env = jsonDecode(_callSetParameterDir(paramDir.path));
+    if (env is Map && env['ok'] == true) {
+      _dirSet = true;
+      return;
+    }
+    // Already set/loading: accept only if the effective dir is already ours.
+    final dir = _ok(_callAleoDir())['data'] as String;
+    final ours = paramDir.existsSync() ? paramDir.resolveSymbolicLinksSync() : paramDir.path;
+    if (dir == ours) {
+      _dirSet = true;
+      return;
+    }
+    throw ProvisioningException('param_dir_locked',
+        'parameter dir is already fixed to $dir, cannot use ${paramDir.path}');
+  }
+
+  // ── Preflight ───────────────────────────────────────────────────────────────
+
+  /// Returns the missing/corrupt parameter files for [consensusVersion] (empty ⇒
+  /// the credits-v1 set is provisioned). Throws on an error envelope / latch.
+  Future<List<MissingParam>> preflight(int consensusVersion) async {
+    _ensureNotDisabled();
+    _ensureParameterDir();
+    final env = _ok(_callPreflight(consensusVersion));
+    final missing = (env['missing'] as List).cast<Map<String, dynamic>>();
+    return missing.map(MissingParam.fromJson).toList();
+  }
+
+  // ── Download (atomic, single-flight, locked) ────────────────────────────────
+
+  /// In-process per-file mutex. `RandomAccessFile.lock` is POSIX `fcntl`, which
+  /// coordinates ACROSS processes but not within one (a process never conflicts
+  /// with its own locks, and isolates don't share statics either way), so
+  /// same-isolate concurrent provisions of one file are serialized here.
+  static final Map<String, Future<void>> _inProcessLocks = {};
+
+  Future<T> _withInProcessLock<T>(String key, Future<T> Function() body) async {
+    while (_inProcessLocks.containsKey(key)) {
+      await _inProcessLocks[key];
+    }
+    final completer = Completer<void>();
+    _inProcessLocks[key] = completer.future;
+    try {
+      return await body();
+    } finally {
+      _inProcessLocks.remove(key);
+      completer.complete();
+    }
+  }
+
+  File _lockFileFor(String relativePath) {
+    final hash = sha256.convert(utf8.encode(relativePath)).toString();
+    return File(p.join(paramDir.path, '.locks', 'files', '$hash.lock'));
+  }
+
+  Future<bool> _fileMatches(File file, MissingParam param) async {
+    if (!await file.exists()) return false;
+    if (await file.length() != param.size) return false;
+    final digest = await sha256.bind(file.openRead()).single;
+    return digest.toString() == param.checksum;
+  }
+
+  /// Downloads one missing file under an exclusive single-flight lock: a concurrent
+  /// caller (or process) blocks, then sees the file already present. The lock binds
+  /// a stable `.lock` file, never the renamed `.tmp` (whose inode detaches on
+  /// rename). Verifies size + SHA-256, then atomically renames into place.
+  Future<void> _provisionFile(MissingParam param) {
+    // In-process single-flight (this isolate), then cross-process via the flock.
+    return _withInProcessLock(param.relativePath, () => _provisionFileLocked(param));
+  }
+
+  Future<void> _provisionFileLocked(MissingParam param) async {
+    final lockFile = _lockFileFor(param.relativePath);
+    await lockFile.parent.create(recursive: true);
+    final raf = await lockFile.open(mode: FileMode.write);
+    try {
+      await raf.lock(FileLock.blockingExclusive);
+      final target = File(p.join(paramDir.path, param.relativePath));
+      if (await _fileMatches(target, param)) return; // another flight finished it
+      await target.parent.create(recursive: true);
+
+      final tmp = File('${target.path}.${Random().nextInt(1 << 31)}.tmp');
+      try {
+        await _downloadTo(param, tmp);
+        if (!await _fileMatches(tmp, param)) {
+          throw ProvisioningException('checksum_mismatch',
+              'downloaded ${param.function} failed size/checksum verification');
+        }
+        await tmp.rename(target.path); // atomic on the same filesystem
+      } finally {
+        if (await tmp.exists()) {
+          await tmp.delete().catchError((_) => tmp);
+        }
+      }
+    } finally {
+      await raf.unlock();
+      await raf.close();
+    }
+  }
+
+  Future<void> _downloadTo(MissingParam param, File tmp) async {
+    Object? lastError;
+    for (final url in param.urls) {
+      final cancel = CancelToken();
+      try {
+        await _dio.download(
+          url,
+          tmp.path,
+          cancelToken: cancel,
+          onReceiveProgress: (received, _) {
+            // Hard cap: never write more than the manifest size.
+            if (received > param.size) {
+              cancel.cancel('parameter ${param.function} exceeded its declared size');
+            }
+          },
+        );
+        return;
+      } catch (e) {
+        lastError = e;
+        if (await tmp.exists()) {
+          await tmp.delete().catchError((_) => tmp);
+        }
+      }
+    }
+    throw ProvisioningException(
+        'download_failed', 'all sources failed for ${param.function}: $lastError');
+  }
+
+  // ── Tier lock + proving ─────────────────────────────────────────────────────
+
+  /// Runs [body] holding a SHARED lock on `<dir>/.locks/<network>.lock`, so a prove
+  /// proceeds concurrently with other proves but cannot run while eviction (a future
+  /// exclusive holder) is deleting a file in the set.
+  Future<T> _withSharedTierLock<T>(Future<T> Function() body) async {
+    final lockFile = File(p.join(paramDir.path, '.locks', '$network.lock'));
+    await lockFile.parent.create(recursive: true);
+    final raf = await lockFile.open(mode: FileMode.write);
+    try {
+      await raf.lock(FileLock.blockingShared);
+      return await body();
+    } finally {
+      await raf.unlock();
+      await raf.close();
+    }
+  }
+
+  Future<List<MissingParam>> _downloadAll(int consensusVersion) async {
+    var missing = await preflight(consensusVersion);
+    for (final param in missing) {
+      await _provisionFile(param);
+    }
+    return missing;
+  }
+
+  /// Provisions then proves, holding the shared tier lock across a re-preflight (to
+  /// close the download→prove TOCTOU) and the whole proving call. Returns the
+  /// native envelope's serialized proof (`data`). [prove] performs the FFI call.
+  Future<String> _provisionAndProve(int consensusVersion, String Function() prove) async {
+    _ensureNotDisabled();
+    await _downloadAll(consensusVersion);
+    return _withSharedTierLock(() async {
+      final still = await preflight(consensusVersion);
+      if (still.isNotEmpty) {
+        throw ProvisioningException('provisioning_incomplete',
+            'still missing after download: ${still.map((m) => m.function).join(", ")}');
+      }
+      return _ok(prove())['data'] as String;
+    });
+  }
+
+  /// preflight → download → prove an execution authorization. Returns the serialized
+  /// execution.
+  Future<String> provisionAndProveExecution({
+    required String authorization,
+    required int height,
+    required int consensusVersion,
+    String statePaths = '',
+    String publicStateRoot = '',
+  }) =>
+      _provisionAndProve(consensusVersion,
+          () => _callExecuteProofChecked(authorization, height, statePaths, publicStateRoot));
+
+  /// preflight → download → prove a fee authorization. Returns the serialized fee.
+  Future<String> provisionAndProveFee({
+    required String authorization,
+    required int height,
+    required int consensusVersion,
+    String statePaths = '',
+    String publicStateRoot = '',
+  }) =>
+      _provisionAndProve(consensusVersion,
+          () => _callExecuteFeeProofChecked(authorization, height, statePaths, publicStateRoot));
+
+  void close() => _dio.close(force: true);
+
+  // ── Test hooks (the download / envelope / latch logic is otherwise private) ──
+
+  /// Exposes [_provisionFile] so the downloader + single-flight lock can be tested
+  /// with a fabricated [MissingParam] against a local server (no real params).
+  Future<void> provisionFileForTest(MissingParam param) => _provisionFile(param);
+
+  /// Exposes the fail-closed envelope parser.
+  Map<String, dynamic> parseEnvelopeForTest(String json) => _ok(json);
+
+  /// Clears the process-global poison latch between tests.
+  static void resetLatchForTest() => _provingDisabled = false;
+}

--- a/packages/aleo_dart/lib/src/aleo_provisioning.dart
+++ b/packages/aleo_dart/lib/src/aleo_provisioning.dart
@@ -91,14 +91,16 @@ class ParameterProvisioner {
     this.network,
     this.paramDir, {
     Dio? dio,
-  }) : _dio = dio ?? Dio(BaseOptions(receiveTimeout: const Duration(minutes: 30)));
+  }) : _dio = dio ??
+            Dio(BaseOptions(receiveTimeout: const Duration(minutes: 30)));
 
   // ── FFI ────────────────────────────────────────────────────────────────────
 
   String _callPreflight(int consensusVersion) {
     final fn = _lib.lookupFunction<
         ffi.Pointer<Utf8> Function(ffi.Pointer<Utf8>, ffi.Uint16),
-        ffi.Pointer<Utf8> Function(ffi.Pointer<Utf8>, int)>('parameter_preflight');
+        ffi.Pointer<Utf8> Function(
+            ffi.Pointer<Utf8>, int)>('parameter_preflight');
     final net = network.toNativeUtf8();
     try {
       return takeNativeString(_lib, fn(net, consensusVersion));
@@ -125,28 +127,32 @@ class ParameterProvisioner {
     return takeNativeString(_lib, fn());
   }
 
-  String _callExecuteProofChecked(
-      String authorization, int height, String statePaths, String publicStateRoot) {
+  String _callExecuteProofChecked(String authorization, int height,
+      String statePaths, String publicStateRoot) {
     final fn = _lib.lookupFunction<
-        ffi.Pointer<Utf8> Function(ffi.Pointer<Utf8>, ffi.Pointer<Utf8>, ffi.Uint32,
-            ffi.Pointer<Utf8>, ffi.Pointer<Utf8>),
+        ffi.Pointer<Utf8> Function(ffi.Pointer<Utf8>, ffi.Pointer<Utf8>,
+            ffi.Uint32, ffi.Pointer<Utf8>, ffi.Pointer<Utf8>),
         ffi.Pointer<Utf8> Function(ffi.Pointer<Utf8>, ffi.Pointer<Utf8>, int,
             ffi.Pointer<Utf8>, ffi.Pointer<Utf8>)>('execute_proof_checked');
     return _callProving(
         (net, auth, paths, root) => fn(net, auth, height, paths, root),
-        authorization, statePaths, publicStateRoot);
+        authorization,
+        statePaths,
+        publicStateRoot);
   }
 
-  String _callExecuteFeeProofChecked(
-      String authorization, int height, String statePaths, String publicStateRoot) {
+  String _callExecuteFeeProofChecked(String authorization, int height,
+      String statePaths, String publicStateRoot) {
     final fn = _lib.lookupFunction<
-        ffi.Pointer<Utf8> Function(ffi.Pointer<Utf8>, ffi.Pointer<Utf8>, ffi.Uint32,
-            ffi.Pointer<Utf8>, ffi.Pointer<Utf8>),
+        ffi.Pointer<Utf8> Function(ffi.Pointer<Utf8>, ffi.Pointer<Utf8>,
+            ffi.Uint32, ffi.Pointer<Utf8>, ffi.Pointer<Utf8>),
         ffi.Pointer<Utf8> Function(ffi.Pointer<Utf8>, ffi.Pointer<Utf8>, int,
             ffi.Pointer<Utf8>, ffi.Pointer<Utf8>)>('execute_fee_proof_checked');
     return _callProving(
         (net, auth, paths, root) => fn(net, auth, height, paths, root),
-        authorization, statePaths, publicStateRoot);
+        authorization,
+        statePaths,
+        publicStateRoot);
   }
 
   /// Shared input marshalling for the 4-pointer checked proving exports.
@@ -178,10 +184,12 @@ class ParameterProvisioner {
     try {
       decoded = jsonDecode(json);
     } catch (_) {
-      throw ProvisioningException('invalid_envelope', 'native returned non-JSON: $json');
+      throw ProvisioningException(
+          'invalid_envelope', 'native returned non-JSON: $json');
     }
     if (decoded is! Map || decoded['ok'] != true) {
-      final code = (decoded is Map ? decoded['code'] : null) ?? 'invalid_envelope';
+      final code =
+          (decoded is Map ? decoded['code'] : null) ?? 'invalid_envelope';
       final message = (decoded is Map ? decoded['message'] : null) ?? json;
       if (code == 'restart_required') {
         _provingDisabled = true;
@@ -209,7 +217,9 @@ class ParameterProvisioner {
     }
     // Already set/loading: accept only if the effective dir is already ours.
     final dir = _ok(_callAleoDir())['data'] as String;
-    final ours = paramDir.existsSync() ? paramDir.resolveSymbolicLinksSync() : paramDir.path;
+    final ours = paramDir.existsSync()
+        ? paramDir.resolveSymbolicLinksSync()
+        : paramDir.path;
     if (dir == ours) {
       _dirSet = true;
       return;
@@ -270,7 +280,8 @@ class ParameterProvisioner {
   /// rename). Verifies size + SHA-256, then atomically renames into place.
   Future<void> _provisionFile(MissingParam param) {
     // In-process single-flight (this isolate), then cross-process via the flock.
-    return _withInProcessLock(param.relativePath, () => _provisionFileLocked(param));
+    return _withInProcessLock(
+        param.relativePath, () => _provisionFileLocked(param));
   }
 
   Future<void> _provisionFileLocked(MissingParam param) async {
@@ -280,7 +291,8 @@ class ParameterProvisioner {
     try {
       await raf.lock(FileLock.blockingExclusive);
       final target = File(p.join(paramDir.path, param.relativePath));
-      if (await _fileMatches(target, param)) return; // another flight finished it
+      if (await _fileMatches(target, param))
+        return; // another flight finished it
       await target.parent.create(recursive: true);
 
       final tmp = File('${target.path}.${Random().nextInt(1 << 31)}.tmp');
@@ -314,7 +326,8 @@ class ParameterProvisioner {
           onReceiveProgress: (received, _) {
             // Hard cap: never write more than the manifest size.
             if (received > param.size) {
-              cancel.cancel('parameter ${param.function} exceeded its declared size');
+              cancel.cancel(
+                  'parameter ${param.function} exceeded its declared size');
             }
           },
         );
@@ -326,8 +339,8 @@ class ParameterProvisioner {
         }
       }
     }
-    throw ProvisioningException(
-        'download_failed', 'all sources failed for ${param.function}: $lastError');
+    throw ProvisioningException('download_failed',
+        'all sources failed for ${param.function}: $lastError');
   }
 
   // ── Tier lock + proving ─────────────────────────────────────────────────────
@@ -359,7 +372,8 @@ class ParameterProvisioner {
   /// Provisions then proves, holding the shared tier lock across a re-preflight (to
   /// close the download→prove TOCTOU) and the whole proving call. Returns the
   /// native envelope's serialized proof (`data`). [prove] performs the FFI call.
-  Future<String> _provisionAndProve(int consensusVersion, String Function() prove) async {
+  Future<String> _provisionAndProve(
+      int consensusVersion, String Function() prove) async {
     _ensureNotDisabled();
     await _downloadAll(consensusVersion);
     return _withSharedTierLock(() async {
@@ -381,8 +395,10 @@ class ParameterProvisioner {
     String statePaths = '',
     String publicStateRoot = '',
   }) =>
-      _provisionAndProve(consensusVersion,
-          () => _callExecuteProofChecked(authorization, height, statePaths, publicStateRoot));
+      _provisionAndProve(
+          consensusVersion,
+          () => _callExecuteProofChecked(
+              authorization, height, statePaths, publicStateRoot));
 
   /// preflight → download → prove a fee authorization. Returns the serialized fee.
   Future<String> provisionAndProveFee({
@@ -392,8 +408,10 @@ class ParameterProvisioner {
     String statePaths = '',
     String publicStateRoot = '',
   }) =>
-      _provisionAndProve(consensusVersion,
-          () => _callExecuteFeeProofChecked(authorization, height, statePaths, publicStateRoot));
+      _provisionAndProve(
+          consensusVersion,
+          () => _callExecuteFeeProofChecked(
+              authorization, height, statePaths, publicStateRoot));
 
   void close() => _dio.close(force: true);
 
@@ -401,7 +419,8 @@ class ParameterProvisioner {
 
   /// Exposes [_provisionFile] so the downloader + single-flight lock can be tested
   /// with a fabricated [MissingParam] against a local server (no real params).
-  Future<void> provisionFileForTest(MissingParam param) => _provisionFile(param);
+  Future<void> provisionFileForTest(MissingParam param) =>
+      _provisionFile(param);
 
   /// Exposes the fail-closed envelope parser.
   Map<String, dynamic> parseEnvelopeForTest(String json) => _ok(json);

--- a/packages/aleo_dart/lib/src/aleo_provisioning.dart
+++ b/packages/aleo_dart/lib/src/aleo_provisioning.dart
@@ -519,6 +519,9 @@ class ParameterProvisioner {
     String statePaths = '',
     String publicStateRoot = '',
   }) async {
+    // Latch first (Contract 3): a poisoned process fail-fasts as
+    // ProvingDisabledException, even for a custom-program call.
+    _ensureNotDisabled();
     if (!_isEmptyClosure(programSources)) {
       throw ProvisioningException('unsupported_feature',
           'custom-program proving is not supported in this version');

--- a/packages/aleo_dart/lib/src/aleo_provisioning.dart
+++ b/packages/aleo_dart/lib/src/aleo_provisioning.dart
@@ -264,25 +264,25 @@ class ParameterProvisioner {
     }
   }
 
-  /// Points the native param loader at [paramDir] (idempotent / set-once).
+  /// Points the native param loader at [paramDir] (idempotent / set-once). Uses the
+  /// shared fail-closed [_ok] parser so a non-JSON envelope throws, `restart_required`
+  /// trips the latch, and `invalid_path` propagates as itself — only `param_dir_locked`
+  /// is reinterpreted (it is fine if the effective dir is already ours).
   void _ensureParameterDir() {
     if (_dirSet) return;
-    final env = jsonDecode(_callSetParameterDir(paramDir.path));
-    if (env is Map && env['ok'] == true) {
+    try {
+      _ok(_callSetParameterDir(paramDir.path));
       _dirSet = true;
-      return;
-    }
-    // Already set/loading: accept only if the effective dir is already ours.
-    final dir = _ok(_callAleoDir())['data'] as String;
-    final ours = paramDir.existsSync()
-        ? paramDir.resolveSymbolicLinksSync()
-        : paramDir.path;
-    if (dir == ours) {
+    } on ProvisioningException catch (e) {
+      if (e.code != 'param_dir_locked') rethrow;
+      // Already fixed: accept only if the effective dir is already ours.
+      final dir = _ok(_callAleoDir())['data'] as String;
+      final ours = paramDir.existsSync()
+          ? paramDir.resolveSymbolicLinksSync()
+          : paramDir.path;
+      if (dir != ours) rethrow;
       _dirSet = true;
-      return;
     }
-    throw ProvisioningException('param_dir_locked',
-        'parameter dir is already fixed to $dir, cannot use ${paramDir.path}');
   }
 
   // ── Preflight ───────────────────────────────────────────────────────────────
@@ -556,6 +556,6 @@ class ParameterProvisioner {
       _callExecuteProgramProofChecked(
           authorization, programSources, height, statePaths, publicStateRoot);
 
-  /// Clears the process-global poison latch between tests.
+  /// Clears the (isolate-local) poison latch between tests.
   static void resetLatchForTest() => _provingDisabled = false;
 }

--- a/packages/aleo_dart/lib/src/aleo_provisioning.dart
+++ b/packages/aleo_dart/lib/src/aleo_provisioning.dart
@@ -80,6 +80,11 @@ class ParameterProvisioner {
 
   final Dio _dio;
   final bool _ownsDio;
+
+  /// Wall-clock ceiling on a single url attempt, so a hung/slow source is abandoned
+  /// for the mirror instead of stalling (`connectTimeout`/`receiveTimeout` alone miss
+  /// a steady-but-slow stream that never goes idle).
+  final Duration _perUrlDeadline;
   bool _dirSet = false;
 
   /// Poison latch (§8 Contract 3). Tripped when a checked-proving call returns
@@ -103,9 +108,14 @@ class ParameterProvisioner {
     this.network,
     this.paramDir, {
     Dio? dio,
+    Duration? perUrlDownloadDeadline,
   })  : _ownsDio = dio == null,
+        _perUrlDeadline = perUrlDownloadDeadline ?? const Duration(minutes: 30),
         _dio = dio ??
-            Dio(BaseOptions(receiveTimeout: const Duration(minutes: 30)));
+            Dio(BaseOptions(
+              connectTimeout: const Duration(seconds: 30),
+              receiveTimeout: const Duration(minutes: 30),
+            ));
 
   // ── FFI ────────────────────────────────────────────────────────────────────
 
@@ -374,6 +384,15 @@ class ParameterProvisioner {
     Object? lastError;
     for (final url in param.urls) {
       final cancel = CancelToken();
+      // Overall wall-clock deadline for this attempt: a hung connect or a
+      // steady-but-slow stream (which never trips receiveTimeout) is cancelled so
+      // the loop falls back to the mirror.
+      final deadline = Timer(_perUrlDeadline, () {
+        if (!cancel.isCancelled) {
+          cancel.cancel('download of ${param.function} from $url exceeded '
+              '${_perUrlDeadline.inSeconds}s');
+        }
+      });
       try {
         await _dio.download(
           url,
@@ -381,7 +400,7 @@ class ParameterProvisioner {
           cancelToken: cancel,
           onReceiveProgress: (received, _) {
             // Hard cap: never write more than the manifest size.
-            if (received > param.size) {
+            if (received > param.size && !cancel.isCancelled) {
               cancel.cancel(
                   'parameter ${param.function} exceeded its declared size');
             }
@@ -392,6 +411,8 @@ class ParameterProvisioner {
             '$url returned a body failing size/checksum verification');
       } catch (e) {
         lastError = e;
+      } finally {
+        deadline.cancel();
       }
       if (await tmp.exists()) {
         await tmp.delete().catchError((_) => tmp);
@@ -471,9 +492,25 @@ class ParameterProvisioner {
           () => _callExecuteFeeProofChecked(
               authorization, height, statePaths, publicStateRoot));
 
+  /// An empty program closure: `""` or `"[]"` (an empty JSON array). Mirrors the
+  /// native rule so a custom program is rejected at the Dart entry; a non-array or
+  /// malformed value is NOT empty (and the native side would reject it too).
+  static bool _isEmptyClosure(String programSources) {
+    final trimmed = programSources.trim();
+    if (trimmed.isEmpty) return true;
+    try {
+      final decoded = jsonDecode(trimmed);
+      return decoded is List && decoded.isEmpty;
+    } catch (_) {
+      return false;
+    }
+  }
+
   /// preflight → download → prove an execution through the program path. v1 is
-  /// credits-only, so a non-empty [programSources] (a custom program) is rejected
-  /// by the native side with `unsupported_feature`. Returns the serialized execution.
+  /// credits-only: a non-empty [programSources] (a custom program) is rejected HERE
+  /// with `unsupported_feature`, BEFORE provisioning ~1.15 GiB — the native side
+  /// would also reject it, but only after the download. Returns the serialized
+  /// execution.
   Future<String> provisionAndProveProgram({
     required String authorization,
     required int height,
@@ -481,11 +518,16 @@ class ParameterProvisioner {
     String programSources = '',
     String statePaths = '',
     String publicStateRoot = '',
-  }) =>
-      _provisionAndProve(
-          consensusVersion,
-          () => _callExecuteProgramProofChecked(authorization, programSources,
-              height, statePaths, publicStateRoot));
+  }) async {
+    if (!_isEmptyClosure(programSources)) {
+      throw ProvisioningException('unsupported_feature',
+          'custom-program proving is not supported in this version');
+    }
+    return _provisionAndProve(
+        consensusVersion,
+        () => _callExecuteProgramProofChecked(authorization, programSources,
+            height, statePaths, publicStateRoot));
+  }
 
   /// Closes the internally-created Dio. A caller-injected Dio is left open — the
   /// caller owns its lifecycle (mirrors `AleoNode`).

--- a/packages/aleo_dart/lib/src/aleo_provisioning.dart
+++ b/packages/aleo_dart/lib/src/aleo_provisioning.dart
@@ -297,11 +297,8 @@ class ParameterProvisioner {
 
       final tmp = File('${target.path}.${Random().nextInt(1 << 31)}.tmp');
       try {
-        await _downloadTo(param, tmp);
-        if (!await _fileMatches(tmp, param)) {
-          throw ProvisioningException('checksum_mismatch',
-              'downloaded ${param.function} failed size/checksum verification');
-        }
+        await _downloadTo(
+            param, tmp); // returns only a size+checksum-verified body
         await tmp.rename(target.path); // atomic on the same filesystem
       } finally {
         if (await tmp.exists()) {
@@ -314,6 +311,11 @@ class ParameterProvisioner {
     }
   }
 
+  /// Downloads [param] into [tmp] from the first url whose body verifies (size +
+  /// SHA-256). Falls back to the next url on a connection error OR a content
+  /// mismatch — so a corrupt/stale primary CDN response (HTTP 200, wrong bytes)
+  /// tries the mirror instead of failing the whole provision. Returns only when a
+  /// url's body is verified.
   Future<void> _downloadTo(MissingParam param, File tmp) async {
     Object? lastError;
     for (final url in param.urls) {
@@ -331,12 +333,14 @@ class ParameterProvisioner {
             }
           },
         );
-        return;
+        if (await _fileMatches(tmp, param)) return; // verified
+        lastError = ProvisioningException('checksum_mismatch',
+            '$url returned a body failing size/checksum verification');
       } catch (e) {
         lastError = e;
-        if (await tmp.exists()) {
-          await tmp.delete().catchError((_) => tmp);
-        }
+      }
+      if (await tmp.exists()) {
+        await tmp.delete().catchError((_) => tmp);
       }
     }
     throw ProvisioningException('download_failed',

--- a/packages/aleo_dart/test/aleo_provisioning_test.dart
+++ b/packages/aleo_dart/test/aleo_provisioning_test.dart
@@ -1,0 +1,201 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:aleo_dart/aleo.dart';
+import 'package:crypto/crypto.dart';
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+import 'support/test_dylib.dart';
+
+/// Serves the given path→bytes map on loopback. A path mapped to `null` 404s.
+Future<HttpServer> serveBytes(Map<String, List<int>?> routes) async {
+  final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+  server.listen((req) async {
+    final body = routes[req.uri.path];
+    if (body == null) {
+      req.response.statusCode = 404;
+    } else {
+      req.response.add(body);
+    }
+    await req.response.close();
+  });
+  return server;
+}
+
+MissingParam missingFor(String dir, String relPath, List<int> body, List<String> urls,
+    {String reason = 'absent'}) {
+  return MissingParam(
+    function: 'test',
+    relativePath: relPath,
+    urls: urls,
+    size: body.length,
+    checksum: sha256.convert(body).toString(),
+    reason: reason,
+  );
+}
+
+void main() {
+  final dyLib = tryLoadAleoLib();
+
+  // ── Pure-Dart: envelope parser + latch (no FFI dir, no network) ─────────────
+  // (Still needs the library handle to construct the provisioner.)
+  group('envelope + latch', () {
+    setUp(ParameterProvisioner.resetLatchForTest);
+    tearDown(ParameterProvisioner.resetLatchForTest);
+
+    test('parses ok / throws on errors / trips latch on restart_required', () {
+      if (dyLib == null) return;
+      final pv = ParameterProvisioner(dyLib, 'mainnet', Directory.systemTemp);
+
+      expect(pv.parseEnvelopeForTest('{"ok":true,"data":"x"}')['data'], 'x');
+
+      expect(() => pv.parseEnvelopeForTest('not json'),
+          throwsA(isA<ProvisioningException>()));
+      expect(() => pv.parseEnvelopeForTest('{"ok":false,"code":"invalid_input","message":"m"}'),
+          throwsA(isA<ProvisioningException>()));
+
+      expect(ParameterProvisioner.provingDisabled, isFalse);
+      expect(() => pv.parseEnvelopeForTest('{"ok":false,"code":"restart_required","message":"m"}'),
+          throwsA(isA<ProvingDisabledException>()));
+      expect(ParameterProvisioner.provingDisabled, isTrue);
+    });
+  }, skip: dyLib == null ? nativeLibMissingReason : null);
+
+  // ── Downloader + single-flight (local server, no FFI dir set) ───────────────
+  group('downloader', () {
+    test('downloads, verifies size+checksum, atomic-renames into place', () async {
+      if (dyLib == null) return;
+      final dir = Directory.systemTemp.createTempSync('aleo_pv_dl_');
+      final body = utf8.encode('a-fake-proving-key-${DateTime.now()}');
+      final server = await serveBytes({'/k.prover': body});
+      final port = server.port;
+      try {
+        final pv = ParameterProvisioner(dyLib, 'mainnet', dir);
+        final param = missingFor(dir.path, 'resources/k.prover.abc1234', body,
+            ['http://127.0.0.1:$port/k.prover']);
+        await pv.provisionFileForTest(param);
+        final target = File(p.join(dir.path, 'resources/k.prover.abc1234'));
+        expect(target.existsSync(), isTrue);
+        expect(target.readAsBytesSync(), body);
+        // No leftover tmp.
+        expect(Directory(p.join(dir.path, 'resources')).listSync().length, 1);
+      } finally {
+        await server.close(force: true);
+        dir.deleteSync(recursive: true);
+      }
+    });
+
+    test('falls back to the second url', () async {
+      if (dyLib == null) return;
+      final dir = Directory.systemTemp.createTempSync('aleo_pv_fb_');
+      final body = utf8.encode('mirror-body');
+      final server = await serveBytes({'/good': body}); // '/bad' 404s
+      final port = server.port;
+      try {
+        final pv = ParameterProvisioner(dyLib, 'mainnet', dir);
+        final param = missingFor(dir.path, 'resources/k.prover.def5678', body,
+            ['http://127.0.0.1:$port/bad', 'http://127.0.0.1:$port/good']);
+        await pv.provisionFileForTest(param);
+        expect(File(p.join(dir.path, 'resources/k.prover.def5678')).existsSync(), isTrue);
+      } finally {
+        await server.close(force: true);
+        dir.deleteSync(recursive: true);
+      }
+    });
+
+    test('rejects a wrong-checksum body (verification), leaves no file', () async {
+      if (dyLib == null) return;
+      final dir = Directory.systemTemp.createTempSync('aleo_pv_bad_');
+      final body = utf8.encode('actual-body');
+      final server = await serveBytes({'/k': body});
+      final port = server.port;
+      try {
+        final pv = ParameterProvisioner(dyLib, 'mainnet', dir);
+        // checksum/size declared for DIFFERENT content.
+        final param = MissingParam(
+          function: 'test',
+          relativePath: 'resources/k.prover.bad',
+          urls: ['http://127.0.0.1:$port/k'],
+          size: body.length,
+          checksum: sha256.convert(utf8.encode('something-else')).toString(),
+          reason: 'absent',
+        );
+        await expectLater(
+            pv.provisionFileForTest(param), throwsA(isA<ProvisioningException>()));
+        expect(File(p.join(dir.path, 'resources/k.prover.bad')).existsSync(), isFalse);
+      } finally {
+        await server.close(force: true);
+        dir.deleteSync(recursive: true);
+      }
+    });
+
+    test('single-flight: a concurrent provision sees the file already present', () async {
+      if (dyLib == null) return;
+      final dir = Directory.systemTemp.createTempSync('aleo_pv_sf_');
+      final body = utf8.encode('single-flight-body');
+      var hits = 0;
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      server.listen((req) async {
+        hits++;
+        await Future.delayed(const Duration(milliseconds: 150));
+        req.response.add(body);
+        await req.response.close();
+      });
+      final port = server.port;
+      try {
+        final pv = ParameterProvisioner(dyLib, 'mainnet', dir);
+        final param = missingFor(
+            dir.path, 'resources/k.prover.sf', body, ['http://127.0.0.1:$port/k']);
+        await Future.wait([
+          pv.provisionFileForTest(param),
+          pv.provisionFileForTest(param),
+        ]);
+        expect(File(p.join(dir.path, 'resources/k.prover.sf')).existsSync(), isTrue);
+        // The exclusive single-flight lock serialized them: only one download.
+        expect(hits, 1);
+      } finally {
+        await server.close(force: true);
+        dir.deleteSync(recursive: true);
+      }
+    });
+  }, skip: dyLib == null ? nativeLibMissingReason : null);
+
+  // ── preflight (FFI): one shared, set-once, empty param dir ──────────────────
+  group('preflight', () {
+    // ffi_set_parameter_dir is process-global set-once, so every preflight test
+    // shares ONE empty dir; the first call fixes it, the rest are idempotent.
+    final shared = Directory.systemTemp.createTempSync('aleo_pv_pf_');
+
+    test('empty dir reports all 16 credits files missing (absent)', () async {
+      if (dyLib == null) return;
+      final pv = ParameterProvisioner(dyLib, 'mainnet', shared);
+      final missing = await pv.preflight(13);
+      expect(missing.length, 16);
+      expect(missing.every((m) => m.reason == 'absent'), isTrue);
+      expect(missing.every((m) => m.urls.length == 2), isTrue);
+      expect(missing.map((m) => m.function), contains('transfer_public'));
+      expect(missing.map((m) => m.function), contains('inclusion'));
+    });
+
+    test('unknown network → ProvisioningException(unsupported_network)', () async {
+      if (dyLib == null) return;
+      final pv = ParameterProvisioner(dyLib, 'bogusnet', shared);
+      await expectLater(
+        pv.preflight(13),
+        throwsA(isA<ProvisioningException>()
+            .having((e) => e.code, 'code', 'unsupported_network')),
+      );
+    });
+
+    test('consensus outside V8..=V13 → unsupported_consensus', () async {
+      if (dyLib == null) return;
+      final pv = ParameterProvisioner(dyLib, 'mainnet', shared);
+      await expectLater(
+        pv.preflight(0),
+        throwsA(isA<ProvisioningException>()
+            .having((e) => e.code, 'code', 'unsupported_consensus')),
+      );
+    });
+  }, skip: dyLib == null ? nativeLibMissingReason : null);
+}

--- a/packages/aleo_dart/test/aleo_provisioning_test.dart
+++ b/packages/aleo_dart/test/aleo_provisioning_test.dart
@@ -112,6 +112,32 @@ void main() {
       }
     });
 
+    test('a corrupt primary url falls back to the verified mirror', () async {
+      if (dyLib == null) return;
+      final dir = Directory.systemTemp.createTempSync('aleo_pv_corrupt_');
+      final good = utf8.encode('the-correct-proving-key');
+      // Primary serves WRONG bytes (HTTP 200), mirror serves the correct body.
+      final server = await serveBytes({
+        '/primary': utf8.encode('corrupt-stale-body'),
+        '/mirror': good,
+      });
+      final port = server.port;
+      try {
+        final pv = ParameterProvisioner(dyLib, 'mainnet', dir);
+        final param = missingFor(dir.path, 'resources/k.prover.cor', good, [
+          'http://127.0.0.1:$port/primary',
+          'http://127.0.0.1:$port/mirror'
+        ]);
+        await pv.provisionFileForTest(param);
+        final target = File(p.join(dir.path, 'resources/k.prover.cor'));
+        expect(target.existsSync(), isTrue);
+        expect(target.readAsBytesSync(), good);
+      } finally {
+        await server.close(force: true);
+        dir.deleteSync(recursive: true);
+      }
+    });
+
     test('rejects a wrong-checksum body (verification), leaves no file',
         () async {
       if (dyLib == null) return;

--- a/packages/aleo_dart/test/aleo_provisioning_test.dart
+++ b/packages/aleo_dart/test/aleo_provisioning_test.dart
@@ -23,7 +23,8 @@ Future<HttpServer> serveBytes(Map<String, List<int>?> routes) async {
   return server;
 }
 
-MissingParam missingFor(String dir, String relPath, List<int> body, List<String> urls,
+MissingParam missingFor(
+    String dir, String relPath, List<int> body, List<String> urls,
     {String reason = 'absent'}) {
   return MissingParam(
     function: 'test',
@@ -52,11 +53,15 @@ void main() {
 
       expect(() => pv.parseEnvelopeForTest('not json'),
           throwsA(isA<ProvisioningException>()));
-      expect(() => pv.parseEnvelopeForTest('{"ok":false,"code":"invalid_input","message":"m"}'),
+      expect(
+          () => pv.parseEnvelopeForTest(
+              '{"ok":false,"code":"invalid_input","message":"m"}'),
           throwsA(isA<ProvisioningException>()));
 
       expect(ParameterProvisioner.provingDisabled, isFalse);
-      expect(() => pv.parseEnvelopeForTest('{"ok":false,"code":"restart_required","message":"m"}'),
+      expect(
+          () => pv.parseEnvelopeForTest(
+              '{"ok":false,"code":"restart_required","message":"m"}'),
           throwsA(isA<ProvingDisabledException>()));
       expect(ParameterProvisioner.provingDisabled, isTrue);
     });
@@ -64,7 +69,8 @@ void main() {
 
   // ── Downloader + single-flight (local server, no FFI dir set) ───────────────
   group('downloader', () {
-    test('downloads, verifies size+checksum, atomic-renames into place', () async {
+    test('downloads, verifies size+checksum, atomic-renames into place',
+        () async {
       if (dyLib == null) return;
       final dir = Directory.systemTemp.createTempSync('aleo_pv_dl_');
       final body = utf8.encode('a-fake-proving-key-${DateTime.now()}');
@@ -97,14 +103,17 @@ void main() {
         final param = missingFor(dir.path, 'resources/k.prover.def5678', body,
             ['http://127.0.0.1:$port/bad', 'http://127.0.0.1:$port/good']);
         await pv.provisionFileForTest(param);
-        expect(File(p.join(dir.path, 'resources/k.prover.def5678')).existsSync(), isTrue);
+        expect(
+            File(p.join(dir.path, 'resources/k.prover.def5678')).existsSync(),
+            isTrue);
       } finally {
         await server.close(force: true);
         dir.deleteSync(recursive: true);
       }
     });
 
-    test('rejects a wrong-checksum body (verification), leaves no file', () async {
+    test('rejects a wrong-checksum body (verification), leaves no file',
+        () async {
       if (dyLib == null) return;
       final dir = Directory.systemTemp.createTempSync('aleo_pv_bad_');
       final body = utf8.encode('actual-body');
@@ -121,16 +130,18 @@ void main() {
           checksum: sha256.convert(utf8.encode('something-else')).toString(),
           reason: 'absent',
         );
-        await expectLater(
-            pv.provisionFileForTest(param), throwsA(isA<ProvisioningException>()));
-        expect(File(p.join(dir.path, 'resources/k.prover.bad')).existsSync(), isFalse);
+        await expectLater(pv.provisionFileForTest(param),
+            throwsA(isA<ProvisioningException>()));
+        expect(File(p.join(dir.path, 'resources/k.prover.bad')).existsSync(),
+            isFalse);
       } finally {
         await server.close(force: true);
         dir.deleteSync(recursive: true);
       }
     });
 
-    test('single-flight: a concurrent provision sees the file already present', () async {
+    test('single-flight: a concurrent provision sees the file already present',
+        () async {
       if (dyLib == null) return;
       final dir = Directory.systemTemp.createTempSync('aleo_pv_sf_');
       final body = utf8.encode('single-flight-body');
@@ -145,13 +156,14 @@ void main() {
       final port = server.port;
       try {
         final pv = ParameterProvisioner(dyLib, 'mainnet', dir);
-        final param = missingFor(
-            dir.path, 'resources/k.prover.sf', body, ['http://127.0.0.1:$port/k']);
+        final param = missingFor(dir.path, 'resources/k.prover.sf', body,
+            ['http://127.0.0.1:$port/k']);
         await Future.wait([
           pv.provisionFileForTest(param),
           pv.provisionFileForTest(param),
         ]);
-        expect(File(p.join(dir.path, 'resources/k.prover.sf')).existsSync(), isTrue);
+        expect(File(p.join(dir.path, 'resources/k.prover.sf')).existsSync(),
+            isTrue);
         // The exclusive single-flight lock serialized them: only one download.
         expect(hits, 1);
       } finally {
@@ -178,7 +190,8 @@ void main() {
       expect(missing.map((m) => m.function), contains('inclusion'));
     });
 
-    test('unknown network → ProvisioningException(unsupported_network)', () async {
+    test('unknown network → ProvisioningException(unsupported_network)',
+        () async {
       if (dyLib == null) return;
       final pv = ParameterProvisioner(dyLib, 'bogusnet', shared);
       await expectLater(

--- a/packages/aleo_dart/test/aleo_provisioning_test.dart
+++ b/packages/aleo_dart/test/aleo_provisioning_test.dart
@@ -245,6 +245,31 @@ void main() {
       expect(env['code'], 'unsupported_feature');
     });
 
+    test('provisionAndProveProgram rejects custom sources BEFORE provisioning',
+        () async {
+      if (dyLib == null) return;
+      final dir = Directory.systemTemp.createTempSync('aleo_pv_prog_');
+      try {
+        final pv = ParameterProvisioner(dyLib, 'mainnet', dir);
+        await expectLater(
+          pv.provisionAndProveProgram(
+            authorization: '{}',
+            programSources:
+                '[{"id":"foo.aleo","edition":0,"source":"program foo.aleo;"}]',
+            height: 17000000,
+            consensusVersion: 13,
+          ),
+          throwsA(isA<ProvisioningException>()
+              .having((e) => e.code, 'code', 'unsupported_feature')),
+        );
+        // Rejected before any provisioning: the dir was never even touched (no
+        // ffi_set_parameter_dir, no preflight, no .locks/resources, no download).
+        expect(dir.listSync(), isEmpty);
+      } finally {
+        dir.deleteSync(recursive: true);
+      }
+    });
+
     test('consensus outside V8..=V13 → unsupported_consensus', () async {
       if (dyLib == null) return;
       final pv = ParameterProvisioner(dyLib, 'mainnet', shared);

--- a/packages/aleo_dart/test/aleo_provisioning_test.dart
+++ b/packages/aleo_dart/test/aleo_provisioning_test.dart
@@ -65,6 +65,31 @@ void main() {
           throwsA(isA<ProvingDisabledException>()));
       expect(ParameterProvisioner.provingDisabled, isTrue);
     });
+
+    test(
+        'provisionAndProveProgram checks the latch before the custom-closure check',
+        () async {
+      if (dyLib == null) return;
+      final pv = ParameterProvisioner(dyLib, 'mainnet', Directory.systemTemp);
+      // Poison the process.
+      try {
+        pv.parseEnvelopeForTest(
+            '{"ok":false,"code":"restart_required","message":"m"}');
+      } catch (_) {}
+      expect(ParameterProvisioner.provingDisabled, isTrue);
+      // A custom-program call now fail-fasts as ProvingDisabledException (Contract 3
+      // — latch first), NOT unsupported_feature.
+      await expectLater(
+        pv.provisionAndProveProgram(
+          authorization: '{}',
+          programSources:
+              '[{"id":"foo.aleo","edition":0,"source":"program foo.aleo;"}]',
+          height: 17000000,
+          consensusVersion: 13,
+        ),
+        throwsA(isA<ProvingDisabledException>()),
+      );
+    });
   }, skip: dyLib == null ? nativeLibMissingReason : null);
 
   // ── Downloader + single-flight (local server, no FFI dir set) ───────────────

--- a/packages/aleo_dart/test/aleo_provisioning_test.dart
+++ b/packages/aleo_dart/test/aleo_provisioning_test.dart
@@ -227,6 +227,24 @@ void main() {
       );
     });
 
+    test(
+        'execute_program_proof_checked binding: custom sources → unsupported_feature',
+        () {
+      if (dyLib == null) return;
+      final pv = ParameterProvisioner(dyLib, 'mainnet', shared);
+      // A non-empty closure is rejected up front (before any param load), so the
+      // authorization need not be valid — this just exercises the binding typedef.
+      final env = jsonDecode(pv.callProgramProofForTest(
+        '{}',
+        '[{"id":"foo.aleo","edition":0,"source":"program foo.aleo;"}]',
+        17000000,
+        '',
+        '',
+      ));
+      expect(env['ok'], false);
+      expect(env['code'], 'unsupported_feature');
+    });
+
     test('consensus outside V8..=V13 → unsupported_consensus', () async {
       if (dyLib == null) return;
       final pv = ParameterProvisioner(dyLib, 'mainnet', shared);

--- a/rust/aleo_ffi/docs/pr2b-orchestration-spec.md
+++ b/rust/aleo_ffi/docs/pr2b-orchestration-spec.md
@@ -1,0 +1,131 @@
+# PR2 part 2b — Dart provisioning + checked-proving orchestration (spec)
+
+> **Status:** spec for review — no code yet. **Base:** `epic/aleo-dart-monorepo` @
+> `3cfe498` (PR2 part 2a). Companion: [`pr2a-preflight-spec.md`](./pr2a-preflight-spec.md),
+> [`phase4-plan.md`](./phase4-plan.md) (§8 Contracts 1–4).
+>
+> Spec-first (the churn countermeasure): this pins the Contract 4 lock state machine,
+> the envelope/latch contract, and the downloader BEFORE coding.
+
+## 0. Scope
+
+Dart-only (+ delete dead Rust-era download code). All **additive / tested via
+`ALEO_NEW_LIB`**; the **public `AleoProgram` proving flow is NOT switched** to the
+checked symbols here — that lands with redistribution in **PR4** (so there is no
+"new Dart + old distributed lib" window). curl untouched (PR3).
+
+In: (1) Dart FFI bindings for the 6 new symbols + a fail-closed envelope parser;
+(2) the `restart_required` latch (§8 Contract 3, Dart side); (3) an atomic
+single-flight downloader; (4) Contract 4 file-locking; (5) a new orchestration
+entry `provisionAndProve…` exercised by tests; (6) delete the dead
+`downloadProvingKey` + its dead S3 URL.
+
+Out (→ PR4): switching `AleoProgram`'s public methods onto the checked symbols;
+`ffi_abi_version` + validated loader; cross-compile/redistribution. Quota/eviction
+(D2) is **not** implemented in 2b beyond the lock hooks — flagged as a follow-up.
+
+## 1. FFI bindings + envelope parsing
+
+New `programs_rust_ffi.dart` bindings (network-aware, envelope-returning, freed by
+`free_string`):
+`parameter_preflight(net, u16)`, `execute_proof_checked(net, auth, u32, paths, root)`,
+`execute_fee_proof_checked(…)`, `execute_program_proof_checked(net, auth, sources, u32,
+paths, root)`, `ffi_set_parameter_dir(path)`, `ffi_aleo_dir()`.
+
+A single `Envelope.parse(String json)` helper — **fail-closed**: parse; if not an
+object or `ok != true` → throw. `ok == false` with `code == "restart_required"` →
+trip the latch (§2) then throw; other codes → `AleoNodeException`(code+message).
+`ok == true` returns the payload (`data` or `missing`). Replaces `_require`'s
+empty-check for the new exports (the old `_static` path keeps `_require` until PR4).
+
+## 2. `restart_required` latch (Contract 3, Dart side)
+
+Process-global `bool _provingDisabled`. On any envelope `restart_required`: set it,
+throw `ProvingDisabledException("a proving parameter is corrupt; restart the app")`.
+Every checked-proving/preflight entry checks the latch FIRST and fail-fasts WITHOUT
+calling the FFI. Rationale (§8 Contract 3 / round-5): a poisoned snarkVM
+`lazy_static` is process-global and **isolate restart does not clear it** — only an
+OS-process restart does; mobile must surface "restart app", never auto-retry in-isolate.
+
+## 3. Atomic single-flight downloader
+
+dio + `CancelToken` (the existing `AleoNode` lifecycle: overall deadline, bounded
+retries, real socket abort). For each `missing` entry:
+1. acquire the file's single-flight lock (§4);
+2. **re-stat** (another flight may have finished it) — if now present+correct, done;
+3. download `urls[0]` (fall back to `urls[1]`) into `<final>.<rand>.tmp`, enforcing
+   `size` as a hard cap (abort+delete on overrun);
+4. verify SHA-256 == `checksum` (defensive; Rust preflight re-checks too);
+5. `flush`/`fsync` → atomic `rename` to the final `relativePath`;
+6. release the lock.
+Download UX (D2: Wi-Fi-only default, progress, resume) — **minimal in 2b** (a
+progress callback hook + the resume-friendly tmp+rename); full Wi-Fi-gating/resume
+policy is a thin follow-up, called out so it is not forgotten.
+
+## 4. Contract 4 file-locking (the hard part)
+
+Primitive: `dart:io` `RandomAccessFile.lock(FileLock.shared|exclusive)` (advisory;
+POSIX flock/fcntl, Windows LockFileEx; auto-released on close/exit). No FFI, no extra
+package.
+
+- **Per-file single-flight (download):** TWO layers, because `RandomAccessFile.lock`
+  is POSIX `fcntl` — it coordinates **across processes** but a process never
+  conflicts with its **own** locks (and isolates don't share statics anyway):
+  - an **in-process** async mutex keyed by `relativePath` (a static `Map<String,
+    Future>`), serializing same-isolate concurrent provisions; and
+  - inside it, an **exclusive** flock on the stable file
+    `<param-dir>/.locks/files/<sha256(relativePath)>.lock` (never renamed, so the
+    lock is not tied to the `.tmp` inode), for cross-process/isolate single-flight.
+  The holder re-checks size+SHA-256 first (a prior flight may have finished it), then
+  downloads to `<file>.<rand>.tmp` → verify → atomic `rename`. *(Found by the
+  single-flight test: the flock alone let two same-isolate downloads both run.)*
+- **Per-network tier (prove):** after all `missing` are downloaded, take a **shared**
+  lock on `<param-dir>/.locks/<network>.lock`, **re-run `parameter_preflight` under
+  the lock** (closes the TOCTOU: nothing was evicted between download and prove),
+  then call `execute_*_checked` and hold the shared lock across the **entire** FFI
+  prove call; release after. Multiple proves run concurrently (shared).
+- **Eviction (future):** would take the **exclusive** tier lock; not implemented in
+  2b, but the lock layout reserves it so eviction can't run while a prove holds shared.
+- Lock files live under the (set-once) param dir, created with the dir.
+
+## 5. Orchestration (new, test-only until PR4)
+
+`Future<String> provisionAndProve({network, consensusVersion, authorization, height,
+statePaths, publicStateRoot, programSources?})`:
+1. latch check (§2);
+2. `ffi_set_parameter_dir(dir)` once (mobile sandbox; desktop default);
+3. `parameter_preflight` → if `missing` non-empty, download each (locked, §3/§4);
+4. take shared tier lock → re-preflight (must now be empty, else
+   `AleoNodeException`) → `execute_*_checked` → release;
+5. return the proof (`data`), or throw per the envelope.
+The fee + program variants mirror this. This is a NEW method; `AleoProgram`'s
+existing public methods are untouched (PR4 switches them).
+
+## 6. Delete dead code
+Remove `downloadProvingKey` + the hardcoded `s3-us-west-1…/inclusion.prover.cd85cc5`
+URL + the now-unused `downloadFile` (grep-confirm no other caller) from
+`aleo_programs.dart`. (The `setup_dylib.dart` `pzhun` / `dyLib.dart` GPL pointers are
+PR4 / workstream D — not here.)
+
+## 7. Tests (offline / `ALEO_NEW_LIB`, like `aleo_node_test`)
+- Envelope parser: ok/missing/error/`restart_required`→latch; non-JSON→throw.
+- Latch: after `restart_required`, the next call fail-fasts without FFI.
+- Downloader vs a local `dart:io` `HttpServer`: atomic rename; size-cap abort; url[0]→
+  url[1] fallback; **single-flight** (two concurrent downloaders of the same file —
+  one downloads, one waits then sees it present).
+- Lock: concurrent `provisionAndProve` (shared tier lock lets both prove; an
+  exclusive holder blocks).
+- **Cold-cache E2E (`#[ignore]`/manual):** isolated temp param dir, download the 16
+  real files via the manifest, run a real credits prove → success. The definitive
+  "16 files sufficient" check (spec 2a §7); manual (needs ~1.2 GiB + a real node).
+
+## 8. Open decisions (review before I code)
+1. **Split 2b?** It is large (bindings+latch / downloader / locking / orchestration).
+   Option: 2b-1 = bindings + envelope + latch + downloader (additive, no locking);
+   2b-2 = Contract 4 locking + orchestration + E2E. Lean: **one PR** (the pieces are
+   tightly coupled and only meaningful together), but I can split if you prefer.
+2. **Download UX in 2b:** minimal (progress hook + resume-friendly tmp/rename) vs full
+   D2 (Wi-Fi-only gating, resume, cellular opt-in). Lean: **minimal now**, full UX a
+   follow-up — the wallet app owns the network-policy UI anyway.
+3. **Eviction/quota (D2):** lock layout reserved; implementation deferred. OK?
+4. **Lock primitive:** `RandomAccessFile.lock` (confirmed in `dart:io`). Agreed?

--- a/rust/aleo_ffi/docs/pr2b-orchestration-spec.md
+++ b/rust/aleo_ffi/docs/pr2b-orchestration-spec.md
@@ -40,12 +40,20 @@ empty-check for the new exports (the old `_static` path keeps `_require` until P
 
 ## 2. `restart_required` latch (Contract 3, Dart side)
 
-Process-global `bool _provingDisabled`. On any envelope `restart_required`: set it,
-throw `ProvingDisabledException("a proving parameter is corrupt; restart the app")`.
-Every checked-proving/preflight entry checks the latch FIRST and fail-fasts WITHOUT
-calling the FFI. Rationale (§8 Contract 3 / round-5): a poisoned snarkVM
-`lazy_static` is process-global and **isolate restart does not clear it** — only an
-OS-process restart does; mobile must surface "restart app", never auto-retry in-isolate.
+A `static bool _provingDisabled`. On any envelope `restart_required`: set it, throw
+`ProvingDisabledException`. Every checked-proving/preflight entry checks it first.
+
+**Scope (corrected):** a Dart `static` is **isolate-local**, so this is a fast-path,
+not the cross-isolate guarantee. The authoritative guard is the **Rust** side: every
+checked export is `catch_unwind`-wrapped, so a fresh isolate that calls the
+already-poisoned FFI gets `restart_required` back cheaply — a poisoned `lazy_static`
+re-deref is an immediate caught panic, not a re-download — and self-latches.
+Proving therefore never crashes and never silently succeeds after a poison, in any
+isolate; the Dart latch only spares a long-lived isolate the (safe, cheap) repeat
+FFI call. (A pid-keyed sentinel file was considered for a true cross-isolate latch
+but rejected: pid reuse could falsely latch a healthy process, worse than the cheap
+repeat call it saves.) Recovery still requires an **OS-process restart** (isolate
+restart does not clear the poisoned static); mobile surfaces "restart app".
 
 ## 3. Atomic single-flight downloader
 
@@ -79,6 +87,14 @@ package.
   The holder re-checks size+SHA-256 first (a prior flight may have finished it), then
   downloads to `<file>.<rand>.tmp` → verify → atomic `rename`. *(Found by the
   single-flight test: the flock alone let two same-isolate downloads both run.)*
+  **Documented gap:** two isolates of the SAME process are coordinated by neither
+  layer (the map is isolate-local; fcntl doesn't conflict intra-process), so both
+  could download one file — only wasted bandwidth, since each verifies + atomically
+  renames. Dart has no intra-process cross-isolate file lock; closing it needs
+  explicit isolate coordination (out of scope).
+- **Download verification is inside the url loop:** a url whose body fails
+  size/SHA-256 falls back to the next url (like a connection error), so a corrupt
+  HTTP-200 from the primary CDN tries the mirror instead of failing the provision.
 - **Per-network tier (prove):** after all `missing` are downloaded, take a **shared**
   lock on `<param-dir>/.locks/<network>.lock`, **re-run `parameter_preflight` under
   the lock** (closes the TOCTOU: nothing was evicted between download and prove),
@@ -98,8 +114,11 @@ statePaths, publicStateRoot, programSources?})`:
 4. take shared tier lock → re-preflight (must now be empty, else
    `AleoNodeException`) → `execute_*_checked` → release;
 5. return the proof (`data`), or throw per the envelope.
-The fee + program variants mirror this. This is a NEW method; `AleoProgram`'s
-existing public methods are untouched (PR4 switches them).
+All three are implemented: `provisionAndProveExecution`, `provisionAndProveFee`,
+`provisionAndProveProgram` (the program one takes `programSources`; v1 rejects a
+non-empty/custom closure with `unsupported_feature`). These are NEW methods;
+`AleoProgram`'s existing public methods are untouched (PR4 switches them). The Dio is
+caller-owned when injected (`close()` only closes an internally-created client).
 
 ## 6. Delete dead code
 Remove `downloadProvingKey` + the hardcoded `s3-us-west-1…/inclusion.prover.cd85cc5`

--- a/rust/aleo_ffi/docs/pr2b-orchestration-spec.md
+++ b/rust/aleo_ffi/docs/pr2b-orchestration-spec.md
@@ -1,11 +1,13 @@
 # PR2 part 2b — Dart provisioning + checked-proving orchestration (spec)
 
-> **Status:** spec for review — no code yet. **Base:** `epic/aleo-dart-monorepo` @
-> `3cfe498` (PR2 part 2a). Companion: [`pr2a-preflight-spec.md`](./pr2a-preflight-spec.md),
-> [`phase4-plan.md`](./phase4-plan.md) (§8 Contracts 1–4).
+> **Status:** implemented (PR #62) and reconciled with the code below. **Base:**
+> `epic/aleo-dart-monorepo` @ `3cfe498` (PR2 part 2a). Companion:
+> [`pr2a-preflight-spec.md`](./pr2a-preflight-spec.md), [`phase4-plan.md`](./phase4-plan.md)
+> (§8 Contracts 1–4).
 >
-> Spec-first (the churn countermeasure): this pins the Contract 4 lock state machine,
-> the envelope/latch contract, and the downloader BEFORE coding.
+> Written spec-first (the churn countermeasure — it pinned the Contract 4 lock state
+> machine, the envelope/latch contract, and the downloader before coding), then kept
+> in sync with the implementation through review.
 
 ## 0. Scope
 
@@ -149,7 +151,9 @@ PR4 / workstream D — not here.)
   The definitive "16 files sufficient" check (spec 2a §7) and the only real exercise
   of the prove path + tier lock.
 
-## 8. Open decisions (review before I code)
+## 8. Decisions (resolved — "按你的倾向来")
+All four taken as the lean below: one PR; minimal download UX (full D2 is a follow-up);
+eviction/quota deferred (lock layout reserved); `RandomAccessFile.lock` as the primitive.
 1. **Split 2b?** It is large (bindings+latch / downloader / locking / orchestration).
    Option: 2b-1 = bindings + envelope + latch + downloader (additive, no locking);
    2b-2 = Contract 4 locking + orchestration + E2E. Lean: **one PR** (the pieces are

--- a/rust/aleo_ffi/docs/pr2b-orchestration-spec.md
+++ b/rust/aleo_ffi/docs/pr2b-orchestration-spec.md
@@ -36,7 +36,7 @@ paths, root)`, `ffi_set_parameter_dir(path)`, `ffi_aleo_dir()`.
 
 A single `Envelope.parse(String json)` helper — **fail-closed**: parse; if not an
 object or `ok != true` → throw. `ok == false` with `code == "restart_required"` →
-trip the latch (§2) then throw; other codes → `AleoNodeException`(code+message).
+trip the latch (§2) then throw; other codes → `ProvisioningException`(code+message).
 `ok == true` returns the payload (`data` or `missing`). Replaces `_require`'s
 empty-check for the new exports (the old `_static` path keeps `_require` until PR4).
 
@@ -119,7 +119,7 @@ statePaths, publicStateRoot, programSources?})`:
 2. `ffi_set_parameter_dir(dir)` once (mobile sandbox; desktop default);
 3. `parameter_preflight` → if `missing` non-empty, download each (locked, §3/§4);
 4. take shared tier lock → re-preflight (must now be empty, else
-   `AleoNodeException`) → `execute_*_checked` → release;
+   `ProvisioningException`) → `execute_*_checked` → release;
 5. return the proof (`data`), or throw per the envelope.
 All three are implemented: `provisionAndProveExecution`, `provisionAndProveFee`,
 `provisionAndProveProgram` (the program one takes `programSources`; v1 rejects a

--- a/rust/aleo_ffi/docs/pr2b-orchestration-spec.md
+++ b/rust/aleo_ffi/docs/pr2b-orchestration-spec.md
@@ -57,18 +57,22 @@ restart does not clear the poisoned static); mobile surfaces "restart app".
 
 ## 3. Atomic single-flight downloader
 
-dio + `CancelToken` (the existing `AleoNode` lifecycle: overall deadline, bounded
-retries, real socket abort). For each `missing` entry:
-1. acquire the file's single-flight lock (§4);
-2. **re-stat** (another flight may have finished it) — if now present+correct, done;
-3. download `urls[0]` (fall back to `urls[1]`) into `<final>.<rand>.tmp`, enforcing
-   `size` as a hard cap (abort+delete on overrun);
-4. verify SHA-256 == `checksum` (defensive; Rust preflight re-checks too);
-5. `flush`/`fsync` → atomic `rename` to the final `relativePath`;
-6. release the lock.
-Download UX (D2: Wi-Fi-only default, progress, resume) — **minimal in 2b** (a
-progress callback hook + the resume-friendly tmp+rename); full Wi-Fi-gating/resume
-policy is a thin follow-up, called out so it is not forgotten.
+dio + `CancelToken`. Per url: a **connect timeout** (15s — a hung DNS/TCP on the
+primary fails over to the mirror), a **receive** between-chunks inactivity timeout
+(60s), and an **overall per-url wall-clock deadline** (a `Timer` that cancels the
+token — catches a steady-but-slow stream that never goes idle). For each `missing`
+entry, under its single-flight lock (§4): re-check size+SHA-256 (another flight may
+have finished it); else, for each url in turn, download into `<final>.<rand>.tmp`
+(`size` as a hard cap via `onReceiveProgress`), **verify size + SHA-256 — on failure
+fall back to the next url** (so a corrupt HTTP-200 from the primary tries the
+mirror); then atomic `rename` to `relativePath`. *(Durability note: just `rename`,
+no explicit `fsync`; a crash mid-write is caught by the next run's preflight
+checksum, which re-downloads.)*
+
+Download UX (D2: Wi-Fi-only default, public progress callback, resume) — **out of
+scope in 2b**; only the internal size-cap `onReceiveProgress` exists. A public
+progress callback + Wi-Fi gating + resume is a follow-up, called out so it is not
+forgotten.
 
 ## 4. Contract 4 file-locking (the hard part)
 
@@ -126,17 +130,23 @@ URL + the now-unused `downloadFile` (grep-confirm no other caller) from
 `aleo_programs.dart`. (The `setup_dylib.dart` `pzhun` / `dyLib.dart` GPL pointers are
 PR4 / workstream D — not here.)
 
-## 7. Tests (offline / `ALEO_NEW_LIB`, like `aleo_node_test`)
-- Envelope parser: ok/missing/error/`restart_required`→latch; non-JSON→throw.
-- Latch: after `restart_required`, the next call fail-fasts without FFI.
-- Downloader vs a local `dart:io` `HttpServer`: atomic rename; size-cap abort; url[0]→
-  url[1] fallback; **single-flight** (two concurrent downloaders of the same file —
-  one downloads, one waits then sees it present).
-- Lock: concurrent `provisionAndProve` (shared tier lock lets both prove; an
-  exclusive holder blocks).
-- **Cold-cache E2E (`#[ignore]`/manual):** isolated temp param dir, download the 16
-  real files via the manifest, run a real credits prove → success. The definitive
-  "16 files sufficient" check (spec 2a §7); manual (needs ~1.2 GiB + a real node).
+## 7. Tests (offline / `ALEO_NEW_LIB`, like `aleo_node_test`) — as implemented
+- Envelope parser: ok / error / `restart_required`→latch; non-JSON→throw.
+- Downloader vs a local `dart:io` `HttpServer`: download+verify+atomic rename; url[0]→
+  url[1] fallback (incl. a corrupt HTTP-200 primary → verified mirror); wrong-checksum
+  rejection; **single-flight** (two concurrent same-isolate downloaders → one download).
+- Preflight (FFI): empty dir → 16 missing/absent; unknown network; unsupported
+  consensus; `execute_program_proof_checked` binding (custom sources →
+  `unsupported_feature`); `provisionAndProveProgram` rejects custom sources before any
+  provisioning (no dir touched).
+- **Not unit-tested (documented):** the per-network **tier-lock** behavior across
+  concurrent *proves* — that path needs a real prove (real params), so it is covered
+  by the cold-cache E2E below, not an offline test. The lock primitive is `dart:io`
+  `RandomAccessFile.lock`; the exclusive flock is exercised by the single-flight test.
+- **Cold-cache E2E (manual; needs ~1.2 GiB + a real node):** isolated temp param dir,
+  download the 16 real files via the manifest, run a real credits prove → success.
+  The definitive "16 files sufficient" check (spec 2a §7) and the only real exercise
+  of the prove path + tier lock.
 
 ## 8. Open decisions (review before I code)
 1. **Split 2b?** It is large (bindings+latch / downloader / locking / orchestration).

--- a/rust/aleo_ffi/docs/pr2b-orchestration-spec.md
+++ b/rust/aleo_ffi/docs/pr2b-orchestration-spec.md
@@ -57,10 +57,11 @@ restart does not clear the poisoned static); mobile surfaces "restart app".
 
 ## 3. Atomic single-flight downloader
 
-dio + `CancelToken`. Per url: a **connect timeout** (15s — a hung DNS/TCP on the
+dio + `CancelToken`. Per url: a **connect timeout** (30s — a hung DNS/TCP on the
 primary fails over to the mirror), a **receive** between-chunks inactivity timeout
-(60s), and an **overall per-url wall-clock deadline** (a `Timer` that cancels the
-token — catches a steady-but-slow stream that never goes idle). For each `missing`
+(30min), and an **overall per-url wall-clock deadline** (`_perUrlDeadline`, default
+30min, constructor-overridable — a `Timer` that cancels the token, catching a
+steady-but-slow stream that never goes idle). For each `missing`
 entry, under its single-flight lock (§4): re-check size+SHA-256 (another flight may
 have finished it); else, for each url in turn, download into `<final>.<rand>.tmp`
 (`size` as a hard cap via `onReceiveProgress`), **verify size + SHA-256 — on failure


### PR DESCRIPTION
**Phase 4 PR2 part 2b** — the Dart side: bind the network-aware checked symbols (PR2 part 1/2a), provision the credits proving keys (preflight → download → prove), and coordinate concurrent callers/processes with advisory file locks. **Additive, exercised via `ALEO_NEW_LIB`; the public `AleoProgram` flow is NOT switched** to the checked symbols here — that lands with the redistributed library in **PR4**. **No Rust change** (symbol set stays 36; curl still on). Spec-first + kept in sync: [`docs/pr2b-orchestration-spec.md`](rust/aleo_ffi/docs/pr2b-orchestration-spec.md).

## `ParameterProvisioner` (new `aleo_provisioning.dart`)
- **FFI bindings for all 6 new symbols** — `parameter_preflight`, `execute_proof_checked`, `execute_fee_proof_checked`, **`execute_program_proof_checked`**, `ffi_set_parameter_dir`, `ffi_aleo_dir` — with a **fail-closed envelope parser** (anything not `{ok:true}` throws; used everywhere, including the param-dir set).
- **Orchestration:** `provisionAndProveExecution`, `provisionAndProveFee`, **`provisionAndProveProgram`** (preflight → download missing → shared-lock + re-preflight → `execute_*_checked`). The program variant rejects a custom closure with `unsupported_feature` at the Dart entry, **before** provisioning ~1.15 GiB, and checks the poison latch first.
- **`restart_required` latch** (§8 Contract 3): the Dart `static` is an isolate-local fast-path; the authoritative cross-isolate guard is the Rust `catch_unwind` → `restart_required` (a fresh isolate calling the poisoned FFI gets it back cheaply and self-latches — never crashes, never silently succeeds). Recovery = OS-process restart.
- **Atomic downloader:** dio + `CancelToken` with a connect timeout, a receive (between-chunks) timeout, and a **per-url wall-clock deadline** (so a hung/slow primary fails over to the mirror). Download to `<file>.<rand>.tmp`, hard size cap, **verify size + SHA-256 inside the url loop** (a corrupt HTTP-200 primary → verified mirror), atomic `rename`.
- **Contract 4 locking:** per-file single-flight = in-process async mutex (same isolate) + exclusive `RandomAccessFile.lock` flock (cross-process); per-network **shared** tier lock held across re-preflight + the whole `execute_*_checked`. (Documented gap: two isolates of one process aren't coordinated — only wasted bandwidth, since each verifies + atomic-renames. Eviction = the reserved exclusive lock; deferred.)
- Deletes the dead Rust-era download code (`downloadProvingKey` + `downloadFile` + the dead `s3-us-west-1` inclusion URL).

## Verification
- `cargo`/Rust unchanged; **full dart suite 77 pass** (envelope/latch incl. latch-before-program-reject; downloader download+verify+atomic-rename, url fallback, corrupt-primary→mirror, wrong-checksum reject, single-flight; preflight empty-dir→16 missing / unknown network / unsupported consensus; program binding → `unsupported_feature`; `provisionAndProveProgram` rejects custom sources before provisioning); `dart analyze` 0; `git diff --check` clean.
- 5 review rounds (self + external), all P2/P3 Dart-orchestration correctness/contract/consistency — no P0/P1.

## Deferred (manual; needs ~1.2 GiB + a live node)
The cold-cache E2E that proves the 16-file set is sufficient end-to-end — the definitive check for 2a §7, and the only real exercise of the prove path + tier lock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)