### PR TITLE
build(aleo_ffi): drop curl/openssl — fail-closed param load (Phase 4, PR3)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# Vendored-crate patch files are unified diffs: a blank context line is encoded
+# as a single space, which `git diff --check` would otherwise flag as trailing
+# whitespace. Exempt patch/diff files from whitespace checks so the diff stays
+# valid and re-appliable.
+*.patch -whitespace
+*.diff -whitespace

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -86,6 +86,28 @@ jobs:
           fi
           echo "exported FFI symbol set matches exactly (35 functions + free_string)"
 
+      # Workstream A (PR3) dropped curl + openssl-sys (the in-Rust param
+      # downloader is gone); workstream B (PR1) dropped the transitive ureq/rustls.
+      # Together they mean aleo_ffi links NO HTTP/TLS stack — all network I/O is in
+      # the Dart layer. Assert none of these crates can creep back into the graph
+      # (`cargo tree -i` exits non-zero when the package is absent, which is what
+      # we want).
+      - name: Verify no HTTP/TLS stack in the dependency graph
+        working-directory: rust/aleo_ffi
+        shell: bash
+        run: |
+          forbidden='curl openssl-sys openssl ureq rustls reqwest'
+          fail=0
+          for pkg in $forbidden; do
+            if cargo tree -i "$pkg" >/dev/null 2>&1; then
+              echo "ERROR: '$pkg' is back in the dependency graph (no-HTTP-stack regression):"
+              cargo tree -i "$pkg"
+              fail=1
+            fi
+          done
+          [ "$fail" = 0 ] || exit 1
+          echo "no curl/openssl-sys/ureq/rustls/reqwest in the dependency graph"
+
       # Run the Dart wrapper's FFI-backed tests against the cdylib built above,
       # so Dart/Rust signature mismatches, string-ownership bugs and wrapper
       # regressions fail CI instead of being skipped for want of a library.

--- a/rust/aleo_ffi/Cargo.lock
+++ b/rust/aleo_ffi/Cargo.lock
@@ -206,16 +206,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
-name = "cc"
-version = "1.2.63"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
-dependencies = [
- "find-msvc-tools",
- "shlex",
-]
-
-[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -227,7 +217,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -302,36 +292,6 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
-]
-
-[[package]]
-name = "curl"
-version = "0.4.49"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79fc3b6dd0b87ba36e565715bf9a2ced221311db47bd18011676f24a6066edbc"
-dependencies = [
- "curl-sys",
- "libc",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "socket2",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "curl-sys"
-version = "0.4.88+curl-8.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "644816de6547255eff4e491a1dda1c19b7237f00b62a61e6e64859ce4f2906d0"
-dependencies = [
- "cc",
- "libc",
- "libz-sys",
- "openssl-sys",
- "pkg-config",
- "vcpkg",
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -462,7 +422,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -480,12 +440,6 @@ dependencies = [
  "rand_core",
  "subtle",
 ]
-
-[[package]]
-name = "find-msvc-tools"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "foldhash"
@@ -683,18 +637,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libz-sys"
-version = "1.1.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85bc9657773828b90eeb625adff10eeac83cc21bbfd8e23a03eaa8a33c9e28d9"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
-
-[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -802,24 +744,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
-name = "openssl-probe"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.116"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
-
-[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -853,12 +777,6 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
-
-[[package]]
-name = "pkg-config"
-version = "0.3.33"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "ppv-lite86"
@@ -1017,7 +935,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1027,15 +945,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
-]
-
-[[package]]
-name = "schannel"
-version = "0.1.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
-dependencies = [
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1123,12 +1032,6 @@ dependencies = [
  "cpufeatures",
  "digest",
 ]
-
-[[package]]
-name = "shlex"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signature"
@@ -1835,7 +1738,6 @@ dependencies = [
  "anyhow",
  "cfg-if",
  "colored",
- "curl",
  "hex",
  "lazy_static",
  "parking_lot",
@@ -1974,16 +1876,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "socket2"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
-dependencies = [
- "libc",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2041,7 +1933,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -2173,12 +2065,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2274,7 +2160,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -2291,85 +2177,12 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
-dependencies = [
- "windows-targets",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
-
-[[package]]
-name = "windows-targets"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
-dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
-]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "wit-bindgen"

--- a/rust/aleo_ffi/Cargo.toml
+++ b/rust/aleo_ffi/Cargo.toml
@@ -59,8 +59,11 @@ snarkvm-synthesizer = { path = "../vendor/snarkvm-synthesizer-4.5.0" }
 # feature so the default `query` build links no HTTP stack. Verbatim 4.5.0 + the
 # 2-file `ledger-query-split-rest.patch`; Apache-2.0. See vendor/README.md.
 snarkvm-ledger-query = { path = "../vendor/snarkvm-ledger-query-4.5.0" }
-# Param-dir ownership: process-global override of the directory proving keys load
-# from (snarkVM has no env override), so the Dart layer can provision into the
-# mobile app sandbox. Verbatim 4.5.0 + parameters-param-dir.patch; Apache-2.0.
-# (curl/openssl removal is the separate workstream A / PR3.) See vendor/README.md.
+# Param-dir ownership + no remote fetch: process-global override of the directory
+# proving keys load from (snarkVM has no env override) so the Dart layer can
+# provision into the mobile app sandbox, AND the in-Rust curl downloader is
+# removed so this build links no HTTP/TLS stack (curl + openssl-sys gone; a
+# missing param fails closed with RemoteFetchDisabled). Verbatim 4.5.0 +
+# parameters-param-dir.patch + parameters-no-remote-fetch.patch; Apache-2.0.
+# See vendor/README.md.
 snarkvm-parameters = { path = "../vendor/snarkvm-parameters-4.5.0" }

--- a/rust/aleo_ffi/Cargo.toml
+++ b/rust/aleo_ffi/Cargo.toml
@@ -27,7 +27,8 @@ snarkvm-ledger-query = { version = "=4.5.0", default-features = false, features 
 snarkvm-synthesizer = "=4.5.0"
 # Direct dep so the FFI can drive parameter provisioning: set the param dir
 # (mobile sandbox) and run preflight. Vendored + patched below to own the
-# param-dir state (curl download path is untouched in this PR; removed in PR3/A).
+# param-dir state AND to remove the curl download path (a missing param fails
+# closed with RemoteFetchDisabled) — so this crate links no curl/openssl-sys.
 snarkvm-parameters = "=4.5.0"
 aleo-std-storage = "=1.0.3"
 anyhow = "1"

--- a/rust/aleo_ffi/docs/network-io-to-dart.md
+++ b/rust/aleo_ffi/docs/network-io-to-dart.md
@@ -10,18 +10,20 @@ orchestration onto the pure primitives, and lands the Rust exact-match guard
 The phase-1 `_static` proving/fee exports keep their names (the canonical rename
 is deferred to phase 4's lib redistribution — see "Deleted from Rust"). The FFI
 surface is now 29 functions + `free_string` and makes **zero node RPC calls**.
-Phase 4 (drop the proving-parameter `curl`/OpenSSL download) is not started — see
-"Proving parameters": the crate still links `curl`/`openssl-sys` for that (and
-`ureq` remains transitively via `snarkvm-ledger-query`, see "Result"), so phase 3
-is "no node RPC", not "no HTTP stack".
+Phase 4 then removed the HTTP stack itself: workstream B (PR1) dropped the
+transitive `ureq` (split `snarkvm-ledger-query`'s REST behind an opt-in feature),
+and workstream A (PR3) dropped the proving-parameter `curl`/`openssl-sys` download
+(vendored `snarkvm-parameters` now fails closed with `RemoteFetchDisabled`; the
+Dart layer provisions params). So the crate now links **no HTTP stack** — see
+"Proving parameters" and "Result".
 Owner: aleo_ffi
 Supersedes: the in-Rust HTTP hardening accreted across PR #51 review rounds 5–13.
 
 ## Phase 1 status (implemented)
 
 Phase 1 is strictly additive: it ships **ten** pure, RPC-free exports (they
-issue no node RPC; proving's parameter download is a separate, still-open matter
-— see "Proving parameters") alongside the untouched old ones — four helpers (`required_commitments`,
+issue no node RPC; proving's parameter download was a separate matter, since
+closed in phase 4 — see "Proving parameters") alongside the untouched old ones — four helpers (`required_commitments`,
 `required_imports`, `state_root_from_paths`, `consensus_version_for`) plus six
 `_static` proving/fee/authorize variants (`get_base_fee_static`,
 `execution_fee_authorization_static`, `execute_proof_static`,
@@ -397,8 +399,9 @@ I/O left in Rust to bound — the proving-parameter download is separate, see
 
 ## Deleted from Rust (phase 3, done)
 
-Removed: `aleo_ffi`'s direct `ureq` dependency (a transitive `ureq` remains via
-`snarkvm-ledger-query`, see "Result"); `http_agent`, `http_get`, `http_get_until`,
+Removed: `aleo_ffi`'s direct `ureq` dependency (the transitive `ureq` via
+`snarkvm-ledger-query` was later dropped too — phase 4 PR1, see "Result");
+`http_agent`, `http_get`, `http_get_until`,
 `http_post`, `request_once_bounded`, the `HttpMethod` enum,
 `InflightPermit`/`MAX_INFLIGHT_REQUESTS` (and its backing atomic); the
 `HTTP_REQUEST_TIMEOUT` / `HTTP_GET_ATTEMPTS` / `HTTP_GET_DEADLINE` constants;
@@ -433,24 +436,27 @@ Result: the Rust crate makes **zero RPC calls** — state, program sources, and
 broadcast all move to Dart. `aleo_ffi`'s **direct** `ureq` dependency (and all of
 its in-crate HTTP code) is gone.
 
-Two network **dependencies remain in the build tree**, neither called by our
-code, both removable only by patching upstream (not by removing a direct dep):
+At phase 3 two network **dependencies still remained in the build tree** (neither
+called by our code, both removable only by patching upstream, not by dropping a
+direct dep); **phase 4 removed both**, so the crate now links no HTTP/TLS stack:
 
-1. `ureq` (now the **rustls** flavor, v3.x) is still pulled in **transitively**
-   by `snarkvm-ledger-query`'s `query` feature — the feature that also provides
-   the offline `StaticQuery` type this phase depends on. The two are one feature
-   bundle (`query = [dep:ureq, ...]`), so there is no way to keep `StaticQuery`
-   and drop `ureq` short of vendoring/patching `snarkvm-ledger-query`. It backs
-   that crate's `RestQuery`, which `aleo_ffi` never uses.
-2. `curl` + `openssl-sys`, via `snarkvm-parameters`' proving-key / SRS download
-   (see "Proving parameters" below).
+1. `ureq` (the **rustls** flavor, v3.x) was pulled in **transitively** by
+   `snarkvm-ledger-query`'s `query` feature — bundled with the offline
+   `StaticQuery` type this phase depends on (`query = [dep:ureq, ...]`), backing
+   that crate's `RestQuery`, which `aleo_ffi` never uses. **Phase 4 PR1
+   (workstream B)** vendored + patched `snarkvm-ledger-query` to split the REST
+   surface behind an opt-in `rest` feature, so the default `query` build no
+   longer pulls `ureq`/`rustls`.
+2. `curl` + `openssl-sys`, via `snarkvm-parameters`' proving-key / SRS download.
+   **Phase 4 PR3 (workstream A)** vendored + patched `snarkvm-parameters` to fail
+   closed with `RemoteFetchDisabled` instead of curl-downloading, and dropped the
+   `curl` dependency (see "Proving parameters").
 
-Eliminating these — pre-provisioning the parameters with remote fetch disabled,
-and patching `snarkvm-ledger-query` if the transitive `ureq` must also go — is
-phase 4's work and the actual prerequisite for the no-OpenSSL iOS/Android
-cross-compile in the GPL-removal plan.
+This was the actual prerequisite for the no-OpenSSL iOS/Android cross-compile in
+the GPL-removal plan; CI now asserts none of
+`curl`/`openssl-sys`/`ureq`/`rustls`/`reqwest` are in the dependency graph.
 
-## Proving parameters (open gap — the network I/O still in Rust)
+## Proving parameters (the last in-Rust network I/O — removed in phase 4, PR3)
 
 This phase's premise is "Rust does no network I/O." That holds for **node RPC**
 (state / program sources / broadcast), but **not** for snarkVM's proving
@@ -463,9 +469,10 @@ parameters, an issue this design originally overlooked:
   downloads **each missing one** with `curl::easy` — **synchronous, with no
   timeout** (`transfer.perform()`), each retrying a list of URLs.
 - `curl` (and thus `openssl-sys`) is an unconditional `cfg(not(wasm),
-  not(sgx))` dependency of `snarkvm-parameters`; **no Cargo feature disables it**
-  on native targets. So removing `ureq` does not stop the crate linking
-  curl/OpenSSL, and a cold-cache prove can still block on the network.
+  not(sgx))` dependency of upstream `snarkvm-parameters`; **no Cargo feature
+  disables it** on native targets. So removing `ureq` did not stop the crate
+  linking curl/OpenSSL on its own, and (until PR3) a cold-cache prove could still
+  block on the network.
 
 This is **not introduced by phase 1** — the old network-bound `execute_proof`
 downloads parameters the same way — but it does mean the early "zero-network /
@@ -478,7 +485,7 @@ and make native targets take the `RemoteFetchDisabled` path that wasm/sgx alread
 use — return an error instead of fetching — then drop the `curl`/`openssl-sys`
 dependency. Parameters are pre-provisioned: bundled with the app, or downloaded
 once by the Dart layer (with `dio` timeout/cancel) into `aleo_dir()` before the
-first prove. Until then, the parameter download remains snarkVM's default
+first prove. Until PR3, the parameter download remained snarkVM's default
 behaviour.
 
 > **Status: done (Phase 4, PR3).** The vendored `snarkvm-parameters` native
@@ -518,13 +525,14 @@ behaviour.
    differs in already-distributed prebuilt libraries (a silent ABI mismatch
    instead of a clean missing-symbol error). `AleoProgram`'s public method
    signatures are unchanged. The FFI surface is 29 functions + `free_string`.
-4. **Remove the proving-parameter network dependency + re-point cross-compile**:
-   vendor/patch `snarkvm-parameters` to disable native remote fetch
-   (pre-provision the keys/SRS), dropping `curl`/`openssl-sys` — see "Proving
-   parameters". This is the actual no-OpenSSL prerequisite; folds into the
-   GPL-removal / mobile-build work. Do the `_static`→canonical rename here, in
-   lockstep with the rebuilt/redistributed library + an ABI-version guard so a
-   version skew fails loudly rather than corrupting the ABI.
+4. **Remove the proving-parameter network dependency + re-point cross-compile**
+   *(curl/openssl: done in phase 4 PR3; `_static`→canonical rename + cross-compile:
+   pending PR4)*: vendored/patched `snarkvm-parameters` to disable native remote
+   fetch (the Dart layer pre-provisions the keys), dropping `curl`/`openssl-sys` —
+   see "Proving parameters". This was the actual no-OpenSSL prerequisite; folds
+   into the GPL-removal / mobile-build work. The `_static`→canonical rename lands
+   here, in lockstep with the rebuilt/redistributed library + an ABI-version guard
+   so a version skew fails loudly rather than corrupting the ABI.
 
 ## Open questions / risks
 

--- a/rust/aleo_ffi/docs/network-io-to-dart.md
+++ b/rust/aleo_ffi/docs/network-io-to-dart.md
@@ -481,6 +481,12 @@ once by the Dart layer (with `dio` timeout/cancel) into `aleo_dir()` before the
 first prove. Until then, the parameter download remains snarkVM's default
 behaviour.
 
+> **Status: done (Phase 4, PR3).** The vendored `snarkvm-parameters` native
+> branch now returns `RemoteFetchDisabled` instead of curl-downloading
+> (`rust/vendor/parameters-no-remote-fetch.patch`), and the `curl`/`openssl-sys`
+> dependency is dropped — the crate links no HTTP/TLS stack. The Dart
+> `ParameterProvisioner` (Phase 4 PR2) provisions params before proving.
+
 ## Migration plan (phased, each independently shippable)
 
 1. **Add pure primitives + helpers under new symbol names, alongside the

--- a/rust/aleo_ffi/src/lib.rs
+++ b/rust/aleo_ffi/src/lib.rs
@@ -3060,6 +3060,26 @@ mod param_dir_tests {
 
                 let _ = std::fs::remove_dir_all(&dir);
             }
+            "missing_param_remote_fetch_disabled" => {
+                // Workstream A: with the in-Rust curl downloader removed, loading a
+                // remote (downloadable) parameter that is ABSENT from the param dir
+                // must fail closed with `RemoteFetchDisabled` — the native load macro
+                // never attempts a network download. (Before PR3 this would have
+                // curl-downloaded ~1GB; now the Dart layer provisions params first.)
+                let dir = std::env::temp_dir().join(format!("aleo_ffi_rfd_{}", std::process::id()));
+                std::fs::create_dir_all(&dir).unwrap();
+                let r = set_dir(dir.to_str().unwrap());
+                assert_eq!(r["ok"], true, "set dir: {r}");
+
+                let err = snarkvm_parameters::mainnet::InclusionProver::load_bytes()
+                    .expect_err("an absent remote param must not load (no in-Rust download)");
+                assert!(
+                    matches!(err, snarkvm_parameters::ParameterError::RemoteFetchDisabled),
+                    "expected RemoteFetchDisabled, got {err:?}",
+                );
+
+                let _ = std::fs::remove_dir_all(&dir);
+            }
             other => panic!("unknown scenario {other}"),
         }
     }
@@ -3089,6 +3109,19 @@ mod param_dir_tests {
     #[test]
     fn set_parameter_dir_rejected_after_load_started() {
         let out = run_scenario("load_started_then_set_locked");
+        assert!(
+            out.status.success(),
+            "subprocess failed.\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr),
+        );
+    }
+
+    /// Workstream A (PR3): curl is gone, so an absent remote parameter fails
+    /// closed with `RemoteFetchDisabled` instead of being downloaded in-process.
+    #[test]
+    fn missing_remote_param_fails_closed_with_remote_fetch_disabled() {
+        let out = run_scenario("missing_param_remote_fetch_disabled");
         assert!(
             out.status.success(),
             "subprocess failed.\nstdout:\n{}\nstderr:\n{}",

--- a/rust/aleo_ffi/src/lib.rs
+++ b/rust/aleo_ffi/src/lib.rs
@@ -643,11 +643,12 @@ pub unsafe extern "C" fn serial_number_string(
 // now-free canonical names is deferred to the phase-4 lib redistribution, where
 // it can land atomically with a rebuilt/redistributed library + an ABI-version
 // guard — reusing a freed name whose ABI differs in an already-distributed lib
-// would turn that clean error into a silent ABI mismatch. NOTE: this is still
-// not "zero network" — snarkVM's proving lazily downloads proving keys / the SRS
-// via `curl` (no timeout) on a cold parameter cache, so the crate still links
-// curl/openssl; removing that is a separate task (phase 4, see the spec's
-// "Proving parameters" section).
+// would turn that clean error into a silent ABI mismatch. The crate now links NO
+// HTTP/TLS stack: the vendored snarkvm-parameters curl downloader is removed
+// (parameters-no-remote-fetch.patch, workstream A), so on a cold parameter cache
+// a missing proving key fails closed with `RemoteFetchDisabled` instead of being
+// downloaded in-process — the Dart `ParameterProvisioner` provisions params
+// (download + verify + atomic rename) into the param dir before any prove.
 // ----------------------------------------------------------------------------
 
 /// Assumed serialized size of one `StatePath`, used *only* as a factor to derive

--- a/rust/vendor/README.md
+++ b/rust/vendor/README.md
@@ -69,9 +69,14 @@ is permitted with attribution; its LICENSE.md is preserved in the directory.
 
 ## snarkvm-parameters 4.5.0 (Apache-2.0)
 
-Verbatim copy of `snarkvm-parameters` 4.5.0 from crates.io with a **param-dir
-change** (see `parameters-param-dir.patch`): a new `src/parameter_dir.rs` module
-plus a two-spot edit to `src/lib.rs` / `src/macros.rs`.
+Verbatim copy of `snarkvm-parameters` 4.5.0 from crates.io with two fx-wallet
+patches, applied in order:
+
+1. **param-dir change** (`parameters-param-dir.patch`): a new
+   `src/parameter_dir.rs` module plus a two-spot edit to `src/lib.rs` /
+   `src/macros.rs`.
+2. **no-remote-fetch change** (`parameters-no-remote-fetch.patch`, workstream A /
+   PR3): removes the in-Rust curl downloader so the build links no HTTP/TLS stack.
 
 ### Why
 
@@ -96,17 +101,29 @@ The macro's **size + SHA-256 checksum guards are unchanged**, so a Dart-provisio
 parameter that is missing/corrupt is still rejected by this crate — the trust
 boundary stays in Rust even once curl is removed.
 
-**This PR (workstream B follow-on) does NOT remove curl/openssl-sys** — the
-download path is untouched; `cargo tree -i openssl-sys` still resolves through
-`snarkvm-parameters`. Flipping the native branch to `RemoteFetchDisabled` and
-dropping the `curl` dep is the separate workstream **A** (PR3).
+### No remote fetch (workstream A, PR3)
+
+The native download branch of `impl_load_bytes_logic_remote!` previously fetched a
+missing parameter with `curl` (pulling in `openssl-sys`). The
+`parameters-no-remote-fetch.patch` removes it: a parameter that is absent from the
+param dir now **fails closed** with `ParameterError::RemoteFetchDisabled` instead
+of being downloaded in-process. The Dart `ParameterProvisioner` provisions params
+(download + verify + atomic rename) into the param dir before any prove. With the
+downloader gone, the native `store_bytes` + curl `remote_fetch` and the
+`From<curl::Error>` impl are deleted and the `curl` dependency is dropped, so
+`cargo tree -i curl` / `-i openssl-sys` no longer resolve through this crate. The
+size + checksum guards stay, so the trust boundary remains in Rust. (CI's "Verify
+no HTTP/TLS stack" step asserts curl/openssl-sys/ureq/rustls/reqwest are all
+absent; a Rust subprocess test asserts an absent remote param returns
+`RemoteFetchDisabled`.)
 
 Consumed via `[patch.crates-io]` in `rust/aleo_ffi/Cargo.toml` (applies tree-wide).
 
 ### Maintenance
 
-- Upgrading snarkVM: re-extract the crate, re-apply `parameters-param-dir.patch`,
-  re-add `src/parameter_dir.rs`, replace this directory, refresh lockfiles.
+- Upgrading snarkVM: re-extract the crate, re-apply `parameters-param-dir.patch`
+  then `parameters-no-remote-fetch.patch`, re-add `src/parameter_dir.rs`, replace
+  this directory, refresh lockfiles.
 - The embedded `resources/*.metadata` (checksums/sizes) and the `impl_local!`
   base-SRS `.usrs` files (~6.3 MB, `include_bytes!`'d) are kept verbatim; only the
   downloadable (`impl_remote!`) keys are fetched at runtime into the param dir.

--- a/rust/vendor/parameters-no-remote-fetch.patch
+++ b/rust/vendor/parameters-no-remote-fetch.patch
@@ -1,0 +1,216 @@
+# No-remote-fetch patch for snarkvm-parameters 4.5.0 (Apache-2.0).
+#
+# Workstream A (Phase 4, PR3): removes the in-Rust curl downloader so the
+# native build links NO HTTP/TLS stack (drops the `curl` dependency and its
+# transitive `openssl-sys`). The load macro now FAILS CLOSED with
+# `ParameterError::RemoteFetchDisabled` when a parameter file is absent — the
+# Dart layer (packages/aleo_dart ParameterProvisioner) provisions params into
+# the (overridable) param dir BEFORE proving. The size + checksum guards in the
+# load macro are UNCHANGED, so a Dart-provisioned param that is corrupt or the
+# wrong size is still rejected by this crate; the trust boundary stays in Rust
+# even with curl gone. The wasm `remote_fetch` (XHR) is kept for crate coherence
+# (wasm is unused by this project).
+#
+# Apply AFTER `parameters-param-dir.patch`, on top of a verbatim 4.5.0
+# extraction (param-dir patch first, then this one).
+#
+diff --git a/Cargo.toml b/Cargo.toml
+index 6c1a41e..0819a3a 100644
+--- a/Cargo.toml
++++ b/Cargo.toml
+@@ -139,5 +139,6 @@ version = "0.8"
+ [dev-dependencies.wasm-bindgen-test]
+ version = "0.3.37"
+ 
+-[target.'cfg(all(not(target_family = "wasm"), not(target_env = "sgx")))'.dependencies.curl]
+-version = "0.4.43"
++# fx-wallet no-remote-fetch patch (workstream A): the `curl` dependency (and its
++# transitive `openssl-sys`) was removed. The native load macro fails closed when
++# a parameter is absent; the Dart layer provisions params before proving.
+diff --git a/src/errors/parameter.rs b/src/errors/parameter.rs
+index 344b5ea..c2fd610 100644
+--- a/src/errors/parameter.rs
++++ b/src/errors/parameter.rs
+@@ -39,12 +39,8 @@ pub enum ParameterError {
+     FilesystemDisabled,
+ }
+ 
+-#[cfg(all(not(feature = "wasm"), not(target_env = "sgx")))]
+-impl From<curl::Error> for ParameterError {
+-    fn from(error: curl::Error) -> Self {
+-        ParameterError::Crate("curl::error", error.description().to_string())
+-    }
+-}
++// fx-wallet no-remote-fetch patch (workstream A): the `From<curl::Error>` impl
++// was removed with the curl dependency (the in-Rust downloader is gone).
+ 
+ impl From<std::io::Error> for ParameterError {
+     fn from(error: std::io::Error) -> Self {
+diff --git a/src/macros.rs b/src/macros.rs
+index 7d48ad8..072f342 100644
+--- a/src/macros.rs
++++ b/src/macros.rs
+@@ -44,66 +44,11 @@ macro_rules! remove_file {
+ 
+ macro_rules! impl_store_and_remote_fetch {
+     () => {
+-        #[cfg(not(feature = "wasm"))]
+-        fn store_bytes(buffer: &[u8], file_path: &std::path::Path) -> Result<(), $crate::errors::ParameterError> {
+-            use snarkvm_utilities::Write;
+-
+-            #[cfg(not(feature = "no_std_out"))]
+-            {
+-                use colored::*;
+-                let output = format!("{:>15} - Storing file in {:?}", "Installation", file_path);
+-                println!("{}", output.dimmed());
+-            }
+-
+-            // Ensure the folders up to the file path all exist.
+-            let mut directory_path = file_path.to_path_buf();
+-            directory_path.pop();
+-            let _ = std::fs::create_dir_all(directory_path)?;
+-
+-            // Attempt to write the parameter buffer to a file.
+-            match std::fs::File::create(file_path) {
+-                Ok(mut file) => file.write_all(&buffer)?,
+-                Err(error) => eprintln!("{}", error),
+-            }
+-            Ok(())
+-        }
+-
+-        #[cfg(all(not(feature = "wasm"), not(target_env = "sgx")))]
+-        fn remote_fetch(buffer: &mut Vec<u8>, url: &str) -> Result<(), $crate::errors::ParameterError> {
+-            let mut easy = curl::easy::Easy::new();
+-            easy.follow_location(true)?;
+-            easy.url(url)?;
+-
+-            #[cfg(not(feature = "no_std_out"))]
+-            {
+-                use colored::*;
+-
+-                let output = format!("{:>15} - Downloading \"{}\"", "Installation", url);
+-                println!("{}", output.dimmed());
+-
+-                easy.progress(true)?;
+-                easy.progress_function(|total_download, current_download, _, _| {
+-                    // avoid division by zero.
+-                    if total_download == 0.0 {
+-                        return true;
+-                    }
+-                    let percent = (current_download / total_download) * 100.0;
+-                    let size_in_megabytes = total_download as u64 / 1_048_576;
+-                    let output =
+-                        format!("\r{:>15} - {:.2}% complete ({:#} MB total)", "Installation", percent, size_in_megabytes);
+-                    print!("{}", output.dimmed());
+-                    true
+-                })?;
+-            }
+-
+-            let mut transfer = easy.transfer();
+-            transfer.write_function(|data| {
+-                buffer.extend_from_slice(data);
+-                Ok(data.len())
+-            })?;
+-            Ok(transfer.perform()?)
+-        }
+-
++        // fx-wallet no-remote-fetch patch (workstream A, NOT upstream): the native
++        // `store_bytes` + curl `remote_fetch` were removed so the build links no
++        // curl/openssl-sys. The native load macro fails closed when a parameter is
++        // absent (the Dart layer provisions it first). Only the wasm `remote_fetch`
++        // remains (wasm is unused by this project but kept for crate coherence).
+         #[cfg(feature = "wasm")]
+         fn remote_fetch(url: &str) -> Result<Vec<u8>, $crate::errors::ParameterError> {
+             // Use the browser's XmlHttpRequest object to download the parameter file synchronously.
+@@ -186,82 +131,15 @@ macro_rules! impl_load_bytes_logic_remote {
+                     // Attempts to load the parameter file locally with an absolute path.
+                     std::fs::read(&file_path)?
+                 } else {
+-                    // Downloads the missing parameters and stores it in the local directory for use.
+-                    #[cfg(not(feature = "no_std_out"))]
+-                    {
+-                        use colored::*;
+-                        let path = format!("(in {:?})", file_path);
+-                        eprintln!(
+-                            "\n⚠️  \"{}\" does not exist. Downloading and storing it {}.\n",
+-                            $filename, path.dimmed()
+-                        );
+-                    }
+-
+-                    // Load remote file
+-                    cfg_if::cfg_if!{
+-                        if #[cfg(all(not(feature = "wasm"), not(target_env = "sgx")))] {
+-                            // Try each URL in order, falling back to the next if one fails.
+-                            let remote_urls: &[&str] = &$remote_urls;
+-                            let mut buffer = vec![];
+-                            let mut last_error: Option<($crate::errors::ParameterError, &str)> = None;
+-
+-                            for base_url in remote_urls.iter() {
+-                                // Remove the previous error (if any).
+-                                cfg_if::cfg_if!{
+-                                    if #[cfg(feature = "no_std_out")] {
+-                                        last_error = None;
+-                                    } else {
+-                                        use colored::Colorize;
+-                                        // If this is a retry, print the previous error as warning.
+-                                        if let Some((err, url)) = last_error.take() {
+-                                            eprintln!("{:>15} - {err}", "Warning".yellow());
+-                                            eprintln!("{:>15} - Failed to fetch from \"{url}\". Trying next source...", "Warning".yellow());
+-                                         }
+-                                    }
+-                                }
+-
+-                                let url = format!("{}/{}", base_url, $filename);
+-                                buffer.clear();
+-
+-                                match Self::remote_fetch(&mut buffer, &url) {
+-                                    Ok(()) => {
+-                                        // Ensure the checksum matches.
+-                                        let candidate_checksum = checksum!(&buffer);
+-                                        if $expected_checksum == candidate_checksum {
+-                                            // Success - break out of the loop
+-                                            break;
+-                                        } else {
+-                                            last_error = Some(($crate::errors::ParameterError::ChecksumMismatch(
+-                                                $expected_checksum.to_string(),
+-                                                candidate_checksum,
+-                                            ), base_url));
+-                                        }
+-                                    }
+-                                    Err(err) => {
+-                                        last_error = Some((err, base_url));
+-                                    }
+-                                }
+-                            }
+-
+-                            // If all URLs failed, return the last error.
+-                            if let Some((err, _)) = last_error {
+-                                return Err(err);
+-                            }
+-
+-                            match Self::store_bytes(&buffer, &file_path) {
+-                                Ok(()) => buffer,
+-                                Err(_) => {
+-                                    eprintln!(
+-                                        "\n❗ Error - Failed to store \"{}\" locally. Please download this file manually and ensure it is stored in {:?}.\n",
+-                                        $filename, file_path
+-                                    );
+-                                    buffer
+-                                }
+-                            }
+-                        } else {
+-                            return Err($crate::errors::ParameterError::RemoteFetchDisabled);
+-                        }
+-                    }
++                    // fx-wallet no-remote-fetch patch (workstream A, NOT upstream):
++                    // the in-Rust curl downloader is removed so the native build links
++                    // no HTTP/TLS stack (curl + openssl-sys). Missing parameters are
++                    // provisioned by the Dart layer into the (overridable) param dir
++                    // BEFORE proving; a file that is still absent here fails closed.
++                    // The size + checksum guards below remain the trust boundary for
++                    // files that ARE present, so a Dart-provisioned param that is
++                    // corrupt/wrong-size is still rejected by this crate.
++                    return Err($crate::errors::ParameterError::RemoteFetchDisabled);
+                 };
+ 
+                 // Ensure the size matches.

--- a/rust/vendor/snarkvm-parameters-4.5.0/Cargo.lock
+++ b/rust/vendor/snarkvm-parameters-4.5.0/Cargo.lock
@@ -229,36 +229,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "curl"
-version = "0.4.49"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79fc3b6dd0b87ba36e565715bf9a2ced221311db47bd18011676f24a6066edbc"
-dependencies = [
- "curl-sys",
- "libc",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "socket2",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "curl-sys"
-version = "0.4.84+curl-8.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abc4294dc41b882eaff37973c2ec3ae203d0091341ee68fbadd1d06e0c18a73b"
-dependencies = [
- "cc",
- "libc",
- "libz-sys",
- "openssl-sys",
- "pkg-config",
- "vcpkg",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -507,18 +477,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libz-sys"
-version = "1.1.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15d118bbf3771060e7311cc7bb0545b01d08a8b4a7de949198dec1fa0ca1c0f7"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
-
-[[package]]
 name = "linux-raw-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -639,24 +597,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
-name = "openssl-probe"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.111"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
-
-[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -690,12 +630,6 @@ name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
-
-[[package]]
-name = "pkg-config"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "ppv-lite86"
@@ -853,15 +787,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "schannel"
-version = "0.1.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
-dependencies = [
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -998,7 +923,6 @@ dependencies = [
  "anyhow",
  "cfg-if",
  "colored",
- "curl",
  "encoding",
  "hex",
  "js-sys",
@@ -1049,16 +973,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.114",
-]
-
-[[package]]
-name = "socket2"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
-dependencies = [
- "libc",
- "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1178,12 +1092,6 @@ name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
-
-[[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
@@ -1359,16 +1267,7 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -1386,31 +1285,14 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -1420,22 +1302,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1444,22 +1314,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1468,22 +1326,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -1492,22 +1338,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "wit-bindgen"

--- a/rust/vendor/snarkvm-parameters-4.5.0/Cargo.toml
+++ b/rust/vendor/snarkvm-parameters-4.5.0/Cargo.toml
@@ -139,5 +139,6 @@ version = "0.8"
 [dev-dependencies.wasm-bindgen-test]
 version = "0.3.37"
 
-[target.'cfg(all(not(target_family = "wasm"), not(target_env = "sgx")))'.dependencies.curl]
-version = "0.4.43"
+# fx-wallet no-remote-fetch patch (workstream A): the `curl` dependency (and its
+# transitive `openssl-sys`) was removed. The native load macro fails closed when
+# a parameter is absent; the Dart layer provisions params before proving.

--- a/rust/vendor/snarkvm-parameters-4.5.0/src/errors/parameter.rs
+++ b/rust/vendor/snarkvm-parameters-4.5.0/src/errors/parameter.rs
@@ -39,12 +39,8 @@ pub enum ParameterError {
     FilesystemDisabled,
 }
 
-#[cfg(all(not(feature = "wasm"), not(target_env = "sgx")))]
-impl From<curl::Error> for ParameterError {
-    fn from(error: curl::Error) -> Self {
-        ParameterError::Crate("curl::error", error.description().to_string())
-    }
-}
+// fx-wallet no-remote-fetch patch (workstream A): the `From<curl::Error>` impl
+// was removed with the curl dependency (the in-Rust downloader is gone).
 
 impl From<std::io::Error> for ParameterError {
     fn from(error: std::io::Error) -> Self {

--- a/rust/vendor/snarkvm-parameters-4.5.0/src/macros.rs
+++ b/rust/vendor/snarkvm-parameters-4.5.0/src/macros.rs
@@ -44,66 +44,11 @@ macro_rules! remove_file {
 
 macro_rules! impl_store_and_remote_fetch {
     () => {
-        #[cfg(not(feature = "wasm"))]
-        fn store_bytes(buffer: &[u8], file_path: &std::path::Path) -> Result<(), $crate::errors::ParameterError> {
-            use snarkvm_utilities::Write;
-
-            #[cfg(not(feature = "no_std_out"))]
-            {
-                use colored::*;
-                let output = format!("{:>15} - Storing file in {:?}", "Installation", file_path);
-                println!("{}", output.dimmed());
-            }
-
-            // Ensure the folders up to the file path all exist.
-            let mut directory_path = file_path.to_path_buf();
-            directory_path.pop();
-            let _ = std::fs::create_dir_all(directory_path)?;
-
-            // Attempt to write the parameter buffer to a file.
-            match std::fs::File::create(file_path) {
-                Ok(mut file) => file.write_all(&buffer)?,
-                Err(error) => eprintln!("{}", error),
-            }
-            Ok(())
-        }
-
-        #[cfg(all(not(feature = "wasm"), not(target_env = "sgx")))]
-        fn remote_fetch(buffer: &mut Vec<u8>, url: &str) -> Result<(), $crate::errors::ParameterError> {
-            let mut easy = curl::easy::Easy::new();
-            easy.follow_location(true)?;
-            easy.url(url)?;
-
-            #[cfg(not(feature = "no_std_out"))]
-            {
-                use colored::*;
-
-                let output = format!("{:>15} - Downloading \"{}\"", "Installation", url);
-                println!("{}", output.dimmed());
-
-                easy.progress(true)?;
-                easy.progress_function(|total_download, current_download, _, _| {
-                    // avoid division by zero.
-                    if total_download == 0.0 {
-                        return true;
-                    }
-                    let percent = (current_download / total_download) * 100.0;
-                    let size_in_megabytes = total_download as u64 / 1_048_576;
-                    let output =
-                        format!("\r{:>15} - {:.2}% complete ({:#} MB total)", "Installation", percent, size_in_megabytes);
-                    print!("{}", output.dimmed());
-                    true
-                })?;
-            }
-
-            let mut transfer = easy.transfer();
-            transfer.write_function(|data| {
-                buffer.extend_from_slice(data);
-                Ok(data.len())
-            })?;
-            Ok(transfer.perform()?)
-        }
-
+        // fx-wallet no-remote-fetch patch (workstream A, NOT upstream): the native
+        // `store_bytes` + curl `remote_fetch` were removed so the build links no
+        // curl/openssl-sys. The native load macro fails closed when a parameter is
+        // absent (the Dart layer provisions it first). Only the wasm `remote_fetch`
+        // remains (wasm is unused by this project but kept for crate coherence).
         #[cfg(feature = "wasm")]
         fn remote_fetch(url: &str) -> Result<Vec<u8>, $crate::errors::ParameterError> {
             // Use the browser's XmlHttpRequest object to download the parameter file synchronously.
@@ -186,82 +131,15 @@ macro_rules! impl_load_bytes_logic_remote {
                     // Attempts to load the parameter file locally with an absolute path.
                     std::fs::read(&file_path)?
                 } else {
-                    // Downloads the missing parameters and stores it in the local directory for use.
-                    #[cfg(not(feature = "no_std_out"))]
-                    {
-                        use colored::*;
-                        let path = format!("(in {:?})", file_path);
-                        eprintln!(
-                            "\n⚠️  \"{}\" does not exist. Downloading and storing it {}.\n",
-                            $filename, path.dimmed()
-                        );
-                    }
-
-                    // Load remote file
-                    cfg_if::cfg_if!{
-                        if #[cfg(all(not(feature = "wasm"), not(target_env = "sgx")))] {
-                            // Try each URL in order, falling back to the next if one fails.
-                            let remote_urls: &[&str] = &$remote_urls;
-                            let mut buffer = vec![];
-                            let mut last_error: Option<($crate::errors::ParameterError, &str)> = None;
-
-                            for base_url in remote_urls.iter() {
-                                // Remove the previous error (if any).
-                                cfg_if::cfg_if!{
-                                    if #[cfg(feature = "no_std_out")] {
-                                        last_error = None;
-                                    } else {
-                                        use colored::Colorize;
-                                        // If this is a retry, print the previous error as warning.
-                                        if let Some((err, url)) = last_error.take() {
-                                            eprintln!("{:>15} - {err}", "Warning".yellow());
-                                            eprintln!("{:>15} - Failed to fetch from \"{url}\". Trying next source...", "Warning".yellow());
-                                         }
-                                    }
-                                }
-
-                                let url = format!("{}/{}", base_url, $filename);
-                                buffer.clear();
-
-                                match Self::remote_fetch(&mut buffer, &url) {
-                                    Ok(()) => {
-                                        // Ensure the checksum matches.
-                                        let candidate_checksum = checksum!(&buffer);
-                                        if $expected_checksum == candidate_checksum {
-                                            // Success - break out of the loop
-                                            break;
-                                        } else {
-                                            last_error = Some(($crate::errors::ParameterError::ChecksumMismatch(
-                                                $expected_checksum.to_string(),
-                                                candidate_checksum,
-                                            ), base_url));
-                                        }
-                                    }
-                                    Err(err) => {
-                                        last_error = Some((err, base_url));
-                                    }
-                                }
-                            }
-
-                            // If all URLs failed, return the last error.
-                            if let Some((err, _)) = last_error {
-                                return Err(err);
-                            }
-
-                            match Self::store_bytes(&buffer, &file_path) {
-                                Ok(()) => buffer,
-                                Err(_) => {
-                                    eprintln!(
-                                        "\n❗ Error - Failed to store \"{}\" locally. Please download this file manually and ensure it is stored in {:?}.\n",
-                                        $filename, file_path
-                                    );
-                                    buffer
-                                }
-                            }
-                        } else {
-                            return Err($crate::errors::ParameterError::RemoteFetchDisabled);
-                        }
-                    }
+                    // fx-wallet no-remote-fetch patch (workstream A, NOT upstream):
+                    // the in-Rust curl downloader is removed so the native build links
+                    // no HTTP/TLS stack (curl + openssl-sys). Missing parameters are
+                    // provisioned by the Dart layer into the (overridable) param dir
+                    // BEFORE proving; a file that is still absent here fails closed.
+                    // The size + checksum guards below remain the trust boundary for
+                    // files that ARE present, so a Dart-provisioned param that is
+                    // corrupt/wrong-size is still rejected by this crate.
+                    return Err($crate::errors::ParameterError::RemoteFetchDisabled);
                 };
 
                 // Ensure the size matches.


### PR DESCRIPTION
## Workstream A — no HTTP/TLS stack

Phase 4 PR3. Removes the in-Rust **curl** downloader from the vendored
`snarkvm-parameters` crate so the native build links **no HTTP/TLS stack**
(`curl` + its transitive `openssl-sys` are gone). This is the real no-OpenSSL
prerequisite for the iOS/Android cross-compile. All parameter network I/O now
lives in the Dart layer (the PR2 `ParameterProvisioner`: download → verify →
atomic rename into the param dir, before any prove).

Base: `epic/aleo-dart-monorepo` @ `4706a7c` (PR2 part 2b).

### What changed (vendored `snarkvm-parameters-4.5.0`)
- **`src/macros.rs`** — the native file-missing branch of
  `impl_load_bytes_logic_remote!` now returns
  `ParameterError::RemoteFetchDisabled` instead of curl-downloading. The native
  `store_bytes` + curl `remote_fetch` are removed; the wasm XHR `remote_fetch`
  is kept for crate coherence (wasm is unused here).
- **`src/errors/parameter.rs`** — drop the `From<curl::Error>` impl.
- **`Cargo.toml`** — drop the `curl` dependency.
- The macro's **size + SHA-256 checksum guards are unchanged**, so a
  Dart-provisioned param that is corrupt or the wrong size is still rejected by
  this crate — the trust boundary stays in Rust even with curl gone.

The divergence from pristine upstream is documented in
`rust/vendor/parameters-no-remote-fetch.patch` (applies after
`parameters-param-dir.patch`) and the vendor `README.md`.

### Scope notes
- Build-graph + fail-closed behavior change only. **No FFI symbols added** — the
  exported set stays at 35 functions + `free_string`, so the `nm` exact-set gate
  is unchanged.
- The public `AleoProgram` proving flow is **not** switched here (PR4 does that,
  in lockstep with redistribution + `ffi_abi_version`). PR3 is additive at the
  vendored-crate level.

### Verification
- `cargo tree -i curl` / `-i openssl-sys` no longer resolve (empty); the
  lockfile drops both crates.
- New CI step **"Verify no HTTP/TLS stack"** asserts
  `curl`/`openssl-sys`/`openssl`/`ureq`/`rustls`/`reqwest` are all absent from
  the dependency graph (locks in workstreams A + B).
- New subprocess unit test
  (`missing_remote_param_fails_closed_with_remote_fetch_disabled`): pointing the
  param dir at an empty dir and loading an absent remote param returns
  `RemoteFetchDisabled` (no network attempt).
- `cargo test --lib`: **60 passed**, 2 ignored. Release cdylib builds with the
  expected **35 fns + free_string**. Dart suite **77 passed**.
- **Cold-cache E2E** (the definitive "16 files sufficient" check, ~1.2 GiB + a
  live node) remains a **manual** run — it is the only real exercise of the
  curl-off prove path and is documented in the 2a/2b specs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)