### PR TITLE
feat(aleo): finalize the FFI ABI + network-aware Dart, lockstep (Phase 4, PR4a)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -47,29 +47,25 @@ jobs:
         run: |
           lib=target/release/libaleo_rust.so
           test -f "$lib" || { echo "release cdylib not found"; exit 1; }
-          # Phase 3 deleted the 12 in-Rust node-RPC exports (the node I/O moved to
-          # the Dart AleoNode). The phase-3 surface is 29 FFI functions + free_string:
-          # 19 offline/account/record originals (31 - 12 deleted) plus the 10
-          # phase-1 I/O-to-Dart primitives/helpers (the proving/fee ones keep their
-          # `_static` names; the canonical rename is deferred to phase 4). Phase 4
-          # PR2 adds the parameter-directory control exports (ffi_set_parameter_dir,
-          # ffi_aleo_dir), the network-aware checked proving exports
-          # (execute_proof_checked, execute_fee_proof_checked,
-          # execute_program_proof_checked) and parameter_preflight → 35 functions +
-          # free_string. The full
-          # EXACT exported set is compared (not just presence), so CI also fails if a
-          # deleted RPC symbol survives or an unexpected symbol appears.
+          # Phase 4 PR4a finalized the ABI (workstream C): the 3 plain proving
+          # exports (execute_proof_static / execute_fee_proof_static /
+          # execute_program_proof_static) were DELETED (superseded by the enveloped
+          # *_checked ones), the 3 remaining `_static` exports were renamed to
+          # canonical + made network-aware (get_base_fee, execution_fee_authorization,
+          # program_authorization), and ffi_abi_version was added (the Dart loader's
+          # ABI guard). Net: 35 - 3 + 1 = 33 FFI functions + free_string = 34 symbols.
+          # The full EXACT exported set is compared (not just presence), so CI also
+          # fails if a deleted symbol survives or an unexpected symbol appears.
           expected=$(printf '%s\n' \
-            numbers_add seed_to_private_key private_key_to_address \
+            ffi_abi_version numbers_add seed_to_private_key private_key_to_address \
             private_key_to_view_key view_key_to_address sign_message verify \
             get_token_owner_hash is_owner decrypt_cipher_text serial_number_string \
             encrypt_private_key decrypt_to_private_key decrypt_sender_ciphertext \
             build_transaction_offline execution_authorization join_authorization \
             upgrade_authorization build_upgrade_transaction_offline free_string \
             required_commitments required_imports state_root_from_paths \
-            consensus_version_for get_base_fee_static execution_fee_authorization_static \
-            execute_proof_static execute_fee_proof_static execute_program_proof_static \
-            program_authorization_static ffi_set_parameter_dir ffi_aleo_dir \
+            consensus_version_for get_base_fee execution_fee_authorization \
+            program_authorization ffi_set_parameter_dir ffi_aleo_dir \
             execute_proof_checked execute_fee_proof_checked execute_program_proof_checked \
             parameter_preflight | sort -u)
           # Exported defined symbols, minus the ELF runtime symbols the linker adds
@@ -84,7 +80,7 @@ jobs:
             comm -13 <(printf '%s\n' "$expected") <(printf '%s\n' "$actual")
             exit 1
           fi
-          echo "exported FFI symbol set matches exactly (35 functions + free_string)"
+          echo "exported FFI symbol set matches exactly (33 functions + free_string)"
 
       # Workstream A (PR3) dropped curl + openssl-sys (the in-Rust param
       # downloader is gone); workstream B (PR1) dropped the transitive ureq/rustls.

--- a/packages/aleo_dart/CHANGELOG.md
+++ b/packages/aleo_dart/CHANGELOG.md
@@ -12,6 +12,26 @@
   load time. Tests that broadcast real transactions are marked as manual
   integration tests.
 
+### Added
+
+- `AleoLib` + `IncompatibleNativeLibraryException`: the native library's
+  `ffi_abi_version` is validated when constructing `AleoAccount`, `AleoRecord`,
+  `AleoProgram`, or `ParameterProvisioner` (a bare `DynamicLibrary` or an `AleoLib`
+  are both accepted). An incompatible or stale library now fails loudly at load
+  time instead of mis-binding a renamed symbol or an argument slot.
+
+### Changed
+
+- The native FFI ABI is finalized and network-aware (Phase 4). Every network-typed
+  export takes a `network` (`"mainnet"`/`"testnet"`); proving goes through
+  `ParameterProvisioner` (preflight → download proving keys → the checked proving
+  path), so a cold parameter cache is provisioned cleanly.
+- **Custom-program proving is not supported in this version (credits-only).**
+  `executeProgram`, `contractExecution`, `contractFeeExecution`, and
+  `executeProgramProof` now reject a non-`credits.aleo` program with
+  `unsupported_feature`, deterministically and before any node I/O. The methods are
+  retained for API stability; arbitrary-program support is a future version.
+
 ## [1.0.0]
 
 - Initial release in the fx-wallet-packages monorepo.

--- a/packages/aleo_dart/lib/src/aleo_account.dart
+++ b/packages/aleo_dart/lib/src/aleo_account.dart
@@ -4,6 +4,7 @@ import 'package:bip39/bip39.dart' as bip39;
 import 'package:ffi/ffi.dart';
 
 import 'package:aleo_dart/src/rust_lib/account_rust_ffi.dart';
+import 'package:aleo_dart/src/rust_lib/dyLib.dart';
 import 'package:aleo_dart/src/aleo_hd_key.dart';
 import 'package:aleo_dart/src/rust_lib/utils.dart';
 import 'package:aleo_dart/src/aleo_utils.dart';
@@ -13,7 +14,8 @@ const ALEO_PATH = "m/44/0/0/0";
 class AleoAccount {
   late AccountRustFFI accountRustFFI;
   AleoAccount(dyLib, [String network_raw = 'testnet']) {
-    this.accountRustFFI = AccountRustFFI(dyLib, network_raw);
+    this.accountRustFFI =
+        AccountRustFFI(AleoLib.coerce(dyLib).dyLib, network_raw);
   }
 
   int testRustFFi(int a, int b) {

--- a/packages/aleo_dart/lib/src/aleo_programs.dart
+++ b/packages/aleo_dart/lib/src/aleo_programs.dart
@@ -230,8 +230,24 @@ class AleoProgram {
     }
   }
 
-  /// Executes an arbitrary program function and broadcasts the transaction,
-  /// returning the node response. The fee is public (no fee record).
+  /// Fetches a program's import closure, **rejecting a custom program up front**:
+  /// v1 is credits-only, so a non-empty closure (anything but `credits.aleo`)
+  /// throws `unsupported_feature` here — deterministically, before authorize /
+  /// state-path / proving work — rather than surfacing later as a malformed-auth
+  /// or node error. credits.aleo is built in, so its closure is empty.
+  Future<String> _creditsOnlyClosure(AleoNode node, String programId) async {
+    final sources = await node.programClosure(programId);
+    if (!ParameterProvisioner.isEmptyClosure(sources)) {
+      throw ProvisioningException('unsupported_feature',
+          'custom-program proving is not supported in this version');
+    }
+    return sources;
+  }
+
+  /// v1 (credits-only): executes a **credits.aleo** function and broadcasts the
+  /// transaction. A non-credits `program_id_raw` is rejected with
+  /// `unsupported_feature`. The fee is public (no fee record). The method is kept
+  /// for API stability; arbitrary-program support is a future version.
   Future<String> executeProgram(
     String private_key_raw,
     String program_id_raw,
@@ -247,10 +263,9 @@ class AleoProgram {
       final height = await node.latestHeight();
       final version = programsRustFFI.consensusVersionFor(height);
 
-      // Fetch the program's import closure once; it is needed to authorize, to
-      // prove, and to cost the fee (execution_cost reads each transition's
-      // program Stack).
-      final sources = await node.programClosure(program_id_raw);
+      // Fetch the program's import closure once (empty for credits.aleo); a
+      // custom program is rejected here before any further work.
+      final sources = await _creditsOnlyClosure(node, program_id_raw);
 
       final auth = _require(
           await programAuthorizationStatic(private_key_raw, program_id_raw,
@@ -283,9 +298,10 @@ class AleoProgram {
     }
   }
 
-  /// Produces the execution proof for an arbitrary program function (split
-  /// proof; the fee follows via [contractFeeExecution]). Returns the serialized
-  /// execution.
+  /// Produces the execution proof for a **credits.aleo** function (split proof;
+  /// the fee follows via [contractFeeExecution]). v1 is credits-only: a custom
+  /// `program_id_raw` is rejected with `unsupported_feature`. Returns the
+  /// serialized execution.
   Future<String> contractExecution(
     String private_key_raw,
     String program_id_raw,
@@ -295,7 +311,7 @@ class AleoProgram {
   ) async {
     final node = _node(url_raw);
     final height = await node.latestHeight();
-    final sources = await node.programClosure(program_id_raw);
+    final sources = await _creditsOnlyClosure(node, program_id_raw);
     final auth = _require(
         await programAuthorizationStatic(private_key_raw, program_id_raw,
             function_name_raw, arguments_raw, sources),
@@ -303,8 +319,9 @@ class AleoProgram {
     return _proveProgramExecution(node, auth, sources, height);
   }
 
-  /// Produces the public fee proof for a contract execution. Returns the
-  /// serialized fee.
+  /// Produces the public fee proof for a **credits.aleo** contract execution. v1
+  /// is credits-only: a custom `program_id_raw` is rejected with
+  /// `unsupported_feature`. Returns the serialized fee.
   Future<String> contractFeeExecution(
     String private_key_raw,
     int fee,
@@ -315,7 +332,7 @@ class AleoProgram {
     AleoUtils.checkAmount(fee, 'fee');
     final node = _node(url_raw);
     final height = await node.latestHeight();
-    final sources = await node.programClosure(program_id_raw);
+    final sources = await _creditsOnlyClosure(node, program_id_raw);
     final feeAuth = _require(
         await executionFeeAuthorizationStatic(
             private_key_raw, execution_raw, fee, '', sources, height),
@@ -333,13 +350,14 @@ class AleoProgram {
     return _proveExecution(node, authorization_raw, height);
   }
 
-  /// Generates the execution proof for an authorization that targets a
-  /// non-builtin program: its closure is fetched and supplied in-memory.
+  /// Generates the execution proof for an authorization through the program path.
+  /// v1 is credits-only: a non-`credits.aleo` [program_id_raw] is rejected with
+  /// `unsupported_feature` (the closure is fetched and, for credits.aleo, empty).
   Future<String> executeProgramProof(String url_raw, String authorization_raw,
       {String program_id_raw = 'credits.aleo'}) async {
     final node = _node(url_raw);
     final height = await node.latestHeight();
-    final sources = await node.programClosure(program_id_raw);
+    final sources = await _creditsOnlyClosure(node, program_id_raw);
     return _proveProgramExecution(node, authorization_raw, sources, height);
   }
 

--- a/packages/aleo_dart/lib/src/aleo_programs.dart
+++ b/packages/aleo_dart/lib/src/aleo_programs.dart
@@ -230,18 +230,18 @@ class AleoProgram {
     }
   }
 
-  /// Fetches a program's import closure, **rejecting a custom program up front**:
-  /// v1 is credits-only, so a non-empty closure (anything but `credits.aleo`)
-  /// throws `unsupported_feature` here — deterministically, before authorize /
-  /// state-path / proving work — rather than surfacing later as a malformed-auth
-  /// or node error. credits.aleo is built in, so its closure is empty.
-  Future<String> _creditsOnlyClosure(AleoNode node, String programId) async {
-    final sources = await node.programClosure(programId);
-    if (!ParameterProvisioner.isEmptyClosure(sources)) {
+  /// The import closure for a credits-only program, **rejecting a custom program
+  /// before any node I/O**: v1 supports only `credits.aleo`, so a non-credits
+  /// `programId` throws `unsupported_feature` deterministically here — it never
+  /// reaches `programClosure`/`latestHeight`, so an unreachable/404/slow/malicious
+  /// node cannot mask the rejection with an `AleoNodeException`. credits.aleo is
+  /// built in, so its closure is empty (`[]`) and needs no node fetch at all.
+  String _creditsOnlyClosure(String programId) {
+    if (programId != 'credits.aleo') {
       throw ProvisioningException('unsupported_feature',
           'custom-program proving is not supported in this version');
     }
-    return sources;
+    return '[]';
   }
 
   /// v1 (credits-only): executes a **credits.aleo** function and broadcasts the
@@ -257,15 +257,13 @@ class AleoProgram {
     String url_raw,
   ) async {
     AleoUtils.checkAmount(fee, 'fee');
+    // v1 credits-only: reject a custom program before any node I/O.
+    final sources = _creditsOnlyClosure(program_id_raw);
     final node = _node(url_raw);
 
     for (var attempt = 0;; attempt++) {
       final height = await node.latestHeight();
       final version = programsRustFFI.consensusVersionFor(height);
-
-      // Fetch the program's import closure once (empty for credits.aleo); a
-      // custom program is rejected here before any further work.
-      final sources = await _creditsOnlyClosure(node, program_id_raw);
 
       final auth = _require(
           await programAuthorizationStatic(private_key_raw, program_id_raw,
@@ -309,9 +307,10 @@ class AleoProgram {
     String arguments_raw,
     String url_raw,
   ) async {
+    // v1 credits-only: reject a custom program before any node I/O.
+    final sources = _creditsOnlyClosure(program_id_raw);
     final node = _node(url_raw);
     final height = await node.latestHeight();
-    final sources = await _creditsOnlyClosure(node, program_id_raw);
     final auth = _require(
         await programAuthorizationStatic(private_key_raw, program_id_raw,
             function_name_raw, arguments_raw, sources),
@@ -330,9 +329,10 @@ class AleoProgram {
     String url_raw,
   ) async {
     AleoUtils.checkAmount(fee, 'fee');
+    // v1 credits-only: reject a custom program before any node I/O.
+    final sources = _creditsOnlyClosure(program_id_raw);
     final node = _node(url_raw);
     final height = await node.latestHeight();
-    final sources = await _creditsOnlyClosure(node, program_id_raw);
     final feeAuth = _require(
         await executionFeeAuthorizationStatic(
             private_key_raw, execution_raw, fee, '', sources, height),
@@ -352,12 +352,13 @@ class AleoProgram {
 
   /// Generates the execution proof for an authorization through the program path.
   /// v1 is credits-only: a non-`credits.aleo` [program_id_raw] is rejected with
-  /// `unsupported_feature` (the closure is fetched and, for credits.aleo, empty).
+  /// `unsupported_feature` before any node I/O (credits.aleo's closure is empty).
   Future<String> executeProgramProof(String url_raw, String authorization_raw,
       {String program_id_raw = 'credits.aleo'}) async {
+    // v1 credits-only: reject a custom program before any node I/O.
+    final sources = _creditsOnlyClosure(program_id_raw);
     final node = _node(url_raw);
     final height = await node.latestHeight();
-    final sources = await _creditsOnlyClosure(node, program_id_raw);
     return _proveProgramExecution(node, authorization_raw, sources, height);
   }
 

--- a/packages/aleo_dart/lib/src/aleo_programs.dart
+++ b/packages/aleo_dart/lib/src/aleo_programs.dart
@@ -1,32 +1,39 @@
 import 'dart:convert';
+import 'dart:ffi' as ffi;
+import 'dart:io';
 
 import 'package:dio/dio.dart';
+import 'package:ffi/ffi.dart';
 
 import 'package:aleo_dart/src/aleo_node.dart';
+import 'package:aleo_dart/src/aleo_provisioning.dart';
+import 'package:aleo_dart/src/rust_lib/dyLib.dart';
 import 'package:aleo_dart/src/rust_lib/programs_rust_ffi.dart';
 import 'package:aleo_dart/src/rust_lib/utils.dart';
 import 'package:aleo_dart/src/aleo_utils.dart';
 
 /// Aleo program orchestration.
 ///
-/// Phase 2 of the I/O-to-Dart migration: the one-call flows (`tryTransfer`,
-/// `tryJoin`, `buildTransaction`, `executeProgram`, `contractExecution`,
-/// `contractFeeExecution`) and the node-touching leaves (`executeProof`,
-/// `executeFeeProof`, `executeProgramProof`, `getBaseFee`,
-/// `executionFeeAuthorization`, `broadcast`) no longer call the blocking-HTTP
-/// FFI exports. They compose the pure phase-1 `*_static` primitives over data an
-/// [AleoNode] fetches in Dart (with real `CancelToken` cancellation), so the
-/// network I/O lives in a layer that can actually be cancelled and bounded.
-/// Public method signatures are unchanged.
+/// The one-call flows (`tryTransfer`, `tryJoin`, `buildTransaction`,
+/// `executeProgram`, ...) and the node-touching leaves compose the offline
+/// authorize/fee/build primitives over data an [AleoNode] fetches in Dart (with
+/// real `CancelToken` cancellation), so the network I/O lives in a layer that can
+/// be cancelled and bounded.
 ///
-/// The split-proof transfer flow mirrors the old in-Rust `full_transaction`
-/// exactly — authorize → prove execution → authorize fee → prove fee → assemble
-/// — but takes two independent inclusion snapshots (execution, then the fee,
-/// because a private fee spends its own record) and pins one consensus version
-/// across the whole transaction (a mid-flow upgrade discards everything and
-/// restarts).
+/// Phase 4 PR4a: proving goes through [ParameterProvisioner] (preflight →
+/// download proving keys → the enveloped, network-aware `*_checked` exports), so
+/// a cold parameter cache provisions cleanly instead of the old in-Rust download,
+/// and a poisoned parameter latches `restart_required` instead of aborting. The
+/// split-proof flow still takes two independent inclusion snapshots (execution,
+/// then the fee) and pins one consensus version across the whole transaction (a
+/// mid-flow upgrade discards everything and restarts).
 class AleoProgram {
   late ProgramsRustFFI programsRustFFI;
+
+  /// The directory proving keys are provisioned into (mobile app sandbox; desktop
+  /// defaults to the library's `aleo_dir()`). Resolved lazily for the provisioner.
+  final Directory? _paramDir;
+  ParameterProvisioner? _provisioner;
 
   /// One HTTP client shared by every node operation, created lazily. Each
   /// operation builds a fresh [AleoNode] but they all reuse this Dio, so we do
@@ -39,8 +46,36 @@ class AleoProgram {
   /// retry means something is badly wrong rather than a real version churn.
   static const int _maxConsensusRetries = 3;
 
-  AleoProgram(dyLib, [String network_raw = 'testnet']) {
-    this.programsRustFFI = ProgramsRustFFI(dyLib, network_raw);
+  /// [dyLib] is validated against the ABI version at construction
+  /// ([AleoLib.coerce]); a bare `DynamicLibrary` or an `AleoLib` are both
+  /// accepted. [paramDir] is where proving keys are provisioned — pass the app
+  /// sandbox on mobile; if omitted, the library's `aleo_dir()` is used.
+  AleoProgram(dyLib, [String network_raw = 'testnet', Directory? paramDir])
+      : _paramDir = paramDir {
+    this.programsRustFFI =
+        ProgramsRustFFI(AleoLib.coerce(dyLib).dyLib, network_raw);
+  }
+
+  /// The parameter provisioner (lazy). Proving funnels through it so a cold cache
+  /// is provisioned (download + verify + atomic rename) before the checked proof.
+  ParameterProvisioner _prov() => _provisioner ??= ParameterProvisioner(
+        programsRustFFI.dyLib,
+        programsRustFFI.network,
+        _paramDir ?? _libAleoDir(),
+      );
+
+  /// The library's effective `aleo_dir()` (the default proving-key directory),
+  /// read through the `ffi_aleo_dir` envelope. Used when no [_paramDir] is given.
+  Directory _libAleoDir() {
+    final fn = programsRustFFI.dyLib.lookupFunction<
+        ffi.Pointer<Utf8> Function(),
+        ffi.Pointer<Utf8> Function()>('ffi_aleo_dir');
+    final raw = takeNativeString(programsRustFFI.dyLib, fn());
+    final env = jsonDecode(raw) as Map<String, dynamic>;
+    if (env['ok'] != true) {
+      throw AleoNodeException('ffi_aleo_dir failed: $raw');
+    }
+    return Directory(env['data'] as String);
   }
 
   /// A node bound to [url_raw] and this program's network, reusing the shared
@@ -60,6 +95,8 @@ class AleoProgram {
   void dispose() {
     _httpClient?.close(force: true);
     _httpClient = null;
+    _provisioner?.close();
+    _provisioner = null;
   }
 
   // --- one-call flows (compose primitives + node I/O) -----------------------
@@ -442,70 +479,11 @@ class AleoProgram {
   }
 
   // --- phase-1 pure primitives (Dart wrappers) ------------------------------
-
-  /// Proves [authorization] (a serialized fee authorization) against its own
-  /// pre-fetched snapshot.
-  Future<String> executeFeeProofStatic(
-    String authorization_raw,
-    int height,
-    String state_paths_json,
-    String public_state_root,
-  ) async {
-    final authorization = dartStrToC(authorization_raw);
-    final statePaths = dartStrToC(state_paths_json);
-    final publicRoot = dartStrToC(public_state_root);
-    try {
-      return takeNativeString(
-          programsRustFFI.dyLib,
-          programsRustFFI.executeFeeProofStatic(
-              authorization, height, statePaths, publicRoot));
-    } finally {
-      freeAll([authorization, statePaths, publicRoot]);
-    }
-  }
-
-  /// Proves [authorization] against a StaticQuery built from pre-fetched node
-  /// data (no node RPC; proving may still download parameters on a cold cache).
-  Future<String> executeProofStatic(
-    String authorization_raw,
-    int height,
-    String state_paths_json,
-    String public_state_root,
-  ) async {
-    final authorization = dartStrToC(authorization_raw);
-    final statePaths = dartStrToC(state_paths_json);
-    final publicRoot = dartStrToC(public_state_root);
-    try {
-      return takeNativeString(
-          programsRustFFI.dyLib,
-          programsRustFFI.executeProofStatic(
-              authorization, height, statePaths, publicRoot));
-    } finally {
-      freeAll([authorization, statePaths, publicRoot]);
-    }
-  }
-
-  /// Like [executeProofStatic] but the program closure is supplied in-memory.
-  Future<String> executeProgramProofStatic(
-    String authorization_raw,
-    String program_sources_json,
-    int height,
-    String state_paths_json,
-    String public_state_root,
-  ) async {
-    final authorization = dartStrToC(authorization_raw);
-    final sources = dartStrToC(program_sources_json);
-    final statePaths = dartStrToC(state_paths_json);
-    final publicRoot = dartStrToC(public_state_root);
-    try {
-      return takeNativeString(
-          programsRustFFI.dyLib,
-          programsRustFFI.executeProgramProofStatic(
-              authorization, sources, height, statePaths, publicRoot));
-    } finally {
-      freeAll([authorization, sources, statePaths, publicRoot]);
-    }
-  }
+  //
+  // The proving steps moved to [ParameterProvisioner] in PR4a (preflight →
+  // download → the enveloped `*_checked` exports); the old plain `execute_*_static`
+  // proving symbols were deleted. See `_proveExecution` / `_proveFee` /
+  // `_proveProgramExecution`.
 
   /// Builds the fee authorization for a proven [execution] at [height].
   Future<String> executionFeeAuthorizationStatic(
@@ -524,7 +502,7 @@ class AleoProgram {
     try {
       return takeNativeString(
           programsRustFFI.dyLib,
-          programsRustFFI.executionFeeAuthorizationStatic(
+          programsRustFFI.executionFeeAuthorization(
               private_key, execution, fee_credits, fee_record, sources, height));
     } finally {
       freeAll([private_key, execution, fee_record, sources]);
@@ -548,7 +526,7 @@ class AleoProgram {
     try {
       return takeNativeString(
           programsRustFFI.dyLib,
-          programsRustFFI.programAuthorizationStatic(
+          programsRustFFI.programAuthorization(
               private_key, program_id, function_name, arguments, sources));
     } finally {
       freeAll([private_key, program_id, function_name, arguments, sources]);
@@ -561,7 +539,7 @@ class AleoProgram {
     final execution = dartStrToC(execution_raw);
     final programSources = dartStrToC(sources);
     try {
-      return programsRustFFI.getBaseFeeStatic(execution, programSources, height);
+      return programsRustFFI.getBaseFee(execution, programSources, height);
     } finally {
       freeAll([execution, programSources]);
     }
@@ -620,43 +598,56 @@ class AleoProgram {
 
   /// Snapshot contract for a credits.aleo authorization: fetch the state paths
   /// for its required commitments (empty for a public flow, in which case the
-  /// latest state root is fetched instead), then prove.
+  /// latest state root is fetched instead), then provision parameters + prove via
+  /// the network-aware checked path. The provisioner throws on failure (it never
+  /// returns an empty proof), so no `_require` is needed here.
   Future<String> _proveExecution(
       AleoNode node, String authorization, int height) async {
     final commitments = requiredCommitments(authorization);
     final paths = await node.statePaths(commitments);
-    final publicRoot =
-        commitments.isEmpty ? await node.latestStateRoot() : '';
-    return _require(
-        await executeProofStatic(authorization, height, paths, publicRoot),
-        'execution proof');
+    final publicRoot = commitments.isEmpty ? await node.latestStateRoot() : '';
+    return _prov().provisionAndProveExecution(
+      authorization: authorization,
+      height: height,
+      consensusVersion: consensusVersionFor(height),
+      statePaths: paths,
+      publicStateRoot: publicRoot,
+    );
   }
 
   /// Snapshot contract for a fee authorization (its own commitments — a private
-  /// fee spends its own record), then prove.
+  /// fee spends its own record), then provision + prove.
   Future<String> _proveFee(
       AleoNode node, String feeAuthorization, int height) async {
     final commitments = requiredCommitments(feeAuthorization);
     final paths = await node.statePaths(commitments);
-    final publicRoot =
-        commitments.isEmpty ? await node.latestStateRoot() : '';
-    return _require(
-        await executeFeeProofStatic(feeAuthorization, height, paths, publicRoot),
-        'fee proof');
+    final publicRoot = commitments.isEmpty ? await node.latestStateRoot() : '';
+    return _prov().provisionAndProveFee(
+      authorization: feeAuthorization,
+      height: height,
+      consensusVersion: consensusVersionFor(height),
+      statePaths: paths,
+      publicStateRoot: publicRoot,
+    );
   }
 
   /// Snapshot contract for an arbitrary-program authorization, proved with the
-  /// program closure supplied in-memory.
+  /// program closure supplied in-memory. v1 is credits-only, so a non-empty
+  /// closure (a custom program) is rejected with `unsupported_feature` by the
+  /// provisioner before any download.
   Future<String> _proveProgramExecution(
       AleoNode node, String authorization, String sources, int height) async {
     final commitments = requiredCommitments(authorization);
     final paths = await node.statePaths(commitments);
-    final publicRoot =
-        commitments.isEmpty ? await node.latestStateRoot() : '';
-    return _require(
-        await executeProgramProofStatic(
-            authorization, sources, height, paths, publicRoot),
-        'program execution proof');
+    final publicRoot = commitments.isEmpty ? await node.latestStateRoot() : '';
+    return _prov().provisionAndProveProgram(
+      authorization: authorization,
+      height: height,
+      consensusVersion: consensusVersionFor(height),
+      programSources: sources,
+      statePaths: paths,
+      publicStateRoot: publicRoot,
+    );
   }
 
   /// The phase-1 primitives return "" on failure (the FFI's single error

--- a/packages/aleo_dart/lib/src/aleo_provisioning.dart
+++ b/packages/aleo_dart/lib/src/aleo_provisioning.dart
@@ -9,6 +9,7 @@ import 'package:dio/dio.dart';
 import 'package:ffi/ffi.dart';
 import 'package:path/path.dart' as p;
 
+import 'rust_lib/dyLib.dart';
 import 'rust_lib/utils.dart';
 
 /// Thrown when the native side reports `restart_required`: a proving parameter is
@@ -104,12 +105,13 @@ class ParameterProvisioner {
   static bool get provingDisabled => _provingDisabled;
 
   ParameterProvisioner(
-    this._lib,
+    Object lib,
     this.network,
     this.paramDir, {
     Dio? dio,
     Duration? perUrlDownloadDeadline,
-  })  : _ownsDio = dio == null,
+  })  : _lib = AleoLib.coerce(lib).dyLib,
+        _ownsDio = dio == null,
         _perUrlDeadline = perUrlDownloadDeadline ?? const Duration(minutes: 30),
         _dio = dio ??
             Dio(BaseOptions(

--- a/packages/aleo_dart/lib/src/aleo_provisioning.dart
+++ b/packages/aleo_dart/lib/src/aleo_provisioning.dart
@@ -496,8 +496,9 @@ class ParameterProvisioner {
 
   /// An empty program closure: `""` or `"[]"` (an empty JSON array). Mirrors the
   /// native rule so a custom program is rejected at the Dart entry; a non-array or
-  /// malformed value is NOT empty (and the native side would reject it too).
-  static bool _isEmptyClosure(String programSources) {
+  /// malformed value is NOT empty (and the native side would reject it too). Public
+  /// so the orchestration layer can fail-fast a custom program before any node I/O.
+  static bool isEmptyClosure(String programSources) {
     final trimmed = programSources.trim();
     if (trimmed.isEmpty) return true;
     try {
@@ -524,7 +525,7 @@ class ParameterProvisioner {
     // Latch first (Contract 3): a poisoned process fail-fasts as
     // ProvingDisabledException, even for a custom-program call.
     _ensureNotDisabled();
-    if (!_isEmptyClosure(programSources)) {
+    if (!isEmptyClosure(programSources)) {
       throw ProvisioningException('unsupported_feature',
           'custom-program proving is not supported in this version');
     }

--- a/packages/aleo_dart/lib/src/aleo_record.dart
+++ b/packages/aleo_dart/lib/src/aleo_record.dart
@@ -1,6 +1,7 @@
 import 'dart:math';
 
 import 'package:aleo_dart/src/rust_lib/record_rust_ffi.dart';
+import 'package:aleo_dart/src/rust_lib/dyLib.dart';
 import 'package:aleo_dart/src/rust_lib/utils.dart';
 import 'package:aleo_dart/src/aleo_utils.dart';
 
@@ -9,7 +10,8 @@ class AleoRecord {
   int decimal = 6;
 
   AleoRecord(dyLib, [String network_raw = 'testnet']) {
-    this.recordRustFFI = RecordRustFFI(dyLib, network_raw);
+    this.recordRustFFI =
+        RecordRustFFI(AleoLib.coerce(dyLib).dyLib, network_raw);
   }
 
   String encryptPrivateKey(privateKeyRaw, secretRaw) {

--- a/packages/aleo_dart/lib/src/rust_lib/dyLib.dart
+++ b/packages/aleo_dart/lib/src/rust_lib/dyLib.dart
@@ -1,6 +1,78 @@
 import 'dart:ffi' as ffi;
 import 'dart:io';
 
+/// Thrown when a native library's ABI does not match what this Dart package was
+/// built against — either the `ffi_abi_version` symbol is missing (a library
+/// predating the Phase-4 ABI guard) or its value differs. Surfacing this at load
+/// time turns a silent ABI mismatch (a renamed symbol, a changed arity, a widened
+/// integer) into a clear, loud failure instead of a later segfault or a bound
+/// symbol reading the wrong bytes.
+class IncompatibleNativeLibraryException implements Exception {
+  final String message;
+  IncompatibleNativeLibraryException(this.message);
+  @override
+  String toString() => 'IncompatibleNativeLibraryException: $message';
+}
+
+/// A native library validated against this package's expected ABI version.
+///
+/// Every public class that reaches the FFI (`AleoAccount`, `AleoRecord`,
+/// `AleoProgram`, `ParameterProvisioner`) funnels its library through
+/// [AleoLib.coerce], so there is no unvalidated path to the native code: a stale
+/// or mismatched library is rejected at construction (before any call can bind a
+/// renamed symbol or pass an argument into the wrong slot). The constructors keep
+/// accepting a bare [ffi.DynamicLibrary] for source compatibility — they just
+/// validate it now.
+class AleoLib {
+  final ffi.DynamicLibrary dyLib;
+  const AleoLib._(this.dyLib);
+
+  /// The ABI version this package is built against. Bump in lockstep with the
+  /// Rust `ffi_abi_version` on every ABI-affecting change.
+  static const int expectedAbiVersion = 1;
+
+  /// Wraps an already-open [dyLib] after checking its ABI version.
+  ///
+  /// Throws [IncompatibleNativeLibraryException] if `ffi_abi_version` is absent
+  /// (a pre-guard library — `lookup` throws `ArgumentError`) or returns a value
+  /// other than [expected].
+  factory AleoLib.fromDynamicLibrary(ffi.DynamicLibrary dyLib,
+      {int expected = expectedAbiVersion}) {
+    final int version;
+    try {
+      version = dyLib.lookupFunction<ffi.Uint32 Function(), int Function()>(
+          'ffi_abi_version')();
+    } on ArgumentError catch (e) {
+      throw IncompatibleNativeLibraryException(
+          'native library predates the ABI guard (no ffi_abi_version symbol); '
+          'rebuild/redistribute it — $e');
+    }
+    if (version != expected) {
+      throw IncompatibleNativeLibraryException(
+          'native library ABI version $version, expected $expected; '
+          'rebuild/redistribute the library in lockstep with this package');
+    }
+    return AleoLib._(dyLib);
+  }
+
+  /// Opens the library at [path] and validates it.
+  factory AleoLib.open(String path, {int expected = expectedAbiVersion}) =>
+      AleoLib.fromDynamicLibrary(ffi.DynamicLibrary.open(path),
+          expected: expected);
+
+  /// The single validation chokepoint the public constructors call: passes an
+  /// already-validated [AleoLib] through, validates a bare [ffi.DynamicLibrary],
+  /// and rejects anything else.
+  static AleoLib coerce(Object lib, {int expected = expectedAbiVersion}) {
+    if (lib is AleoLib) return lib;
+    if (lib is ffi.DynamicLibrary) {
+      return AleoLib.fromDynamicLibrary(lib, expected: expected);
+    }
+    throw ArgumentError(
+        'expected an AleoLib or DynamicLibrary, got ${lib.runtimeType}');
+  }
+}
+
 const DEFAULT_RUST_LIB_CARGO_SO =
     './aleo_rust/target/release/libaleo_rust.so'; // linux
 const DEFAULT_RUST_LIB_CARGO_DLL =

--- a/packages/aleo_dart/lib/src/rust_lib/programs_rust_ffi.dart
+++ b/packages/aleo_dart/lib/src/rust_lib/programs_rust_ffi.dart
@@ -36,40 +36,49 @@ typedef TypeUpgradeAuthorization = ffi.Pointer<Utf8> Function(
 typedef TypeJoinAuthorization = ffi.Pointer<Utf8> Function(ffi.Pointer<Utf8>,
     ffi.Pointer<Utf8>, ffi.Pointer<Utf8>, ffi.Pointer<Utf8>, ffi.Pointer<Utf8>);
 
-// --- Pure primitives (node I/O lives in AleoNode) ----------------------------
-// These take no `network` argument: they compute over pre-fetched data and
-// issue no node RPC. The `_static` proving variants still synchronously download
-// snarkVM proving parameters on a cold cache (a separate, phase-4 concern).
-// Phase 3 deleted the old blocking-HTTP exports; these keep their `_static` Rust
-// symbol names. Renaming them to the now-free canonical names is deferred to the
-// phase-4 lib redistribution: reusing a freed name whose ABI differs in an
-// already-distributed prebuilt library would turn a clean missing-symbol error
-// into a silent ABI mismatch, so the rename must land atomically with a
-// rebuilt/redistributed library (+ an ABI-version guard).
+// --- Phase-4 ABI (network-aware) ---------------------------------------------
+// Phase 4 PR4a finalized the ABI: the proving exports moved to the enveloped,
+// cold-cache-safe `*_checked` symbols (bound by `ParameterProvisioner`), the
+// fee/authorize primitives were renamed to their canonical names, and every
+// network-typed export now takes a `network` string ("mainnet"|"testnet") that
+// dispatches the matching snarkVM monomorphization. The load-time
+// `ffi_abi_version` guard (see `AleoLib`) makes a stale/mismatched library fail
+// loudly rather than binding a renamed symbol or an argument into the wrong slot.
 
-/// One `Pointer<Utf8>` in, one out — the shape of `required_commitments`,
-/// `required_imports`, and `state_root_from_paths`.
+/// `(network, arg) -> string` — `required_commitments` / `state_root_from_paths`.
+/// Both gained a `network` first arg in PR4a (they deserialize network-typed
+/// snarkVM data, so they must know the network).
+typedef TypeNetArgString = ffi.Pointer<Utf8> Function(
+    ffi.Pointer<Utf8>, ffi.Pointer<Utf8>);
+
+/// `required_imports` is network-agnostic (a program source is plain text), so it
+/// keeps its single-argument shape.
 typedef TypeOneArgString = ffi.Pointer<Utf8> Function(ffi.Pointer<Utf8>);
 
-typedef TypeConsensusVersionForRust = ffi.Uint16 Function(ffi.Uint32);
-typedef TypeConsensusVersionForDart = int Function(int);
+// consensus_version_for(network, height) -> u16
+typedef TypeConsensusVersionForRust = ffi.Uint16 Function(
+    ffi.Pointer<Utf8>, ffi.Uint32);
+typedef TypeConsensusVersionForDart = int Function(ffi.Pointer<Utf8>, int);
 
-// get_base_fee_static(execution, program_sources_json, height) -> u64
-typedef TypeGetBaseFeeStaticInRust = ffi.Uint64 Function(
-    ffi.Pointer<Utf8>, ffi.Pointer<Utf8>, ffi.Uint32);
-typedef TypeGetBaseFeeStaticInDart = int Function(
-    ffi.Pointer<Utf8>, ffi.Pointer<Utf8>, int);
+// get_base_fee(network, execution, program_sources_json, height) -> u64
+typedef TypeGetBaseFeeInRust = ffi.Uint64 Function(
+    ffi.Pointer<Utf8>, ffi.Pointer<Utf8>, ffi.Pointer<Utf8>, ffi.Uint32);
+typedef TypeGetBaseFeeInDart = int Function(
+    ffi.Pointer<Utf8>, ffi.Pointer<Utf8>, ffi.Pointer<Utf8>, int);
 
-// execution_fee_authorization_static(
-//   private_key, execution, fee_credits, fee_record, program_sources_json, height)
-typedef TypeExecutionFeeAuthStaticInRust = ffi.Pointer<Utf8> Function(
+// execution_fee_authorization(
+//   network, private_key, execution, fee_credits, fee_record,
+//   program_sources_json, height)
+typedef TypeExecutionFeeAuthInRust = ffi.Pointer<Utf8> Function(
+    ffi.Pointer<Utf8>,
     ffi.Pointer<Utf8>,
     ffi.Pointer<Utf8>,
     ffi.Uint64,
     ffi.Pointer<Utf8>,
     ffi.Pointer<Utf8>,
     ffi.Uint32);
-typedef TypeExecutionFeeAuthStaticInDart = ffi.Pointer<Utf8> Function(
+typedef TypeExecutionFeeAuthInDart = ffi.Pointer<Utf8> Function(
+    ffi.Pointer<Utf8>,
     ffi.Pointer<Utf8>,
     ffi.Pointer<Utf8>,
     int,
@@ -77,28 +86,10 @@ typedef TypeExecutionFeeAuthStaticInDart = ffi.Pointer<Utf8> Function(
     ffi.Pointer<Utf8>,
     int);
 
-// execute_proof_static / execute_fee_proof_static(
-//   authorization, height, state_paths_json, public_state_root)
-typedef TypeExecuteProofStaticInRust = ffi.Pointer<Utf8> Function(
-    ffi.Pointer<Utf8>, ffi.Uint32, ffi.Pointer<Utf8>, ffi.Pointer<Utf8>);
-typedef TypeExecuteProofStaticInDart = ffi.Pointer<Utf8> Function(
-    ffi.Pointer<Utf8>, int, ffi.Pointer<Utf8>, ffi.Pointer<Utf8>);
-
-// execute_program_proof_static(
-//   authorization, program_sources_json, height, state_paths_json, public_state_root)
-typedef TypeExecuteProgramProofStaticInRust = ffi.Pointer<Utf8> Function(
+// program_authorization(
+//   network, private_key, program_id, function_name, arguments, program_sources_json)
+typedef TypeProgramAuth = ffi.Pointer<Utf8> Function(
     ffi.Pointer<Utf8>,
-    ffi.Pointer<Utf8>,
-    ffi.Uint32,
-    ffi.Pointer<Utf8>,
-    ffi.Pointer<Utf8>);
-typedef TypeExecuteProgramProofStaticInDart = ffi.Pointer<Utf8> Function(
-    ffi.Pointer<Utf8>, ffi.Pointer<Utf8>, int, ffi.Pointer<Utf8>,
-    ffi.Pointer<Utf8>);
-
-// program_authorization_static(
-//   private_key, program_id, function_name, arguments, program_sources_json)
-typedef TypeProgramAuthStatic = ffi.Pointer<Utf8> Function(
     ffi.Pointer<Utf8>,
     ffi.Pointer<Utf8>,
     ffi.Pointer<Utf8>,
@@ -182,58 +173,61 @@ class ProgramsRustFFI {
     return _withNetwork((network) => rustFunction(execution, network));
   }
 
-  // --- Pure primitives -------------------------------------------------------
-  // Synchronous: they compute over caller-supplied data and pass no `network`.
-  // The string-returning ones hand back a Rust-allocated pointer the caller
-  // releases through `takeNativeString`, exactly like the older exports.
+  // --- Pure primitives (node I/O lives in AleoNode) --------------------------
+  // Synchronous: they compute over caller-supplied data and issue no node RPC.
+  // The network-typed ones take a `network` (threaded here via `_withNetwork`);
+  // the string-returning ones hand back a Rust-allocated pointer the caller
+  // releases through `takeNativeString`.
 
   /// The global input-record commitments whose state paths the caller must
   /// fetch before proving, as a JSON `[field]`. Empty for a public flow.
   ffi.Pointer<Utf8> requiredCommitments(ffi.Pointer<Utf8> authorization) {
-    final fn = dyLib.lookupFunction<TypeOneArgString, TypeOneArgString>(
+    final fn = dyLib.lookupFunction<TypeNetArgString, TypeNetArgString>(
         'required_commitments');
-    return fn(authorization);
+    return _withNetwork((network) => fn(network, authorization));
   }
 
   /// The direct imports of a program source, as a JSON `[program_id]`, so the
-  /// closure walk knows what else to fetch.
+  /// closure walk knows what else to fetch. Network-agnostic (plain text).
   ffi.Pointer<Utf8> requiredImports(ffi.Pointer<Utf8> programSource) {
-    final fn = dyLib.lookupFunction<TypeOneArgString, TypeOneArgString>(
-        'required_imports');
+    final fn = dyLib
+        .lookupFunction<TypeOneArgString, TypeOneArgString>('required_imports');
     return fn(programSource);
   }
 
   /// The shared global state root of a non-empty batch of state paths (for
   /// logging/caching; proving derives it itself). "" if empty or disagreeing.
   ffi.Pointer<Utf8> stateRootFromPaths(ffi.Pointer<Utf8> statePathsJson) {
-    final fn = dyLib.lookupFunction<TypeOneArgString, TypeOneArgString>(
+    final fn = dyLib.lookupFunction<TypeNetArgString, TypeNetArgString>(
         'state_root_from_paths');
-    return fn(statePathsJson);
+    return _withNetwork((network) => fn(network, statePathsJson));
   }
 
-  /// The consensus version active at [height] — Dart pins one for a whole
-  /// transaction without hardcoding upgrade heights.
+  /// The consensus version active at [height] for this network — Dart pins one
+  /// for a whole transaction without hardcoding upgrade heights (which differ
+  /// per network).
   int consensusVersionFor(int height) {
     final fn = dyLib.lookupFunction<TypeConsensusVersionForRust,
         TypeConsensusVersionForDart>('consensus_version_for');
-    return fn(height);
+    return _withNetwork((network) => fn(network, height));
   }
 
   /// Base fee (microcredits) for an [execution] at [height]. [programSources]
   /// supplies the execution's root program (empty for credits.aleo).
-  int getBaseFeeStatic(
+  int getBaseFee(
     ffi.Pointer<Utf8> execution,
     ffi.Pointer<Utf8> programSources,
     int height,
   ) {
-    final fn = dyLib.lookupFunction<TypeGetBaseFeeStaticInRust,
-        TypeGetBaseFeeStaticInDart>('get_base_fee_static');
-    return fn(execution, programSources, height);
+    final fn = dyLib.lookupFunction<TypeGetBaseFeeInRust, TypeGetBaseFeeInDart>(
+        'get_base_fee');
+    return _withNetwork(
+        (network) => fn(network, execution, programSources, height));
   }
 
   /// Authorizes the fee for a proven [execution] at [height]. An empty
   /// [feeRecord] is a public fee, otherwise a private fee spending that record.
-  ffi.Pointer<Utf8> executionFeeAuthorizationStatic(
+  ffi.Pointer<Utf8> executionFeeAuthorization(
     ffi.Pointer<Utf8> privateKey,
     ffi.Pointer<Utf8> execution,
     int feeCredits,
@@ -241,66 +235,25 @@ class ProgramsRustFFI {
     ffi.Pointer<Utf8> programSources,
     int height,
   ) {
-    final fn = dyLib.lookupFunction<TypeExecutionFeeAuthStaticInRust,
-        TypeExecutionFeeAuthStaticInDart>('execution_fee_authorization_static');
-    return fn(privateKey, execution, feeCredits, feeRecord, programSources,
-        height);
-  }
-
-  /// Proves an [authorization] against a StaticQuery built from pre-fetched
-  /// [height] / [statePathsJson] / [publicStateRoot].
-  ffi.Pointer<Utf8> executeProofStatic(
-    ffi.Pointer<Utf8> authorization,
-    int height,
-    ffi.Pointer<Utf8> statePathsJson,
-    ffi.Pointer<Utf8> publicStateRoot,
-  ) {
-    final fn = dyLib.lookupFunction<TypeExecuteProofStaticInRust,
-        TypeExecuteProofStaticInDart>('execute_proof_static');
-    return fn(authorization, height, statePathsJson, publicStateRoot);
-  }
-
-  /// Proves a fee [authorization] against its own pre-fetched snapshot (a
-  /// private fee spends its own record, so its paths differ from the execution's).
-  ffi.Pointer<Utf8> executeFeeProofStatic(
-    ffi.Pointer<Utf8> authorization,
-    int height,
-    ffi.Pointer<Utf8> statePathsJson,
-    ffi.Pointer<Utf8> publicStateRoot,
-  ) {
-    final fn = dyLib.lookupFunction<TypeExecuteProofStaticInRust,
-        TypeExecuteProofStaticInDart>('execute_fee_proof_static');
-    return fn(authorization, height, statePathsJson, publicStateRoot);
-  }
-
-  /// Like [executeProofStatic] but the referenced program (+ closure) is
-  /// supplied in-memory via [programSources] rather than fetched from a node.
-  ffi.Pointer<Utf8> executeProgramProofStatic(
-    ffi.Pointer<Utf8> authorization,
-    ffi.Pointer<Utf8> programSources,
-    int height,
-    ffi.Pointer<Utf8> statePathsJson,
-    ffi.Pointer<Utf8> publicStateRoot,
-  ) {
-    final fn = dyLib.lookupFunction<TypeExecuteProgramProofStaticInRust,
-        TypeExecuteProgramProofStaticInDart>('execute_program_proof_static');
-    return fn(
-        authorization, programSources, height, statePathsJson, publicStateRoot);
+    final fn = dyLib.lookupFunction<TypeExecutionFeeAuthInRust,
+        TypeExecutionFeeAuthInDart>('execution_fee_authorization');
+    return _withNetwork((network) => fn(network, privateKey, execution,
+        feeCredits, feeRecord, programSources, height));
   }
 
   /// Builds an execution authorization for an arbitrary program function offline.
   /// [arguments] is a JSON array of Aleo value strings (record inputs already
   /// plaintext); [programSources] supplies the program (empty for credits.aleo).
-  ffi.Pointer<Utf8> programAuthorizationStatic(
+  ffi.Pointer<Utf8> programAuthorization(
     ffi.Pointer<Utf8> privateKey,
     ffi.Pointer<Utf8> programId,
     ffi.Pointer<Utf8> functionName,
     ffi.Pointer<Utf8> arguments,
     ffi.Pointer<Utf8> programSources,
   ) {
-    final fn =
-        dyLib.lookupFunction<TypeProgramAuthStatic, TypeProgramAuthStatic>(
-            'program_authorization_static');
-    return fn(privateKey, programId, functionName, arguments, programSources);
+    final fn = dyLib.lookupFunction<TypeProgramAuth, TypeProgramAuth>(
+        'program_authorization');
+    return _withNetwork((network) => fn(network, privateKey, programId,
+        functionName, arguments, programSources));
   }
 }

--- a/packages/aleo_dart/test/aleo_credits_only_test.dart
+++ b/packages/aleo_dart/test/aleo_credits_only_test.dart
@@ -1,0 +1,82 @@
+import 'dart:io';
+
+import 'package:aleo_dart/aleo.dart';
+import 'package:test/test.dart';
+
+import 'support/test_dylib.dart';
+
+/// v1 is credits-only. The public program flows must reject a non-`credits.aleo`
+/// program **deterministically and before any node I/O** — so an unreachable /
+/// 404 / slow / malicious node can never turn the rejection into an
+/// `AleoNodeException`. These tests point the program at a loopback server that
+/// counts every request and assert: `unsupported_feature` is thrown and the server
+/// is never hit.
+void main() {
+  final dyLib = tryLoadAleoLib();
+
+  late HttpServer server;
+  late int requests;
+  late String url;
+  late AleoProgram program;
+
+  setUp(() async {
+    requests = 0;
+    server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    server.listen((req) {
+      requests++;
+      req.response.statusCode = 500;
+      req.response.close();
+    });
+    url = 'http://${server.address.host}:${server.port}';
+    if (dyLib != null) program = AleoProgram(dyLib, 'testnet');
+  });
+
+  tearDown(() async {
+    if (dyLib != null) program.dispose();
+    await server.close(force: true);
+  });
+
+  final unsupported = throwsA(isA<ProvisioningException>()
+      .having((e) => e.code, 'code', 'unsupported_feature'));
+
+  test('executeProgramProof rejects a custom program before any node request',
+      () async {
+    if (dyLib == null) {
+      markTestSkipped(nativeLibMissingReason);
+      return;
+    }
+    await expectLater(
+      program.executeProgramProof(url, '{}', program_id_raw: 'custom.aleo'),
+      unsupported,
+    );
+    expect(requests, 0, reason: 'must reject before reaching the node');
+  });
+
+  test('executeProgram rejects a custom program before any node request',
+      () async {
+    if (dyLib == null) {
+      markTestSkipped(nativeLibMissingReason);
+      return;
+    }
+    await expectLater(
+      program.executeProgram(
+          'APrivateKey1zkp', 'custom.aleo', 'foo', '[]', 1, url),
+      unsupported,
+    );
+    expect(requests, 0, reason: 'must reject before reaching the node');
+  });
+
+  test('contractExecution rejects a custom program before any node request',
+      () async {
+    if (dyLib == null) {
+      markTestSkipped(nativeLibMissingReason);
+      return;
+    }
+    await expectLater(
+      program.contractExecution(
+          'APrivateKey1zkp', 'custom.aleo', 'foo', '[]', url),
+      unsupported,
+    );
+    expect(requests, 0, reason: 'must reject before reaching the node');
+  });
+}

--- a/packages/aleo_dart/test/aleo_credits_only_test.dart
+++ b/packages/aleo_dart/test/aleo_credits_only_test.dart
@@ -79,4 +79,18 @@ void main() {
     );
     expect(requests, 0, reason: 'must reject before reaching the node');
   });
+
+  test('contractFeeExecution rejects a custom program before any node request',
+      () async {
+    if (dyLib == null) {
+      markTestSkipped(nativeLibMissingReason);
+      return;
+    }
+    await expectLater(
+      program.contractFeeExecution(
+          'APrivateKey1zkp', 1, '{}', 'custom.aleo', url),
+      unsupported,
+    );
+    expect(requests, 0, reason: 'must reject before reaching the node');
+  });
 }

--- a/packages/aleo_dart/test/aleo_lib_test.dart
+++ b/packages/aleo_dart/test/aleo_lib_test.dart
@@ -1,0 +1,73 @@
+import 'dart:ffi' as ffi;
+import 'dart:io';
+
+import 'package:aleo_dart/aleo.dart';
+import 'package:test/test.dart';
+
+import 'support/test_dylib.dart';
+
+/// A real, loadable native library that does NOT export `ffi_abi_version`, opened
+/// as its own handle so the lookup is scoped to it (not the globally-loaded aleo
+/// library). Used as the "stale / pre-guard library" fixture.
+ffi.DynamicLibrary? _guardlessLibrary() {
+  if (Platform.isMacOS) {
+    return ffi.DynamicLibrary.open('/usr/lib/libSystem.B.dylib');
+  }
+  if (Platform.isLinux) {
+    return ffi.DynamicLibrary.open('libc.so.6');
+  }
+  return null; // no portable fixture on this platform
+}
+
+/// The load-time ABI guard (PR4a §4). These cases use explicit fixtures rather
+/// than the prebuilt fallback, so a stale-but-loadable library can never mask a
+/// regression:
+///   - a fresh library (ALEO_NEW_LIB) validates and exposes ffi_abi_version == 1;
+///   - a library without the symbol (the Dart executable) is rejected;
+///   - a version mismatch (via the injectable `expected` seam) is rejected before
+///     any business lookup.
+void main() {
+  final dyLib = tryLoadAleoLib();
+
+  test('fresh library validates and is wrapped', () {
+    if (dyLib == null) {
+      markTestSkipped(nativeLibMissingReason);
+      return;
+    }
+    final lib = AleoLib.fromDynamicLibrary(dyLib);
+    expect(lib.dyLib, same(dyLib));
+    // coerce passes an AleoLib through and validates a bare DynamicLibrary.
+    expect(AleoLib.coerce(lib), same(lib));
+    expect(AleoLib.coerce(dyLib).dyLib, same(dyLib));
+  });
+
+  test('missing ffi_abi_version symbol is rejected', () {
+    final guardless = _guardlessLibrary();
+    if (guardless == null) {
+      markTestSkipped('no portable guardless-library fixture on this platform');
+      return;
+    }
+    // The system library does not export ffi_abi_version, so the lookup throws
+    // ArgumentError, which the loader maps to IncompatibleNativeLibraryException.
+    expect(
+      () => AleoLib.fromDynamicLibrary(guardless),
+      throwsA(isA<IncompatibleNativeLibraryException>()),
+    );
+  });
+
+  test('ABI version mismatch is rejected before any business lookup', () {
+    if (dyLib == null) {
+      markTestSkipped(nativeLibMissingReason);
+      return;
+    }
+    // The library reports version 1; demanding a different version must fail.
+    expect(
+      () => AleoLib.fromDynamicLibrary(dyLib, expected: 2),
+      throwsA(isA<IncompatibleNativeLibraryException>()),
+    );
+  });
+
+  test('coerce rejects a non-library argument', () {
+    expect(() => AleoLib.coerce('not a library'), throwsArgumentError);
+  });
+}

--- a/packages/aleo_dart/test/aleo_provisioning_test.dart
+++ b/packages/aleo_dart/test/aleo_provisioning_test.dart
@@ -39,6 +39,34 @@ MissingParam missingFor(
 void main() {
   final dyLib = tryLoadAleoLib();
 
+  // ── Pure-Dart: the credits-only closure predicate (no FFI, no network) ──────
+  // It gates the public-flow fail-fast: a non-empty (custom-program) closure is
+  // rejected with `unsupported_feature` before any authorize / state-path / prove
+  // work, so a custom program never surfaces as a malformed-auth or node error.
+  group('isEmptyClosure (credits-only gate)', () {
+    test('empty / "[]" / whitespace-around are empty (credits.aleo)', () {
+      expect(ParameterProvisioner.isEmptyClosure(''), isTrue);
+      expect(ParameterProvisioner.isEmptyClosure('   '), isTrue);
+      expect(ParameterProvisioner.isEmptyClosure('[]'), isTrue);
+      expect(ParameterProvisioner.isEmptyClosure(' [ ] '), isTrue);
+    });
+
+    test('a non-empty array (a custom program) is NOT empty', () {
+      expect(
+        ParameterProvisioner.isEmptyClosure(
+            '[{"id":"custom.aleo","edition":0,"source":"program custom.aleo;"}]'),
+        isFalse,
+      );
+    });
+
+    test('malformed / non-array values are NOT empty (fail-closed)', () {
+      expect(ParameterProvisioner.isEmptyClosure('not json'), isFalse);
+      expect(ParameterProvisioner.isEmptyClosure('{}'), isFalse);
+      // A non-breaking space is not JSON whitespace, so this is not an empty array.
+      expect(ParameterProvisioner.isEmptyClosure('[ ]'), isFalse);
+    });
+  });
+
   // ── Pure-Dart: envelope parser + latch (no FFI dir, no network) ─────────────
   // (Still needs the library handle to construct the provisioner.)
   group('envelope + latch', () {

--- a/packages/aleo_dart/test/transfer/aleo_phase2_e2e.dart
+++ b/packages/aleo_dart/test/transfer/aleo_phase2_e2e.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:aleo_dart/aleo.dart';
 import 'package:test/test.dart';
 
@@ -74,9 +76,17 @@ void main() async {
         reason: 'a single-record private transfer spends one record');
 
     final paths = await node.statePaths(commitments);
-    // checked_static_query enforces paths' set == required_commitments, so a
-    // proof only succeeds when the helper was exact.
-    final proof = await rust.executeProofStatic(auth, height, paths, '');
+    // PR4a: proving goes through the ParameterProvisioner checked path (preflight
+    // → download keys → execute_*_checked). checked_static_query enforces paths'
+    // set == required_commitments, so a proof only succeeds when the helper was
+    // exact.
+    final prov = ParameterProvisioner(dyLib, 'testnet', Directory.systemTemp);
+    final version = rust.consensusVersionFor(height);
+    final proof = await prov.provisionAndProveExecution(
+        authorization: auth,
+        height: height,
+        consensusVersion: version,
+        statePaths: paths);
     expect(proof, isNotEmpty, reason: 'private execution proof must verify');
 
     final feeAuth = await rust.executionFeeAuthorizationStatic(
@@ -86,12 +96,17 @@ void main() async {
     final feeCommitments = rust.requiredCommitments(feeAuth);
     final feePaths = await node.statePaths(feeCommitments);
     final feeRoot = feeCommitments.isEmpty ? await node.latestStateRoot() : '';
-    final feeProof =
-        await rust.executeFeeProofStatic(feeAuth, height, feePaths, feeRoot);
+    final feeProof = await prov.provisionAndProveFee(
+        authorization: feeAuth,
+        height: height,
+        consensusVersion: version,
+        statePaths: feePaths,
+        publicStateRoot: feeRoot);
     expect(feeProof, isNotEmpty, reason: 'private-flow fee proof must verify');
 
     final tx = await rust.buildTransactionOffline(proof, feeProof);
     expect(tx, isNotEmpty);
     print('assembled private transfer tx (${tx.length} bytes)');
+    prov.close();
   }, skip: 'manual: requires a funded testnet record + proving keys');
 }

--- a/rust/aleo_ffi/docs/pr4a-abi-spec.md
+++ b/rust/aleo_ffi/docs/pr4a-abi-spec.md
@@ -107,6 +107,34 @@ After this, the network ID embedded at authorize time matches the network the pr
 is produced for — the precondition for testnet working end-to-end (today everything
 is forced to `MainnetV0`, which silently mis-IDs a testnet tx).
 
+### 3.3.1 Genericize the helper stack, not just the entry points
+
+`match parse_network` at the export is necessary but **not sufficient**. The
+network-typed exports (§3.2 + §3.3) call helpers that are still pinned to the
+`type Net = MainnetV0` alias; an export dispatched to `f::<TestnetV0>` that calls a
+`PrivateKey<Net>`-typed helper does not even type-check (it would force a
+`PrivateKey<MainnetV0>`), so the genericization must go **down the call stack**.
+Verified Net-fixed helpers on the authorize/build/fee path (epic `1387238`):
+
+| Helper | Pinned type | Called by | Action |
+|---|---|---|---|
+| `transfer_inputs` (`lib.rs:399`) | `&PrivateKey<Net>` | `execution_authorization` (`:511`) | `<N: Network>` |
+| `plaintext_record` (`:378`) | `&PrivateKey<Net>` | `join_authorization` (`:480,481`), `transfer_inputs` (`:410`) | `<N: Network>` |
+| `plaintext_record_typed` (`:390`) | `&PrivateKey<Net>` → `Record<Net,…>` | `execution_fee_authorization_static` (`:1141`) | `<N: Network>` |
+| `base_fee_at_height` (`:804`) | `&Execution<Net>`, `Net::CONSENSUS_VERSION` | `get_base_fee_static` (`:1097`) | `<N: Network>` |
+
+`new_vm`, `add_programs_from_sources(+_within)` are already `<N: Network>` (PR2 chunk
+3). `check_total_fee(base_fee: u64, priority_fee: u64)` is **network-agnostic** (pure
+`u64` arithmetic, no `Net` in its signature) — left as-is.
+
+Both-network coverage is **mandatory** (compile + behavior), not just the proving
+path: private-record decrypt (`plaintext_record`/`plaintext_record_typed`), private
+fee authorization, `build_transaction_offline`, and `transfer_inputs`
+public/private — each exercised for `TestnetV0` as well as `MainnetV0`. Where a live
+testnet record fixture is unavailable, the TestnetV0 monomorphization is still
+verified at compile + dispatch + network-id level (the existing `TEST_RECORD`/`owner()`
+fixtures are MainnetV0).
+
 ### 3.4 Add `ffi_abi_version`
 
 ```rust
@@ -185,6 +213,15 @@ the constructors. PR4a:
 - Migrates `example/`, `test/support/test_dylib.dart`, and any in-repo callers to the
   `AleoLib` form. The CHANGELOG calls out the constructor signature break.
 
+**`ParameterProvisioner` is part of this surface.** It is a public class
+(`export 'package:aleo_dart/src/aleo_provisioning.dart'` in `aleo.dart`) whose
+constructor takes a bare `ffi.DynamicLibrary _lib` (`aleo_provisioning.dart:73,106`).
+If only `AleoAccount`/`AleoRecord`/`AleoProgram` are migrated, a caller can still do
+`ParameterProvisioner(rawLib, …)` and bypass the guard. PR4a changes its constructor
+to take an `AleoLib` and read `lib.dyLib` internally (same break, same changelog
+entry). After this, **every** public class that reaches the FFI takes a validated
+handle — there is no unguarded constructor left.
+
 ### 4.2 Test harness must not let the fallback mask the guard
 
 `tryLoadAleoLib()` currently: `ALEO_NEW_LIB` (loud) → else `getDyLibFromCargo` →
@@ -223,6 +260,21 @@ honored.
 - Public `AleoProgram` method signatures stay source-compatible where possible; any
   that must change (e.g. a result now coming from an envelope) are documented.
 
+### 5.1 Custom-program proving becomes unsupported (intended behavior break)
+
+`executeProgramProof(url, authorization, program_id, …)` today accepts a **custom
+program id** and proves it via the closure fetched from the node. The PR2
+`provisionAndProveProgram` is **credits-only**: a non-empty program closure throws
+`ProvisioningException('unsupported_feature', …)` before provisioning
+(`aleo_provisioning.dart:514–526`, `_isEmptyClosure`). Switching the public flow to
+`provisionAndProve*` therefore **removes custom-program proving** in v1 — a deliberate
+convergence to the locked "credits-only" scope, not an accident.
+
+This must be **explicit**: a CHANGELOG entry ("custom-program proving is unsupported
+in v1; credits.aleo only") and a test asserting a custom-program call throws
+`unsupported_feature` (so it can never be mistaken for a regression). The mainnet/
+testnet credits flows (empty/`"[]"` closure) are unaffected.
+
 ## 6. Test table (write first, per the churn lesson)
 
 | Surface | Case | Expectation |
@@ -233,6 +285,8 @@ honored.
 | `parse_network` | `"mainnet"` / `"testnet"` | correct monomorphization (compile + dispatch) |
 | `parse_network` | unknown | `get_base_fee`→0; `execution_fee_authorization`→""; checked→`unsupported_network` |
 | authorize/build | `network="testnet"` | tx carries the TestnetV0 network id (not mainnet) |
+| helper stack (both networks) | `transfer_inputs`, `plaintext_record(_typed)`, `base_fee_at_height`, `execution_fee_authorization` private fee, `build_transaction_offline` | TestnetV0 + MainnetV0 each (compile + dispatch + network-id) |
+| custom program | `executeProgramProof` with a non-credits program id | throws `unsupported_feature` (intended break, §5.1) |
 | symbol set | release cdylib `nm` | exactly the 34-symbol set |
 | public flow | `executeProof` cold-cache (subprocess/temp dir) | preflight→download→checked, no abort |
 | public flow | proving after latch tripped | fail-fast, no FFI call |

--- a/rust/aleo_ffi/docs/pr4a-abi-spec.md
+++ b/rust/aleo_ffi/docs/pr4a-abi-spec.md
@@ -226,8 +226,14 @@ class AleoLib {
 }
 ```
 
-- The three public classes' constructors take an `AleoLib` (breaking Dart API
-  change — documented in the changelog). Internally they read `lib.dyLib`.
+- **Refinement (decided): internal validation, non-breaking.** Rather than forcing
+  every constructor to take an `AleoLib` (which would break ~24 in-repo call sites +
+  every app-repo construction), the public constructors keep accepting a
+  `DynamicLibrary` *and* also accept an `AleoLib`, funnelling both through
+  `AleoLib.coerce(...)` which validates `ffi_abi_version` and unwraps. Every public
+  constructor (`AleoAccount`/`AleoRecord`/`AleoProgram`/`ParameterProvisioner`)
+  validates on construction, so there is no unvalidated path to the FFI — the same
+  no-bypass guarantee as the type-only design, without the breaking signature change.
 - A missing `ffi_abi_version` symbol surfaces as a clear thrown error, not a crash.
 
 ### 4.1 `DyLib` → `AleoLib` boundary (close the bypass)

--- a/rust/aleo_ffi/docs/pr4a-abi-spec.md
+++ b/rust/aleo_ffi/docs/pr4a-abi-spec.md
@@ -288,6 +288,15 @@ honored.
   field, `programsRustFFI.network`).
 - `getBaseFee` / `executionFeeAuthorization` / program authorization → the renamed
   `network`-aware symbols (§3.2), passing the program's network.
+- **The three consumers gained a `network` first arg too** (round-3 abort fix:
+  `required_commitments`, `state_root_from_paths`, `consensus_version_for`). Their
+  Dart wrappers MUST be updated in lockstep — this is an **arity** change, not just a
+  rename, so a stale 1-arg wrapper passes a non-pointer (e.g. a `height`) into the
+  `network` pointer slot → `read_str`/`strlen` on a bogus address → **SIGSEGV** (a
+  hardware fault `catch_unwind` cannot catch). Easy to miss while focused on the
+  proving/fee wrappers. The `ffi_abi_version` load-time guard (§4) is what makes the
+  interim safe: a stale lib + new Dart (or vice-versa) is rejected at load, before any
+  call can segfault — so the guard and these wrapper updates land together.
 - The deleted `_static` proving bindings + their now-unused typedefs are removed
   from `programs_rust_ffi.dart`; the stale "rename deferred to phase 4" comment
   block (lines 39–48) is updated to reflect that PR4a did the rename.

--- a/rust/aleo_ffi/docs/pr4a-abi-spec.md
+++ b/rust/aleo_ffi/docs/pr4a-abi-spec.md
@@ -4,6 +4,31 @@
 > epic `1387238`. This is the ABI half of workstream C from `phase4-plan.md` §3.C.
 > PR4b (cross-compile + distribution) is split out per the Phase-4 PR-split decision.
 
+## 0. Applicable baseline (read before reviewing)
+
+This spec is written **against epic `1387238`** (the PR4a branch base, commit
+`203023f`). Review against that ref, not `main` or an older branch. The crate under
+change is **`rust/aleo_ffi/`**.
+
+⚠️ **Do not review `rust/aleo_rust/`.** That is the legacy **GPL** crate, slated for
+deletion in PR5. It is unrelated to the Phase-1..4 work. Both crates set
+`[lib] name = "aleo_rust"`, so **both build a `libaleo_rust` artifact** — this name
+collision is the easy trap: the Dart layer loads `rust/aleo_ffi`'s output, but a
+reviewer who greps `rust/aleo_rust/src/lib.rs` will see the *old* symbols (canonical
+`execute_proof`/`get_base_fee`, a 2-arg `build_transaction_offline`, no `_network`)
+and conclude the spec is wrong. Those legacy symbols are not this spec's subject.
+
+Ground-truth checks on epic `1387238` (what this spec assumes):
+
+| Claim | Verify | Expected |
+|---|---|---|
+| CI gate is `rust.yml` (exact symbol set) | `git show 1387238:.github/workflows/rust.yml` | present (in addition to `ci.yml`) |
+| `_static` + `_checked` + preflight exports exist | `grep -E '_static\|_checked\|parameter_preflight' rust/aleo_ffi/src/lib.rs` | all present |
+| `ParameterProvisioner` exists (PR2) | `packages/aleo_dart/lib/src/aleo_provisioning.dart` | present |
+| `build_transaction_offline` arity | `rust/aleo_ffi/src/lib.rs` | 3 args incl. `_network` (matches Dart) |
+| `build_upgrade_transaction_offline` arity | `rust/aleo_ffi/src/lib.rs` | 2 args incl. `_network` (matches Dart) |
+| `get_base_fee_static` failure mode | `rust/aleo_ffi/src/lib.rs` | `inner().unwrap_or(0)` (no panic) |
+
 ## 1. Why PR4a is split from PR4b
 
 Workstream C (the C-ABI change) and workstream D (cross-compile + redistribution)
@@ -92,6 +117,13 @@ pub extern "C" fn ffi_abi_version() -> u32 { 1 }
 Bump on every future ABI change. Retroactively guards the PR-#51 `u64`-widening
 drift (an older library lacks the symbol → the loader rejects it).
 
+Dart typedef must mirror `u32` exactly — do **not** reuse the generic `ffi.Int`:
+
+```dart
+typedef _FfiAbiVersionNative = ffi.Uint32 Function();
+typedef _FfiAbiVersionDart = int Function();
+```
+
 ### 3.5 `parse_network` contract
 
 A single helper: `"mainnet" → MainnetV0`, `"testnet" → TestnetV0`, anything else →
@@ -135,8 +167,41 @@ class AleoLib {
 - The three public classes' constructors take an `AleoLib` (breaking Dart API
   change — documented in the changelog). Internally they read `lib.dyLib`.
 - A missing `ffi_abi_version` symbol surfaces as a clear thrown error, not a crash.
-- Test harness (`test/support/test_dylib.dart`) builds an `AleoLib` from the
-  `ALEO_NEW_LIB` path so the whole suite exercises the guard.
+
+### 4.1 `DyLib` → `AleoLib` boundary (close the bypass)
+
+The chokepoint is only real if **every** path that produces a library for the public
+classes is validated. Today `DyLib.{getDyLibByPosition,getLocalDyLib,getDyLibFromCargo,
+getDyLibFromGit}` each return a **bare `DynamicLibrary`** that callers hand straight to
+the constructors. PR4a:
+
+- Adds validated factories on `DyLib` (or a new `AleoLib`) that wrap each loader and
+  return an `AleoLib` (open → `ffi_abi_version()` check → handle). These become the
+  public way to get a library.
+- Keeps the raw `DynamicLibrary`-returning loaders only as **internal/deprecated**
+  (`@Deprecated`) helpers used by the validated factories — not as a public unguarded
+  path. The public constructors no longer accept a bare `DynamicLibrary` at all (so
+  there is no unvalidated bypass left to forget).
+- Migrates `example/`, `test/support/test_dylib.dart`, and any in-repo callers to the
+  `AleoLib` form. The CHANGELOG calls out the constructor signature break.
+
+### 4.2 Test harness must not let the fallback mask the guard
+
+`tryLoadAleoLib()` currently: `ALEO_NEW_LIB` (loud) → else `getDyLibFromCargo` →
+`getDyLibFromGit` (a possibly-stale prebuilt) → `null` (suite skips). For ordinary
+suites that fallback is fine, but the **ABI-guard tests must not depend on it** — a
+stale-but-new-enough prebuilt, or a graceful skip, would hide a regression. PR4a:
+
+- For the normal suite: build `AleoLib` from `ALEO_NEW_LIB` (CI sets it; loud on a
+  bad path) so the guard runs against the freshly built library on every run.
+- For the guard's negative cases, construct **explicit fixtures**, never the fallback:
+  - *symbol absent* → open a library known to lack `ffi_abi_version` (a system
+    library such as libc/libSystem, or a tiny purpose-built stub `.so`); the lookup
+    throws `ArgumentError` → assert it maps to `IncompatibleNativeLibraryException`.
+  - *version mismatch* → a test seam: the loader's version comparison takes the
+    expected version as an injectable parameter (default `AleoLib.expectedAbiVersion`),
+    so a test can assert a `2 != 1` mismatch throws before any business lookup without
+    needing a second native build.
 
 ## 5. Dart: switch the public proving flow to the checked + provisioned path
 
@@ -162,9 +227,9 @@ honored.
 
 | Surface | Case | Expectation |
 |---|---|---|
-| `ffi_abi_version` | symbol present, ==1 | loader returns handle |
-| loader | symbol absent (phase-3 lib) | `IncompatibleNativeLibraryException` |
-| loader | version != 1 | throws before any business lookup |
+| `ffi_abi_version` | freshly built lib (`ALEO_NEW_LIB`), ==1 | loader returns handle |
+| loader | symbol absent — fixture: system lib / stub `.so` (not the fallback) | `IncompatibleNativeLibraryException` |
+| loader | version mismatch — test seam injects expected `2` | throws before any business lookup |
 | `parse_network` | `"mainnet"` / `"testnet"` | correct monomorphization (compile + dispatch) |
 | `parse_network` | unknown | `get_base_fee`→0; `execution_fee_authorization`→""; checked→`unsupported_network` |
 | authorize/build | `network="testnet"` | tx carries the TestnetV0 network id (not mainnet) |

--- a/rust/aleo_ffi/docs/pr4a-abi-spec.md
+++ b/rust/aleo_ffi/docs/pr4a-abi-spec.md
@@ -107,6 +107,38 @@ After this, the network ID embedded at authorize time matches the network the pr
 is produced for — the precondition for testnet working end-to-end (today everything
 is forced to `MainnetV0`, which silently mis-IDs a testnet tx).
 
+`network` is the **new first arg** on the §3.2 renamed exports and the `_checked`
+exports, but stays in its **existing (last) position** on these five (their slot
+already exists; moving it would be a gratuitous ABI break). The Dart bindings (§5)
+must mind this asymmetry — it is the one place the arg order differs.
+
+### 3.3.0 Activate it on the *consumers* too, or testnet aborts the process
+
+Making the producers (authorize) network-aware while leaving the consumers hardcoded
+to `MainnetV0` is worse than doing nothing: a `TestnetV0` authorization fed to a
+`MainnetV0` deserializer trips snarkVM's network-id assertion
+(`console-network-environment`), which **panics** — and the legacy exports have no
+`catch_unwind`, so the panic unwinds across `extern "C"` = abort (verified: the
+direct cross-network deser panics, not `Err`). So the network-typed **consumers**
+also take `network` + dispatch:
+
+- `required_commitments` (deserializes `Authorization<N>`) — `network` first arg
+- `state_root_from_paths` (deserializes `StatePath<N>`) — `network` first arg
+- `consensus_version_for` (per-network upgrade heights differ) — `network` first arg
+
+And, defense-in-depth (the round-3 reviewer's backstop, and the [[review-fix-classes-not-instances]]
+move): every **network-threaded** legacy export runs its body under a `catch_unwind`
+wrapper (`ffi_legacy_string`/`_u64`/`_u16`) so a panic from a wrong-network or
+malformed input degrades to the fail-closed sentinel (`""`/`0`) instead of aborting.
+The new §8-envelope exports already had this via `ffi_envelope`; this extends the
+same guarantee to the legacy convention. (The pure account/crypto exports —
+key/seed/sign/verify/encrypt — take no cross-network serialized blob and are
+unchanged from epic, so they are out of this regression's scope.)
+
+Regression test: a `TestnetV0` authorization → `required_commitments(network=testnet)`
+returns the right result, and the same blob under `network=mainnet` returns `""` via
+the backstop (not an abort).
+
 ### 3.3.1 Genericize the helper stack, not just the entry points
 
 `match parse_network` at the export is necessary but **not sufficient**. The

--- a/rust/aleo_ffi/docs/pr4a-abi-spec.md
+++ b/rust/aleo_ffi/docs/pr4a-abi-spec.md
@@ -122,10 +122,12 @@ Verified Net-fixed helpers on the authorize/build/fee path (epic `1387238`):
 | `plaintext_record` (`:378`) | `&PrivateKey<Net>` | `join_authorization` (`:480,481`), `transfer_inputs` (`:410`) | `<N: Network>` |
 | `plaintext_record_typed` (`:390`) | `&PrivateKey<Net>` → `Record<Net,…>` | `execution_fee_authorization_static` (`:1141`) | `<N: Network>` |
 | `base_fee_at_height` (`:804`) | `&Execution<Net>`, `Net::CONSENSUS_VERSION` | `get_base_fee_static` (`:1097`) | `<N: Network>` |
+| `check_total_fee` (`:363`) | `Net::MAX_FEE` in the body (signature is `u64`s) | `execution_fee_authorization_static` (`:1135`) | `<N: Network>` (turbofish callsites) |
 
 `new_vm`, `add_programs_from_sources(+_within)` are already `<N: Network>` (PR2 chunk
-3). `check_total_fee(base_fee: u64, priority_fee: u64)` is **network-agnostic** (pure
-`u64` arithmetic, no `Net` in its signature) — left as-is.
+3). Note `check_total_fee`'s *signature* is two `u64`s, but its body compares against
+`Net::MAX_FEE`, so it is network-dependent and must be generic too (its callsites
+turbofish `::<N>` since `N` isn't in the arguments).
 
 Both-network coverage is **mandatory** (compile + behavior), not just the proving
 path: private-record decrypt (`plaintext_record`/`plaintext_record_typed`), private

--- a/rust/aleo_ffi/docs/pr4a-abi-spec.md
+++ b/rust/aleo_ffi/docs/pr4a-abi-spec.md
@@ -1,0 +1,189 @@
+# Phase 4 — PR4a spec: ABI finalization (rename + network activation + ABI guard + validated loader)
+
+> Status: spec, not yet implemented. Branch `feature/aleo-io-dart-phase4-pr4a` off
+> epic `1387238`. This is the ABI half of workstream C from `phase4-plan.md` §3.C.
+> PR4b (cross-compile + distribution) is split out per the Phase-4 PR-split decision.
+
+## 1. Why PR4a is split from PR4b
+
+Workstream C (the C-ABI change) and workstream D (cross-compile + redistribution)
+were planned to land in one lockstep PR so a renamed symbol never reaches a stale
+prebuilt library. PR4a makes that lockstep *safe to stage* by shipping the
+**`ffi_abi_version` guard + validated Dart loader first**: a library that predates
+the guard lacks the `ffi_abi_version` symbol, so the Dart loader fails with a clear
+"incompatible native library" error at load time instead of binding a renamed
+symbol to a different ABI and crashing silently. PR4a is therefore:
+
+- **Purely local**: every test builds the library from this commit and points at it
+  via `ALEO_NEW_LIB` (the established pattern). Nothing in PR4a publishes or
+  repoints a distributed library — `dyLib.dart`/`setup_dylib.dart` still point at
+  the old artifacts; PR4b repoints them.
+- **Guarded**: because the guard lands here, the interim "new Dart + old distributed
+  library" window fails loud, not silently. Mobile and CI build their own library,
+  so nothing actually consumes the stale distributed artifact today (epic → main is
+  not even open yet).
+
+## 2. Scope decisions locked for this PR
+
+| Decision | Choice |
+|---|---|
+| PR split | PR4a (this) = ABI + loader + flow switch; PR4b = cross-compile + distribute |
+| Library hosting (v1) | No runtime download in v1. Mobile build-time bundles; desktop/CI build from source. (PR4b) |
+| iOS scope | This repo ships staticlib crate-type + xcframework script + docs; app repo does device. (PR4b) |
+| `ffi_abi_version` | Monotonic `u32`, value `1` for this ABI; Dart requires **exact match**. |
+
+## 3. Rust ABI changes (the lockstep surface)
+
+Current exported set = **35 functions + `free_string`** (36 symbols), all verified
+in `rust.yml`'s exact-set gate.
+
+### 3.1 Delete (superseded by PR2's enveloped `_checked` proving exports)
+
+- `execute_proof_static`
+- `execute_fee_proof_static`
+- `execute_program_proof_static`
+
+The Dart public flow switches to `execute_proof_checked` / `execute_fee_proof_checked`
+/ `execute_program_proof_checked` (§5), so these have no caller. The canonical names
+`execute_proof` / `execute_fee_proof` / `execute_program_proof` are intentionally
+**left free** (not reused) — the `_checked` symbols keep their suffix, which carries
+meaning (enveloped + network-aware + credits-only enforced) and avoids another
+freed-name-reuse hazard.
+
+### 3.2 Rename `_static` → canonical + add `network` dispatch
+
+| Old symbol | New symbol | New first arg |
+|---|---|---|
+| `get_base_fee_static` | `get_base_fee` | `network: *const c_char` |
+| `execution_fee_authorization_static` | `execution_fee_authorization` | `network: *const c_char` |
+| `program_authorization_static` | `program_authorization` | `network: *const c_char` |
+
+Each becomes generic over `N: Network` (same refactor shape as PR2 chunk 3) and
+dispatches `match parse_network(net) { Mainnet => f::<MainnetV0>(..), Testnet =>
+f::<TestnetV0>(..), _ => <fail-closed> }`. **Return shape is unchanged** for this PR
+(`get_base_fee` → `u64`, `0` on failure incl. unknown network; the two `*mut c_char`
+exports → `""` on failure) — Dart's existing `_require`/zero-fee checks already treat
+those as errors. Converting these three to the envelope is a deferred consolidation,
+not in PR4a (keeps the diff focused; one ABI-version bump still covers it later).
+
+### 3.3 Activate the already-present (ignored) `_network` on authorize/build
+
+These already carry an ignored `_network: *const c_char` (verified at
+`lib.rs:468,499,533,564,585`). Wire it to the same `parse_network` + dispatch; no
+signature change, no symbol-set change:
+
+- `execution_authorization`
+- `join_authorization`
+- `upgrade_authorization`
+- `build_upgrade_transaction_offline`
+- `build_transaction_offline`
+
+After this, the network ID embedded at authorize time matches the network the proof
+is produced for — the precondition for testnet working end-to-end (today everything
+is forced to `MainnetV0`, which silently mis-IDs a testnet tx).
+
+### 3.4 Add `ffi_abi_version`
+
+```rust
+#[no_mangle]
+pub extern "C" fn ffi_abi_version() -> u32 { 1 }
+```
+
+Bump on every future ABI change. Retroactively guards the PR-#51 `u64`-widening
+drift (an older library lacks the symbol → the loader rejects it).
+
+### 3.5 `parse_network` contract
+
+A single helper: `"mainnet" → MainnetV0`, `"testnet" → TestnetV0`, anything else →
+the export's fail-closed value (`""` / `0`) for the legacy-shaped exports, or
+`unsupported_network` for the already-enveloped `_checked`/preflight exports (PR2,
+unchanged). No clamping, no default-to-mainnet.
+
+### 3.6 Symbol-set delta
+
+`35 fns − 3 (deleted) + 1 (ffi_abi_version) = 33 fns + free_string = 34 symbols`.
+Update `.github/workflows/rust.yml`: drop the 3 deleted, rename the 3 `_static`, add
+`ffi_abi_version`, and the "(N functions + free_string)" echo.
+
+## 4. Dart: validated loader / handle (round-1 F3)
+
+Today `AleoAccount(dyLib, [network])`, `AleoRecord(dyLib, …)`, `AleoProgram(dyLib,
+[network])` take a **bare untyped `DynamicLibrary`** — any caller passes any library
+(arbitrary path / test override) straight to the FFI wrappers with no ABI check.
+
+PR4a introduces one chokepoint that opens the library, calls `ffi_abi_version()`
+once, and rejects a mismatch:
+
+```dart
+class AleoLib {
+  final ffi.DynamicLibrary dyLib;
+  AleoLib._(this.dyLib);
+
+  static const int expectedAbiVersion = 1;
+
+  /// Opens [path], validates the ABI version, returns a handle. Throws
+  /// [IncompatibleNativeLibraryException] if the symbol is missing (pre-guard /
+  /// stale library → ArgumentError on lookup) or the version differs.
+  factory AleoLib.open(String path) { … }
+
+  /// For an already-open library (e.g. DynamicLibrary.process() on iOS, or a
+  /// test override via ALEO_NEW_LIB).
+  factory AleoLib.fromDynamicLibrary(ffi.DynamicLibrary dyLib) { … }
+}
+```
+
+- The three public classes' constructors take an `AleoLib` (breaking Dart API
+  change — documented in the changelog). Internally they read `lib.dyLib`.
+- A missing `ffi_abi_version` symbol surfaces as a clear thrown error, not a crash.
+- Test harness (`test/support/test_dylib.dart`) builds an `AleoLib` from the
+  `ALEO_NEW_LIB` path so the whole suite exercises the guard.
+
+## 5. Dart: switch the public proving flow to the checked + provisioned path
+
+The public `AleoProgram` flow currently calls the plain `_static` proving exports
+directly (no envelope, no parameter provisioning → a cold cache **panics across the
+C ABI**, the pre-existing latent bug). PR4a routes proving through
+`ParameterProvisioner` (PR2) so the flow is: `parameter_preflight` → download →
+`execute_*_checked` under the Contract-4 lock, with the `restart_required` latch
+honored.
+
+- `executeProof` / `executeFeeProof` / `executeProgramProof` → the
+  `provisionAndProve*` entry points, threading `network` (already a constructor
+  field, `programsRustFFI.network`).
+- `getBaseFee` / `executionFeeAuthorization` / program authorization → the renamed
+  `network`-aware symbols (§3.2), passing the program's network.
+- The deleted `_static` proving bindings + their now-unused typedefs are removed
+  from `programs_rust_ffi.dart`; the stale "rename deferred to phase 4" comment
+  block (lines 39–48) is updated to reflect that PR4a did the rename.
+- Public `AleoProgram` method signatures stay source-compatible where possible; any
+  that must change (e.g. a result now coming from an envelope) are documented.
+
+## 6. Test table (write first, per the churn lesson)
+
+| Surface | Case | Expectation |
+|---|---|---|
+| `ffi_abi_version` | symbol present, ==1 | loader returns handle |
+| loader | symbol absent (phase-3 lib) | `IncompatibleNativeLibraryException` |
+| loader | version != 1 | throws before any business lookup |
+| `parse_network` | `"mainnet"` / `"testnet"` | correct monomorphization (compile + dispatch) |
+| `parse_network` | unknown | `get_base_fee`→0; `execution_fee_authorization`→""; checked→`unsupported_network` |
+| authorize/build | `network="testnet"` | tx carries the TestnetV0 network id (not mainnet) |
+| symbol set | release cdylib `nm` | exactly the 34-symbol set |
+| public flow | `executeProof` cold-cache (subprocess/temp dir) | preflight→download→checked, no abort |
+| public flow | proving after latch tripped | fail-fast, no FFI call |
+
+Rust unit tests: rename references; add `ffi_abi_version` test; both-network dispatch
+for the renamed exports (TestnetV0 instantiation verified at compile/dispatch level —
+live testnet proving still blocked on a tx-bearing testnet, as before).
+
+## 7. Out of scope (later PRs)
+
+- **PR4b**: `build_android.sh` (cd aleo_ffi, drop OPENSSL, 16K check fail-nonzero,
+  jniLibs), iOS staticlib + xcframework script + dead-strip/nm docs, `dyLib.dart`
+  Android/iOS branches + cargo path repoint, `setup_dylib.dart` (deprecate the dead
+  pzhun/S3 path; no runtime download in v1), manifest-drift CI.
+- **PR5**: delete GPL `rust/aleo_rust` + prebuilt binaries; `cargo-license` zero GPL;
+  pub.dev dry-run.
+- Enveloping `get_base_fee`/`execution_fee_authorization`/`program_authorization`
+  (deferred consolidation).
+- Live private/fee/program testnet end-to-end (blocked on a tx-bearing testnet).

--- a/rust/aleo_ffi/src/lib.rs
+++ b/rust/aleo_ffi/src/lib.rs
@@ -76,6 +76,17 @@ pub unsafe extern "C" fn free_string(ptr: *mut c_char) {
     }
 }
 
+/// The ABI version of this library. The Dart loader reads it once at load time
+/// and refuses a library whose version it was not built against, turning an
+/// ABI drift (a renamed symbol, a widened integer, a reordered argument) into a
+/// clear "incompatible native library" error instead of a silent mismatch. A
+/// library predating this guard lacks the symbol entirely, so the lookup itself
+/// fails loudly. Bump on every ABI-affecting change.
+#[no_mangle]
+pub extern "C" fn ffi_abi_version() -> u32 {
+    1
+}
+
 /// FFI sanity check used by the test suite.
 #[no_mangle]
 pub extern "C" fn numbers_add(a: c_int, b: c_int) -> c_int {
@@ -360,14 +371,14 @@ fn new_vm<N: Network>() -> anyhow::Result<VM<N, ConsensusMemory<N>>> {
 /// proving: snarkVM verification requires `fee.amount() <= N::MAX_FEE`, so a
 /// base + priority total past the cap could only produce a proof of a
 /// transaction every node rejects.
-fn check_total_fee(base_fee: u64, priority_fee: u64) -> anyhow::Result<()> {
+fn check_total_fee<N: Network>(base_fee: u64, priority_fee: u64) -> anyhow::Result<()> {
     let total = base_fee
         .checked_add(priority_fee)
         .ok_or_else(|| anyhow::anyhow!("total fee overflows u64"))?;
     anyhow::ensure!(
-        total <= Net::MAX_FEE,
+        total <= N::MAX_FEE,
         "total fee {total} exceeds the network maximum {}",
-        Net::MAX_FEE
+        N::MAX_FEE
     );
     Ok(())
 }
@@ -375,11 +386,11 @@ fn check_total_fee(base_fee: u64, priority_fee: u64) -> anyhow::Result<()> {
 /// Returns a plaintext record string suitable as a function input. Records are
 /// supplied encrypted (`record1...`); they are decrypted with the key's view
 /// key. An already-plaintext record (`{ ... }`) is returned unchanged.
-fn plaintext_record(record: &str, private_key: &PrivateKey<Net>) -> anyhow::Result<String> {
+fn plaintext_record<N: Network>(record: &str, private_key: &PrivateKey<N>) -> anyhow::Result<String> {
     let record = record.trim();
     if record.starts_with("record1") {
-        let view_key = ViewKey::<Net>::try_from(private_key)?;
-        let ciphertext = Record::<Net, Ciphertext<Net>>::from_str(record)?;
+        let view_key = ViewKey::<N>::try_from(private_key)?;
+        let ciphertext = Record::<N, Ciphertext<N>>::from_str(record)?;
         Ok(ciphertext.decrypt(&view_key)?.to_string())
     } else {
         Ok(record.to_string())
@@ -387,21 +398,21 @@ fn plaintext_record(record: &str, private_key: &PrivateKey<Net>) -> anyhow::Resu
 }
 
 /// Decrypts (if needed) and parses a record as a typed plaintext record.
-fn plaintext_record_typed(
+fn plaintext_record_typed<N: Network>(
     record: &str,
-    private_key: &PrivateKey<Net>,
-) -> anyhow::Result<Record<Net, Plaintext<Net>>> {
-    Ok(Record::<Net, Plaintext<Net>>::from_str(&plaintext_record(record, private_key)?)?)
+    private_key: &PrivateKey<N>,
+) -> anyhow::Result<Record<N, Plaintext<N>>> {
+    Ok(Record::<N, Plaintext<N>>::from_str(&plaintext_record(record, private_key)?)?)
 }
 
 /// Maps a credits.aleo transfer function to its input list, decrypting the
 /// spent record for private transfers.
-fn transfer_inputs(
+fn transfer_inputs<N: Network>(
     function: &str,
     recipient: &str,
     amount: u64,
     amount_record: &str,
-    private_key: &PrivateKey<Net>,
+    private_key: &PrivateKey<N>,
 ) -> anyhow::Result<Vec<String>> {
     let amount = format!("{amount}u64");
     Ok(match function {
@@ -466,35 +477,59 @@ fn add_fetched_program<N: Network>(
 /// private records). Offline. Returns "" on failure.
 ///
 /// SAFETY: the pointer args are NUL-terminated C strings.
+fn join_authorization_inner<N: Network>(
+    private_key: &str,
+    record_1: &str,
+    record_2: &str,
+) -> anyhow::Result<String> {
+    let private_key = PrivateKey::<N>::from_str(private_key)?;
+    let inputs = vec![
+        plaintext_record(record_1, &private_key)?,
+        plaintext_record(record_2, &private_key)?,
+    ];
+    let vm = new_vm::<N>()?;
+    let authorization =
+        vm.authorize(&private_key, "credits.aleo", "join", inputs, &mut rand::thread_rng())?;
+    Ok(serde_json::to_string(&authorization)?)
+}
+
 #[no_mangle]
 pub unsafe extern "C" fn join_authorization(
     private_key: *const c_char,
     record_1: *const c_char,
     record_2: *const c_char,
     _url: *const c_char,
-    _network: *const c_char,
+    network: *const c_char,
 ) -> *mut c_char {
-    let inner = || -> anyhow::Result<String> {
-        let private_key = PrivateKey::<Net>::from_str(read_str(private_key))?;
-        let inputs = vec![
-            plaintext_record(read_str(record_1), &private_key)?,
-            plaintext_record(read_str(record_2), &private_key)?,
-        ];
-        let vm = new_vm()?;
-        let authorization =
-            vm.authorize(&private_key, "credits.aleo", "join", inputs, &mut rand::thread_rng())?;
-        Ok(serde_json::to_string(&authorization)?)
+    let (private_key, record_1, record_2) =
+        (read_str(private_key), read_str(record_1), read_str(record_2));
+    let result = match parse_network(read_str(network)) {
+        Some(NetworkKind::Mainnet) => join_authorization_inner::<MainnetV0>(private_key, record_1, record_2),
+        Some(NetworkKind::Testnet) => join_authorization_inner::<TestnetV0>(private_key, record_1, record_2),
+        None => Err(anyhow::anyhow!("unknown network")),
     };
-    match inner() {
-        Ok(authorization) => to_cstring(authorization),
-        Err(_) => to_cstring(String::new()),
-    }
+    to_cstring(result.unwrap_or_default())
 }
 
 /// Builds an execution authorization for a credits.aleo transfer. Offline
 /// (credits.aleo is built in). Returns "" on failure.
 ///
 /// SAFETY: the pointer args are NUL-terminated C strings.
+fn execution_authorization_inner<N: Network>(
+    private_key: &str,
+    recipient: &str,
+    transfer_type: &str,
+    amount: u64,
+    amount_record: &str,
+) -> anyhow::Result<String> {
+    let private_key = PrivateKey::<N>::from_str(private_key)?;
+    let inputs = transfer_inputs(transfer_type, recipient, amount, amount_record, &private_key)?;
+    let vm = new_vm::<N>()?;
+    let authorization =
+        vm.authorize(&private_key, "credits.aleo", transfer_type, inputs, &mut rand::thread_rng())?;
+    Ok(serde_json::to_string(&authorization)?)
+}
+
 #[no_mangle]
 pub unsafe extern "C" fn execution_authorization(
     private_key: *const c_char,
@@ -503,27 +538,24 @@ pub unsafe extern "C" fn execution_authorization(
     amount: u64,
     _url: *const c_char,
     amount_record: *const c_char,
-    _network: *const c_char,
+    network: *const c_char,
 ) -> *mut c_char {
-    let inner = || -> anyhow::Result<String> {
-        let private_key = PrivateKey::<Net>::from_str(read_str(private_key))?;
-        let function = read_str(transfer_type);
-        let inputs = transfer_inputs(
-            function,
-            read_str(recipient),
-            amount,
-            read_str(amount_record),
-            &private_key,
-        )?;
-        let vm = new_vm()?;
-        let authorization =
-            vm.authorize(&private_key, "credits.aleo", function, inputs, &mut rand::thread_rng())?;
-        Ok(serde_json::to_string(&authorization)?)
+    let (private_key, recipient, transfer_type, amount_record) = (
+        read_str(private_key),
+        read_str(recipient),
+        read_str(transfer_type),
+        read_str(amount_record),
+    );
+    let result = match parse_network(read_str(network)) {
+        Some(NetworkKind::Mainnet) => {
+            execution_authorization_inner::<MainnetV0>(private_key, recipient, transfer_type, amount, amount_record)
+        }
+        Some(NetworkKind::Testnet) => {
+            execution_authorization_inner::<TestnetV0>(private_key, recipient, transfer_type, amount, amount_record)
+        }
+        None => Err(anyhow::anyhow!("unknown network")),
     };
-    match inner() {
-        Ok(authorization) => to_cstring(authorization),
-        Err(_) => to_cstring(String::new()),
-    }
+    to_cstring(result.unwrap_or_default())
 }
 
 /// Builds the authorization to migrate an old (version-0) credits record to a
@@ -532,32 +564,39 @@ pub unsafe extern "C" fn execution_authorization(
 /// Returns "" on failure.
 ///
 /// SAFETY: the pointer args are NUL-terminated C strings.
+fn upgrade_authorization_inner<N: Network>(
+    private_key: &str,
+    record: &str,
+) -> anyhow::Result<String> {
+    let private_key = PrivateKey::<N>::from_str(private_key)?;
+    let view_key = ViewKey::<N>::try_from(&private_key)?;
+    let record = Record::<N, Ciphertext<N>>::from_str(record)?;
+    let plaintext = record.decrypt(&view_key)?;
+    let vm = new_vm::<N>()?;
+    let authorization = vm.authorize(
+        &private_key,
+        "credits.aleo",
+        "upgrade",
+        vec![plaintext.to_string()],
+        &mut rand::thread_rng(),
+    )?;
+    Ok(serde_json::to_string(&authorization)?)
+}
+
 #[no_mangle]
 pub unsafe extern "C" fn upgrade_authorization(
     private_key: *const c_char,
     record: *const c_char,
     _url: *const c_char,
-    _network: *const c_char,
+    network: *const c_char,
 ) -> *mut c_char {
-    let inner = || -> anyhow::Result<String> {
-        let private_key = PrivateKey::<Net>::from_str(read_str(private_key))?;
-        let view_key = ViewKey::<Net>::try_from(&private_key)?;
-        let record = Record::<Net, Ciphertext<Net>>::from_str(read_str(record))?;
-        let plaintext = record.decrypt(&view_key)?;
-        let vm = new_vm()?;
-        let authorization = vm.authorize(
-            &private_key,
-            "credits.aleo",
-            "upgrade",
-            vec![plaintext.to_string()],
-            &mut rand::thread_rng(),
-        )?;
-        Ok(serde_json::to_string(&authorization)?)
+    let (private_key, record) = (read_str(private_key), read_str(record));
+    let result = match parse_network(read_str(network)) {
+        Some(NetworkKind::Mainnet) => upgrade_authorization_inner::<MainnetV0>(private_key, record),
+        Some(NetworkKind::Testnet) => upgrade_authorization_inner::<TestnetV0>(private_key, record),
+        None => Err(anyhow::anyhow!("unknown network")),
     };
-    match inner() {
-        Ok(authorization) => to_cstring(authorization),
-        Err(_) => to_cstring(String::new()),
-    }
+    to_cstring(result.unwrap_or_default())
 }
 
 /// Assembles a credits.aleo `upgrade` transaction from its execution alone. A
@@ -565,19 +604,23 @@ pub unsafe extern "C" fn upgrade_authorization(
 /// is attached (`Transaction::from_execution(execution, None)`). Returns "".
 ///
 /// SAFETY: `execution` is a NUL-terminated C string.
+fn build_upgrade_transaction_offline_inner<N: Network>(execution: &str) -> anyhow::Result<String> {
+    let execution: Execution<N> = serde_json::from_str(execution)?;
+    Ok(Transaction::from_execution(execution, None)?.to_string())
+}
+
 #[no_mangle]
 pub unsafe extern "C" fn build_upgrade_transaction_offline(
     execution: *const c_char,
-    _network: *const c_char,
+    network: *const c_char,
 ) -> *mut c_char {
-    let inner = || -> anyhow::Result<String> {
-        let execution: Execution<Net> = serde_json::from_str(read_str(execution))?;
-        Ok(Transaction::from_execution(execution, None)?.to_string())
+    let execution = read_str(execution);
+    let result = match parse_network(read_str(network)) {
+        Some(NetworkKind::Mainnet) => build_upgrade_transaction_offline_inner::<MainnetV0>(execution),
+        Some(NetworkKind::Testnet) => build_upgrade_transaction_offline_inner::<TestnetV0>(execution),
+        None => Err(anyhow::anyhow!("unknown network")),
     };
-    match inner() {
-        Ok(transaction) => to_cstring(transaction),
-        Err(_) => to_cstring(String::new()),
-    }
+    to_cstring(result.unwrap_or_default())
 }
 
 /// Assembles a transaction from a serialized execution proof and fee proof
@@ -585,18 +628,25 @@ pub unsafe extern "C" fn build_upgrade_transaction_offline(
 ///
 /// SAFETY: `execution`/`fee`/`_network` are NUL-terminated C strings
 /// (snarkVM serde JSON).
+fn build_transaction_offline_inner<N: Network>(execution: &str, fee: &str) -> Option<String> {
+    let execution: Execution<N> = serde_json::from_str(execution).ok()?;
+    let fee: Fee<N> = serde_json::from_str(fee).ok()?;
+    let transaction = Transaction::from_execution(execution, Some(fee)).ok()?;
+    Some(transaction.to_string())
+}
+
 #[no_mangle]
 pub unsafe extern "C" fn build_transaction_offline(
     execution: *const c_char,
     fee: *const c_char,
-    _network: *const c_char,
+    network: *const c_char,
 ) -> *mut c_char {
-    let result = (|| -> Option<String> {
-        let execution: Execution<Net> = serde_json::from_str(read_str(execution)).ok()?;
-        let fee: Fee<Net> = serde_json::from_str(read_str(fee)).ok()?;
-        let transaction = Transaction::from_execution(execution, Some(fee)).ok()?;
-        Some(transaction.to_string())
-    })();
+    let (execution, fee) = (read_str(execution), read_str(fee));
+    let result = match parse_network(read_str(network)) {
+        Some(NetworkKind::Mainnet) => build_transaction_offline_inner::<MainnetV0>(execution, fee),
+        Some(NetworkKind::Testnet) => build_transaction_offline_inner::<TestnetV0>(execution, fee),
+        None => None,
+    };
     to_cstring(result.unwrap_or_default())
 }
 
@@ -636,14 +686,12 @@ pub unsafe extern "C" fn serial_number_string(
 // pre-fetched node data (`height`, `state_paths_json`, `public_state_root`,
 // `program_sources_json`) instead of a `url`/`network` to query, so these
 // exports issue no node RPC — all node I/O lives in the Dart `AleoNode`. Phase 3
-// deleted the old in-Rust HTTP path (the 12 network exports). The proving/fee
-// primitives KEEP their `_static` symbol names: those names never collided with
-// an old export, so a stale prebuilt library (which lacks them) fails Dart's
-// `lookupFunction` with a clear missing-symbol error. Renaming them to the
-// now-free canonical names is deferred to the phase-4 lib redistribution, where
-// it can land atomically with a rebuilt/redistributed library + an ABI-version
-// guard — reusing a freed name whose ABI differs in an already-distributed lib
-// would turn that clean error into a silent ABI mismatch. The crate now links NO
+// deleted the old in-Rust HTTP path (the 12 network exports). Phase 4 PR4a
+// (workstream C) renamed the surviving fee/authorize primitives to their
+// canonical names and made them network-aware, and added `ffi_abi_version` as the
+// load-time ABI guard the Dart loader checks — so a stale prebuilt library (a
+// different ABI, or lacking the guard symbol) is rejected loudly rather than
+// binding a renamed symbol to a different signature. The crate now links NO
 // HTTP/TLS stack: the vendored snarkvm-parameters curl downloader is removed
 // (parameters-no-remote-fetch.patch, workstream A), so on a cold parameter cache
 // a missing proving key fails closed with `RemoteFetchDisabled` instead of being
@@ -801,13 +849,13 @@ fn checked_static_query<N: Network>(
 /// program (and its imports) — snarkVM's `execution_cost` reads each transition's
 /// program `Stack`, so a non-builtin execution needs them loaded first. Empty
 /// for a credits.aleo execution (the program is built in).
-fn base_fee_at_height(
-    execution: &Execution<Net>,
+fn base_fee_at_height<N: Network>(
+    execution: &Execution<N>,
     program_sources_json: &str,
     height: u32,
 ) -> anyhow::Result<u64> {
-    let consensus_version = Net::CONSENSUS_VERSION(height)?;
-    let vm = new_vm()?;
+    let consensus_version = N::CONSENSUS_VERSION(height)?;
+    let vm = new_vm::<N>()?;
     add_programs_from_sources(&vm, program_sources_json)?;
     let process = vm.process();
     let process = process.read();
@@ -1080,36 +1128,78 @@ pub extern "C" fn consensus_version_for(height: u32) -> u16 {
     Net::CONSENSUS_VERSION(height).map(|version| version as u16).unwrap_or(0)
 }
 
-/// Pure variant of [`get_base_fee_static`]: `height` (→ consensus version) replaces the
-/// node fetch, and `program_sources_json` supplies the execution's root program
-/// (+ imports) needed to compute its cost — empty for a credits.aleo execution.
-/// Returns the base fee in microcredits, or 0 on failure.
-///
-/// SAFETY: `execution`/`program_sources_json` are NUL-terminated C strings.
+/// Computes the base fee for `execution` at `height` (→ consensus version),
+/// offline: `program_sources_json` supplies the execution's root program (+
+/// imports) needed to cost it — empty for a credits.aleo execution. The exported
+/// [`get_base_fee`] dispatches to this per network. Returns the base fee in
+/// microcredits.
+fn get_base_fee_inner<N: Network>(
+    execution: &str,
+    program_sources_json: &str,
+    height: u32,
+) -> anyhow::Result<u64> {
+    let execution: Execution<N> = serde_json::from_str(execution)?;
+    base_fee_at_height::<N>(&execution, program_sources_json, height)
+}
+
 #[no_mangle]
-pub unsafe extern "C" fn get_base_fee_static(
+pub unsafe extern "C" fn get_base_fee(
+    network: *const c_char,
     execution: *const c_char,
     program_sources_json: *const c_char,
     height: u32,
 ) -> u64 {
-    let inner = || -> anyhow::Result<u64> {
-        let execution: Execution<Net> = serde_json::from_str(read_str(execution))?;
-        base_fee_at_height(&execution, read_str(program_sources_json), height)
+    let (execution, program_sources_json) = (read_str(execution), read_str(program_sources_json));
+    let result = match parse_network(read_str(network)) {
+        Some(NetworkKind::Mainnet) => get_base_fee_inner::<MainnetV0>(execution, program_sources_json, height),
+        Some(NetworkKind::Testnet) => get_base_fee_inner::<TestnetV0>(execution, program_sources_json, height),
+        None => Err(anyhow::anyhow!("unknown network")),
     };
-    inner().unwrap_or(0)
+    result.unwrap_or(0)
 }
 
-/// Pure variant of [`execution_fee_authorization_static`]: `height` replaces the node
-/// fetch used to derive the base fee, and `program_sources_json` supplies the
-/// execution's root program (+ imports) needed to compute that fee (empty for a
-/// credits.aleo execution). `fee_credits` is the priority fee; an empty
-/// `fee_record` uses a public fee, otherwise a private fee spending that record.
-/// Returns "" on failure.
-///
-/// SAFETY: `private_key`/`execution`/`fee_record`/`program_sources_json` are
-/// NUL-terminated C strings.
+/// Authorizes the fee for `execution`, offline: `height` (→ consensus version)
+/// derives the base fee and `program_sources_json` supplies the execution's root
+/// program (+ imports) needed to cost it (empty for a credits.aleo execution).
+/// `fee_credits` is the priority fee; an empty `fee_record` uses a public fee,
+/// otherwise a private fee spending that record. The exported
+/// [`execution_fee_authorization`] dispatches to this per network.
+fn execution_fee_authorization_inner<N: Network>(
+    private_key: &str,
+    execution: &str,
+    fee_credits: u64,
+    fee_record: &str,
+    program_sources_json: &str,
+    height: u32,
+) -> anyhow::Result<String> {
+    let private_key = PrivateKey::<N>::from_str(private_key)?;
+    let execution: Execution<N> = serde_json::from_str(execution)?;
+    let execution_id = execution.to_execution_id()?;
+    // One VM loads the execution's program(s) so its cost can be computed,
+    // then authorizes the fee (credits.aleo is built in) — no second VM.
+    let consensus_version = N::CONSENSUS_VERSION(height)?;
+    let vm = new_vm::<N>()?;
+    add_programs_from_sources(&vm, program_sources_json)?;
+    let base_fee = {
+        let process = vm.process();
+        let process = process.read();
+        snarkvm_synthesizer::process::execution_cost(&process, &execution, consensus_version)?.0
+    };
+    let priority_fee = fee_credits;
+    check_total_fee::<N>(base_fee, priority_fee)?;
+    let rng = &mut rand::thread_rng();
+    let authorization = if fee_record.trim().is_empty() {
+        vm.authorize_fee_public(&private_key, base_fee, priority_fee, execution_id, rng)?
+    } else {
+        let record = plaintext_record_typed(fee_record, &private_key)?;
+        vm.authorize_fee_private(&private_key, record, base_fee, priority_fee, execution_id, rng)?
+    };
+    Ok(serde_json::to_string(&authorization)?)
+}
+
 #[no_mangle]
-pub unsafe extern "C" fn execution_fee_authorization_static(
+pub unsafe extern "C" fn execution_fee_authorization(
+    network: *const c_char,
     private_key: *const c_char,
     execution: *const c_char,
     fee_credits: u64,
@@ -1117,138 +1207,30 @@ pub unsafe extern "C" fn execution_fee_authorization_static(
     program_sources_json: *const c_char,
     height: u32,
 ) -> *mut c_char {
-    let inner = || -> anyhow::Result<String> {
-        let private_key = PrivateKey::<Net>::from_str(read_str(private_key))?;
-        let execution: Execution<Net> = serde_json::from_str(read_str(execution))?;
-        let execution_id = execution.to_execution_id()?;
-        // One VM loads the execution's program(s) so its cost can be computed,
-        // then authorizes the fee (credits.aleo is built in) — no second VM.
-        let consensus_version = Net::CONSENSUS_VERSION(height)?;
-        let vm = new_vm()?;
-        add_programs_from_sources(&vm, read_str(program_sources_json))?;
-        let base_fee = {
-            let process = vm.process();
-            let process = process.read();
-            snarkvm_synthesizer::process::execution_cost(&process, &execution, consensus_version)?.0
-        };
-        let priority_fee = fee_credits;
-        check_total_fee(base_fee, priority_fee)?;
-        let fee_record = read_str(fee_record);
-        let rng = &mut rand::thread_rng();
-        let authorization = if fee_record.trim().is_empty() {
-            vm.authorize_fee_public(&private_key, base_fee, priority_fee, execution_id, rng)?
-        } else {
-            let record = plaintext_record_typed(fee_record, &private_key)?;
-            vm.authorize_fee_private(&private_key, record, base_fee, priority_fee, execution_id, rng)?
-        };
-        Ok(serde_json::to_string(&authorization)?)
+    let (private_key, execution, fee_record, program_sources_json) = (
+        read_str(private_key),
+        read_str(execution),
+        read_str(fee_record),
+        read_str(program_sources_json),
+    );
+    let result = match parse_network(read_str(network)) {
+        Some(NetworkKind::Mainnet) => execution_fee_authorization_inner::<MainnetV0>(
+            private_key, execution, fee_credits, fee_record, program_sources_json, height,
+        ),
+        Some(NetworkKind::Testnet) => execution_fee_authorization_inner::<TestnetV0>(
+            private_key, execution, fee_credits, fee_record, program_sources_json, height,
+        ),
+        None => Err(anyhow::anyhow!("unknown network")),
     };
-    match inner() {
-        Ok(authorization) => to_cstring(authorization),
-        Err(_) => to_cstring(String::new()),
-    }
+    to_cstring(result.unwrap_or_default())
 }
 
-/// Pure variant of [`execute_proof_static`]: proves an authorization against a
-/// [`StaticQuery`] built from pre-fetched `height` / `state_paths_json` /
-/// `public_state_root` instead of querying a node. Returns the serialized
-/// execution, or "" on failure.
-///
-/// SAFETY: `authorization`/`state_paths_json`/`public_state_root` are
-/// NUL-terminated C strings.
-#[no_mangle]
-pub unsafe extern "C" fn execute_proof_static(
-    authorization: *const c_char,
-    height: u32,
-    state_paths_json: *const c_char,
-    public_state_root: *const c_char,
-) -> *mut c_char {
-    let inner = || -> anyhow::Result<String> {
-        let authorization: Authorization<Net> = serde_json::from_str(read_str(authorization))?;
-        let query = checked_static_query(
-            &authorization,
-            height,
-            read_str(state_paths_json),
-            read_str(public_state_root),
-        )?;
-        let vm = new_vm()?;
-        let (execution, _response) =
-            vm.execute_authorization_raw(authorization, &query, &mut rand::thread_rng())?;
-        Ok(serde_json::to_string(&execution)?)
-    };
-    match inner() {
-        Ok(execution) => to_cstring(execution),
-        Err(_) => to_cstring(String::new()),
-    }
-}
-
-/// Pure variant of [`execute_fee_proof_static`]: proves a fee authorization against a
-/// [`StaticQuery`] built from pre-fetched node data. A private fee spends its
-/// own record, so its `state_paths_json` is its own snapshot (distinct from the
-/// execution's); a public fee passes empty paths + a `public_state_root`.
-/// Returns the serialized fee, or "" on failure.
-///
-/// SAFETY: `authorization`/`state_paths_json`/`public_state_root` are
-/// NUL-terminated C strings.
-#[no_mangle]
-pub unsafe extern "C" fn execute_fee_proof_static(
-    authorization: *const c_char,
-    height: u32,
-    state_paths_json: *const c_char,
-    public_state_root: *const c_char,
-) -> *mut c_char {
-    let inner = || -> anyhow::Result<String> {
-        let authorization: Authorization<Net> = serde_json::from_str(read_str(authorization))?;
-        let query = checked_static_query(
-            &authorization,
-            height,
-            read_str(state_paths_json),
-            read_str(public_state_root),
-        )?;
-        let vm = new_vm()?;
-        let fee = vm.execute_fee_authorization_raw(authorization, &query, &mut rand::thread_rng())?;
-        Ok(serde_json::to_string(&fee)?)
-    };
-    match inner() {
-        Ok(fee) => to_cstring(fee),
-        Err(_) => to_cstring(String::new()),
-    }
-}
-
-/// Pure variant of [`execute_program_proof_static`]: the referenced program (and its
-/// import closure) is supplied in-memory via `program_sources_json` rather than
-/// fetched from a node, then the authorization is proved against a
-/// [`StaticQuery`] built from pre-fetched node data. Returns the serialized
-/// execution, or "" on failure.
-///
-/// SAFETY: the pointer args are NUL-terminated C strings.
-#[no_mangle]
-pub unsafe extern "C" fn execute_program_proof_static(
-    authorization: *const c_char,
-    program_sources_json: *const c_char,
-    height: u32,
-    state_paths_json: *const c_char,
-    public_state_root: *const c_char,
-) -> *mut c_char {
-    let inner = || -> anyhow::Result<String> {
-        let authorization: Authorization<Net> = serde_json::from_str(read_str(authorization))?;
-        let vm = new_vm()?;
-        add_programs_from_sources(&vm, read_str(program_sources_json))?;
-        let query = checked_static_query(
-            &authorization,
-            height,
-            read_str(state_paths_json),
-            read_str(public_state_root),
-        )?;
-        let (execution, _response) =
-            vm.execute_authorization_raw(authorization, &query, &mut rand::thread_rng())?;
-        Ok(serde_json::to_string(&execution)?)
-    };
-    match inner() {
-        Ok(execution) => to_cstring(execution),
-        Err(_) => to_cstring(String::new()),
-    }
-}
+// The plain proving exports (`execute_proof_static` / `execute_fee_proof_static` /
+// `execute_program_proof_static`) were deleted in PR4a: they are superseded by the
+// network-aware, enveloped, cold-cache-safe `*_checked` exports below, which the
+// public Dart flow now uses. Their canonical names (`execute_proof`, …) are left
+// unused on purpose — reusing a freed symbol name whose ABI differs across already
+// distributed libraries is the hazard `ffi_abi_version` guards against.
 
 /// Builds an execution authorization for an arbitrary program function, offline.
 /// The referenced program (and its imports) is supplied in-memory via
@@ -1262,32 +1244,48 @@ pub unsafe extern "C" fn execute_program_proof_static(
 /// for a built-in program (credits.aleo). Returns "" on failure.
 ///
 /// SAFETY: the pointer args are NUL-terminated C strings.
+fn program_authorization_inner<N: Network>(
+    private_key: &str,
+    program_id: &str,
+    function_name: &str,
+    arguments: &str,
+    program_sources_json: &str,
+) -> anyhow::Result<String> {
+    let private_key = PrivateKey::<N>::from_str(private_key)?;
+    let inputs: Vec<String> = serde_json::from_str(arguments)?;
+    let vm = new_vm::<N>()?;
+    add_programs_from_sources(&vm, program_sources_json)?;
+    let authorization =
+        vm.authorize(&private_key, program_id, function_name, inputs, &mut rand::thread_rng())?;
+    Ok(serde_json::to_string(&authorization)?)
+}
+
 #[no_mangle]
-pub unsafe extern "C" fn program_authorization_static(
+pub unsafe extern "C" fn program_authorization(
+    network: *const c_char,
     private_key: *const c_char,
     program_id: *const c_char,
     function_name: *const c_char,
     arguments: *const c_char,
     program_sources_json: *const c_char,
 ) -> *mut c_char {
-    let inner = || -> anyhow::Result<String> {
-        let private_key = PrivateKey::<Net>::from_str(read_str(private_key))?;
-        let inputs: Vec<String> = serde_json::from_str(read_str(arguments))?;
-        let vm = new_vm()?;
-        add_programs_from_sources(&vm, read_str(program_sources_json))?;
-        let authorization = vm.authorize(
-            &private_key,
-            read_str(program_id),
-            read_str(function_name),
-            inputs,
-            &mut rand::thread_rng(),
-        )?;
-        Ok(serde_json::to_string(&authorization)?)
+    let (private_key, program_id, function_name, arguments, program_sources_json) = (
+        read_str(private_key),
+        read_str(program_id),
+        read_str(function_name),
+        read_str(arguments),
+        read_str(program_sources_json),
+    );
+    let result = match parse_network(read_str(network)) {
+        Some(NetworkKind::Mainnet) => program_authorization_inner::<MainnetV0>(
+            private_key, program_id, function_name, arguments, program_sources_json,
+        ),
+        Some(NetworkKind::Testnet) => program_authorization_inner::<TestnetV0>(
+            private_key, program_id, function_name, arguments, program_sources_json,
+        ),
+        None => Err(anyhow::anyhow!("unknown network")),
     };
-    match inner() {
-        Ok(authorization) => to_cstring(authorization),
-        Err(_) => to_cstring(String::new()),
-    }
+    to_cstring(result.unwrap_or_default())
 }
 
 // ── Phase 4 FFI result envelope (docs/phase4-plan.md §8 Contract 1) ──────────
@@ -1578,8 +1576,8 @@ fn execute_program_proof_checked_inner<N: Network>(
     }
 }
 
-/// Network-aware [`execute_proof_static`]: proves an execution authorization for
-/// `network` against a [`StaticQuery`] built from pre-fetched node data, returning
+/// Proves an execution authorization for `network` against a [`StaticQuery`]
+/// built from pre-fetched node data, returning
 /// the §8 Contract 1 envelope (`{"ok":true,"data":"<execution>"}` or a tagged
 /// error). Credits-only.
 ///
@@ -1609,7 +1607,7 @@ pub unsafe extern "C" fn execute_proof_checked(
     })
 }
 
-/// Network-aware [`execute_fee_proof_static`]: proves a fee authorization (a
+/// Proves a fee authorization for `network` (a
 /// private fee spends its own record, so its state paths are its own snapshot;
 /// a public fee passes empty paths + a `public_state_root`). Credits-only.
 ///
@@ -1639,8 +1637,8 @@ pub unsafe extern "C" fn execute_fee_proof_checked(
     })
 }
 
-/// Network-aware [`execute_program_proof_static`]. v1 is credits-only, so a
-/// non-empty `program_sources_json` (a custom program) is rejected with
+/// Proves a program execution authorization for `network`. v1 is credits-only, so
+/// a non-empty `program_sources_json` (a custom program) is rejected with
 /// `unsupported_feature`; the symbol is kept so the Dart program path can bind it.
 ///
 /// SAFETY: the pointer args are null or NUL-terminated C strings.
@@ -2027,11 +2025,11 @@ mod tests {
     // base + priority sum must not wrap.
     #[test]
     fn total_fee_capped_at_network_maximum() {
-        assert!(check_total_fee(Net::MAX_FEE, 0).is_ok());
-        assert!(check_total_fee(Net::MAX_FEE - 1, 1).is_ok());
-        let error = check_total_fee(Net::MAX_FEE, 1).unwrap_err();
+        assert!(check_total_fee::<Net>(Net::MAX_FEE, 0).is_ok());
+        assert!(check_total_fee::<Net>(Net::MAX_FEE - 1, 1).is_ok());
+        let error = check_total_fee::<Net>(Net::MAX_FEE, 1).unwrap_err();
         assert!(error.to_string().contains("exceeds"), "got: {error}");
-        let error = check_total_fee(u64::MAX, 1).unwrap_err();
+        let error = check_total_fee::<Net>(u64::MAX, 1).unwrap_err();
         assert!(error.to_string().contains("overflows"), "got: {error}");
     }
 
@@ -2040,6 +2038,8 @@ mod tests {
     #[test]
     fn ffi_smoke_through_c_abi() {
         assert_eq!(numbers_add(2, 3), 6); // a + b + 1
+        // The ABI-version export the Dart loader guards on (PR4a).
+        assert_eq!(ffi_abi_version(), 1);
         unsafe {
             let seed = [1u8; 32];
             let pk_ptr = seed_to_private_key(seed.as_ptr());
@@ -2050,6 +2050,13 @@ mod tests {
             let addr_ptr = private_key_to_address(pk_c.as_ptr());
             let addr = CStr::from_ptr(addr_ptr).to_str().unwrap();
             assert!(addr.starts_with("aleo1"), "got {addr}");
+
+            // A renamed network-aware export reached through the C ABI: an unknown
+            // network fails closed (0), and a malformed execution does too, so this
+            // exercises the rename + dispatch without needing a real execution.
+            let net = CString::new("mainnet").unwrap();
+            let bad = CString::new("not-json").unwrap();
+            assert_eq!(get_base_fee(net.as_ptr(), bad.as_ptr(), bad.as_ptr(), 9_430_000), 0);
 
             free_string(pk_ptr);
             free_string(addr_ptr);
@@ -2171,7 +2178,7 @@ mod tests {
     use snarkvm_console::network::prelude::TestRng;
     use snarkvm_console::program::state_path::test_helpers::sample_global_state_path;
 
-    // The load-bearing assumption execute_proof_static relies on: a *global*
+    // The load-bearing assumption the checked proving path relies on: a *global*
     // StatePath's transition-leaf id IS the record commitment, so static_query
     // can key the query map by it and proving finds each path by commitment.
     #[test]
@@ -2524,41 +2531,53 @@ mod tests {
         }
     }
 
-    // The static fee API takes program_sources_json (so non-builtin executions
-    // can be costed). Malformed input returns 0 / "" without panicking across the
-    // FFI boundary — and exercises the new 3-arg / 6-arg ABIs.
+    // The fee API takes a network + program_sources_json (so non-builtin
+    // executions can be costed). Malformed input returns 0 / "" without panicking
+    // across the FFI boundary; an unknown network is fail-closed the same way.
     #[test]
-    fn get_base_fee_static_malformed_returns_zero() {
+    fn get_base_fee_malformed_or_unknown_network_returns_zero() {
         unsafe {
             let execution = CString::new("not json").unwrap();
             let sources = CString::new("").unwrap();
-            assert_eq!(get_base_fee_static(execution.as_ptr(), sources.as_ptr(), 9_430_000), 0);
+            for net in ["mainnet", "testnet", "bogus"] {
+                let n = CString::new(net).unwrap();
+                assert_eq!(
+                    get_base_fee(n.as_ptr(), execution.as_ptr(), sources.as_ptr(), 9_430_000),
+                    0,
+                    "network {net}"
+                );
+            }
         }
     }
 
     #[test]
-    fn execution_fee_authorization_static_malformed_returns_empty() {
+    fn execution_fee_authorization_malformed_or_unknown_network_returns_empty() {
         unsafe {
             let pk = CString::new(OWNER_KEY).unwrap();
             let execution = CString::new("not json").unwrap();
             let fee_record = CString::new("").unwrap();
             let sources = CString::new("").unwrap();
-            let ptr = execution_fee_authorization_static(
-                pk.as_ptr(),
-                execution.as_ptr(),
-                1000,
-                fee_record.as_ptr(),
-                sources.as_ptr(),
-                9_430_000,
-            );
-            let out = CStr::from_ptr(ptr).to_str().unwrap().to_owned();
-            free_string(ptr);
-            assert_eq!(out, "");
+            for net in ["mainnet", "testnet", "bogus"] {
+                let n = CString::new(net).unwrap();
+                let ptr = execution_fee_authorization(
+                    n.as_ptr(),
+                    pk.as_ptr(),
+                    execution.as_ptr(),
+                    1000,
+                    fee_record.as_ptr(),
+                    sources.as_ptr(),
+                    9_430_000,
+                );
+                let out = CStr::from_ptr(ptr).to_str().unwrap().to_owned();
+                free_string(ptr);
+                assert_eq!(out, "", "network {net}");
+            }
         }
     }
 
-    /// Calls the 5-arg program_authorization_static and returns the owned result.
-    fn call_program_authorization_static(
+    /// Calls the network-aware program_authorization and returns the owned result.
+    fn call_program_authorization(
+        network: &str,
         private_key: &str,
         program_id: &str,
         function: &str,
@@ -2566,12 +2585,14 @@ mod tests {
         sources: &str,
     ) -> String {
         unsafe {
+            let net = CString::new(network).unwrap();
             let pk = CString::new(private_key).unwrap();
             let program = CString::new(program_id).unwrap();
             let function = CString::new(function).unwrap();
             let arguments = CString::new(arguments).unwrap();
             let sources = CString::new(sources).unwrap();
-            let ptr = program_authorization_static(
+            let ptr = program_authorization(
+                net.as_ptr(),
                 pk.as_ptr(),
                 program.as_ptr(),
                 function.as_ptr(),
@@ -2586,10 +2607,11 @@ mod tests {
 
     // A built-in program (credits.aleo) authorizes with no program sources.
     #[test]
-    fn program_authorization_static_builtin_no_sources() {
+    fn program_authorization_builtin_no_sources() {
         let args = serde_json::to_string(&vec![recipient_address(), "5u64".to_string()]).unwrap();
-        let out =
-            call_program_authorization_static(OWNER_KEY, "credits.aleo", "transfer_public", &args, "");
+        let out = call_program_authorization(
+            "mainnet", OWNER_KEY, "credits.aleo", "transfer_public", &args, "",
+        );
         let auth: Authorization<Net> = serde_json::from_str(&out).unwrap();
         assert_eq!(auth.to_vec_deque().len(), 1);
     }
@@ -2597,35 +2619,92 @@ mod tests {
     // The path credits-only authorize exports can't reach: load a non-builtin
     // program from sources, then authorize its function offline.
     #[test]
-    fn program_authorization_static_loads_then_authorizes() {
+    fn program_authorization_loads_then_authorizes() {
         let sources = sources_json(&[("auth0.aleo", &[])]);
-        let out = call_program_authorization_static(OWNER_KEY, "auth0.aleo", "noop", "[]", &sources);
+        let out = call_program_authorization("mainnet", OWNER_KEY, "auth0.aleo", "noop", "[]", &sources);
         let auth: Authorization<Net> = serde_json::from_str(&out).unwrap();
         assert!(!auth.to_vec_deque().is_empty(), "authorized a non-builtin function");
     }
 
-    // Malformed input returns "" rather than panicking across the FFI boundary.
+    // Malformed input — and an unknown network — return "" rather than panicking.
     #[test]
-    fn program_authorization_static_malformed_returns_empty() {
+    fn program_authorization_malformed_returns_empty() {
         // Bad arguments JSON.
         assert_eq!(
-            call_program_authorization_static(OWNER_KEY, "credits.aleo", "transfer_public", "nope", ""),
+            call_program_authorization("mainnet", OWNER_KEY, "credits.aleo", "transfer_public", "nope", ""),
             ""
         );
         // Unknown program with no sources to load it.
-        assert_eq!(call_program_authorization_static(OWNER_KEY, "ghost.aleo", "go", "[]", ""), "");
+        assert_eq!(call_program_authorization("mainnet", OWNER_KEY, "ghost.aleo", "go", "[]", ""), "");
+        // Unknown network.
+        let args = serde_json::to_string(&vec![recipient_address(), "5u64".to_string()]).unwrap();
+        assert_eq!(
+            call_program_authorization("bogus", OWNER_KEY, "credits.aleo", "transfer_public", &args, ""),
+            ""
+        );
     }
 
-    // End-to-end proof through execute_proof_static for a PUBLIC transfer: no
+    // ── Network activation: helper stack + authorize entry are generic over N ──
+
+    // The genericized transfer-input helper instantiates and runs for TestnetV0,
+    // not just the MainnetV0 default. The public branch needs no record fixture,
+    // so both networks are exercised offline.
+    #[test]
+    fn transfer_inputs_generic_over_network() {
+        let mainnet_key = PrivateKey::<MainnetV0>::from_str(OWNER_KEY).unwrap();
+        let testnet_key = PrivateKey::<TestnetV0>::from_str(OWNER_KEY).unwrap();
+        let m = transfer_inputs("transfer_public", "aleo1recipient", 5, "", &mainnet_key).unwrap();
+        let t = transfer_inputs("transfer_public", "aleo1recipient", 5, "", &testnet_key).unwrap();
+        // A public transfer's inputs are [recipient, amount] regardless of network.
+        assert_eq!(m, vec!["aleo1recipient".to_string(), "5u64".to_string()]);
+        assert_eq!(m, t);
+    }
+
+    // execution_authorization honors the network arg: a transfer_public
+    // authorization is produced under the requested network (parses under that
+    // network's type), and an unknown network is fail-closed.
+    #[test]
+    fn execution_authorization_honors_network() {
+        let recipient = recipient_address();
+        let auth_for = |network: &str| -> String {
+            unsafe {
+                let n = CString::new(network).unwrap();
+                let pk = CString::new(OWNER_KEY).unwrap();
+                let rcpt = CString::new(recipient.clone()).unwrap();
+                let func = CString::new("transfer_public").unwrap();
+                let url = CString::new("").unwrap();
+                let rec = CString::new("").unwrap();
+                let ptr = execution_authorization(
+                    pk.as_ptr(),
+                    rcpt.as_ptr(),
+                    func.as_ptr(),
+                    5,
+                    url.as_ptr(),
+                    rec.as_ptr(),
+                    n.as_ptr(),
+                );
+                let out = CStr::from_ptr(ptr).to_str().unwrap().to_owned();
+                free_string(ptr);
+                out
+            }
+        };
+        let m = auth_for("mainnet");
+        assert!(serde_json::from_str::<Authorization<MainnetV0>>(&m).is_ok(), "mainnet: {m}");
+        let t = auth_for("testnet");
+        assert!(serde_json::from_str::<Authorization<TestnetV0>>(&t).is_ok(), "testnet: {t}");
+        assert_eq!(auth_for("bogus"), "", "unknown network must be fail-closed");
+    }
+
+    // End-to-end proof through execute_proof_checked for a PUBLIC transfer: no
     // record inputs, so no state paths — proving only needs a height and a real
-    // (non-zero) state root. This exercises static_query's public branch +
-    // execute_authorization_raw for real and checks the proof carries the
-    // supplied root. Heavy (downloads proving keys + proves), hence #[ignore].
-    // The private-flow end-to-end stays for the phase-2 testnet parity run (it
-    // needs a real on-chain state path).
+    // (non-zero) state root. This exercises checked_static_query's public branch +
+    // execute_authorization_raw for real and checks the proof carries the supplied
+    // root. Heavy (downloads proving keys + proves), hence #[ignore]. The
+    // private-flow end-to-end stays for the testnet parity run (it needs a real
+    // on-chain state path).
     #[test]
     #[ignore = "proving: downloads keys + proves, run with `cargo test --release -- --ignored`"]
-    fn execute_proof_static_public_transfer_end_to_end() {
+    fn execute_proof_checked_public_transfer_end_to_end() {
         let owner = owner();
         let vm = new_vm::<Net>().unwrap();
         let auth = vm
@@ -2641,24 +2720,29 @@ mod tests {
         // Any valid, non-zero state root works for a public flow (no inclusion
         // assignments to check it against; consensus checks it on-chain later).
         let root = "sr1dz06ur5spdgzkguh4pr42mvft6u3nwsg5drh9rdja9v8jpcz3czsls9geg";
-        let out = unsafe {
+        let env = unsafe {
+            let n = CString::new("mainnet").unwrap();
             let auth_c = CString::new(auth_json).unwrap();
             let paths_c = CString::new("").unwrap();
             let root_c = CString::new(root).unwrap();
-            let ptr = execute_proof_static(auth_c.as_ptr(), 9_430_000, paths_c.as_ptr(), root_c.as_ptr());
-            let out = CStr::from_ptr(ptr).to_str().unwrap().to_owned();
-            free_string(ptr);
-            out
+            call_envelope(execute_proof_checked(
+                n.as_ptr(),
+                auth_c.as_ptr(),
+                9_430_000,
+                paths_c.as_ptr(),
+                root_c.as_ptr(),
+            ))
         };
-        assert!(!out.is_empty(), "expected a serialized execution, got the error sentinel");
-        let execution: Execution<Net> = serde_json::from_str(&out).unwrap();
-        // The proof carries the root static_query was given.
+        assert_eq!(env["ok"], serde_json::json!(true), "envelope: {env}");
+        let execution: Execution<Net> =
+            serde_json::from_str(env["data"].as_str().expect("data string")).unwrap();
+        // The proof carries the root checked_static_query was given.
         assert_eq!(execution.global_state_root().to_string(), root);
     }
 
     // ── Network-aware checked proving exports (§8): the offline reject paths ────
     // (The happy path is real SNARK proving — covered by the #[ignore] end-to-end
-    // test above for the equivalent `_static` export.)
+    // test above through execute_proof_checked.)
 
     fn call_envelope(ptr: *mut c_char) -> serde_json::Value {
         let s = unsafe { CStr::from_ptr(ptr) }.to_str().unwrap().to_owned();

--- a/rust/aleo_ffi/src/lib.rs
+++ b/rust/aleo_ffi/src/lib.rs
@@ -62,6 +62,33 @@ fn to_cstring(s: String) -> *mut c_char {
     unsafe { CString::from_vec_unchecked(bytes) }.into_raw()
 }
 
+// ── Panic backstop for the legacy (pre-§8-envelope) exports ──────────────────
+//
+// The legacy exports keep their historic fail-closed convention ("" for a string,
+// 0 for a number) instead of the richer §8 envelope. But a panic must still never
+// cross the C ABI: snarkVM `.expect()`s deep in deserialization — most sharply, a
+// value deserialized under the WRONG network trips a network-id assertion
+// (`console-network-environment`), which a direct FFI caller (or a Dart bug that
+// passes the wrong `network`) can reach. Each legacy export runs its body under
+// `catch_unwind` so such a panic degrades to the fail-closed sentinel rather than
+// unwinding across `extern "C"` (UB/abort). `panic = "unwind"` (Cargo.toml) keeps
+// this effective in release. `AssertUnwindSafe` is sound: the closures only borrow
+// caller input and compute over snarkVM types; aleo_ffi holds no lock or invariant
+// a panic could leave inconsistent (the only cross-call state is snarkVM's
+// parameter cache, which these non-proving exports never touch).
+fn ffi_legacy_string(f: impl FnOnce() -> *mut c_char) -> *mut c_char {
+    std::panic::catch_unwind(std::panic::AssertUnwindSafe(f))
+        .unwrap_or_else(|_| to_cstring(String::new()))
+}
+
+fn ffi_legacy_u64(f: impl FnOnce() -> u64) -> u64 {
+    std::panic::catch_unwind(std::panic::AssertUnwindSafe(f)).unwrap_or(0)
+}
+
+fn ffi_legacy_u16(f: impl FnOnce() -> u16) -> u16 {
+    std::panic::catch_unwind(std::panic::AssertUnwindSafe(f)).unwrap_or(0)
+}
+
 /// Frees a string previously returned by this library. Returned pointers are
 /// allocated with Rust's allocator via `CString::into_raw`, so they must be
 /// handed back to Rust to be freed — calling the C `free` on them is undefined
@@ -473,10 +500,7 @@ fn add_fetched_program<N: Network>(
     Ok(())
 }
 
-/// Builds an execution authorization for credits.aleo `join` (merging two
-/// private records). Offline. Returns "" on failure.
-///
-/// SAFETY: the pointer args are NUL-terminated C strings.
+/// Network-generic core of [`join_authorization`].
 fn join_authorization_inner<N: Network>(
     private_key: &str,
     record_1: &str,
@@ -493,6 +517,10 @@ fn join_authorization_inner<N: Network>(
     Ok(serde_json::to_string(&authorization)?)
 }
 
+/// Builds an execution authorization for credits.aleo `join` (merging two
+/// private records). Offline. Returns "" on failure.
+///
+/// SAFETY: the pointer args are NUL-terminated C strings.
 #[no_mangle]
 pub unsafe extern "C" fn join_authorization(
     private_key: *const c_char,
@@ -501,20 +529,23 @@ pub unsafe extern "C" fn join_authorization(
     _url: *const c_char,
     network: *const c_char,
 ) -> *mut c_char {
-    let (private_key, record_1, record_2) =
-        (read_str(private_key), read_str(record_1), read_str(record_2));
-    let result = match parse_network(read_str(network)) {
-        Some(NetworkKind::Mainnet) => join_authorization_inner::<MainnetV0>(private_key, record_1, record_2),
-        Some(NetworkKind::Testnet) => join_authorization_inner::<TestnetV0>(private_key, record_1, record_2),
-        None => Err(anyhow::anyhow!("unknown network")),
-    };
-    to_cstring(result.unwrap_or_default())
+    ffi_legacy_string(|| {
+        let (private_key, record_1, record_2) =
+            (read_str(private_key), read_str(record_1), read_str(record_2));
+        let result = match parse_network(read_str(network)) {
+            Some(NetworkKind::Mainnet) => {
+                join_authorization_inner::<MainnetV0>(private_key, record_1, record_2)
+            }
+            Some(NetworkKind::Testnet) => {
+                join_authorization_inner::<TestnetV0>(private_key, record_1, record_2)
+            }
+            None => Err(anyhow::anyhow!("unknown network")),
+        };
+        to_cstring(result.unwrap_or_default())
+    })
 }
 
-/// Builds an execution authorization for a credits.aleo transfer. Offline
-/// (credits.aleo is built in). Returns "" on failure.
-///
-/// SAFETY: the pointer args are NUL-terminated C strings.
+/// Network-generic core of [`execution_authorization`].
 fn execution_authorization_inner<N: Network>(
     private_key: &str,
     recipient: &str,
@@ -530,6 +561,10 @@ fn execution_authorization_inner<N: Network>(
     Ok(serde_json::to_string(&authorization)?)
 }
 
+/// Builds an execution authorization for a credits.aleo transfer. Offline
+/// (credits.aleo is built in). Returns "" on failure.
+///
+/// SAFETY: the pointer args are NUL-terminated C strings.
 #[no_mangle]
 pub unsafe extern "C" fn execution_authorization(
     private_key: *const c_char,
@@ -540,30 +575,27 @@ pub unsafe extern "C" fn execution_authorization(
     amount_record: *const c_char,
     network: *const c_char,
 ) -> *mut c_char {
-    let (private_key, recipient, transfer_type, amount_record) = (
-        read_str(private_key),
-        read_str(recipient),
-        read_str(transfer_type),
-        read_str(amount_record),
-    );
-    let result = match parse_network(read_str(network)) {
-        Some(NetworkKind::Mainnet) => {
-            execution_authorization_inner::<MainnetV0>(private_key, recipient, transfer_type, amount, amount_record)
-        }
-        Some(NetworkKind::Testnet) => {
-            execution_authorization_inner::<TestnetV0>(private_key, recipient, transfer_type, amount, amount_record)
-        }
-        None => Err(anyhow::anyhow!("unknown network")),
-    };
-    to_cstring(result.unwrap_or_default())
+    ffi_legacy_string(|| {
+        let (private_key, recipient, transfer_type, amount_record) = (
+            read_str(private_key),
+            read_str(recipient),
+            read_str(transfer_type),
+            read_str(amount_record),
+        );
+        let result = match parse_network(read_str(network)) {
+            Some(NetworkKind::Mainnet) => execution_authorization_inner::<MainnetV0>(
+                private_key, recipient, transfer_type, amount, amount_record,
+            ),
+            Some(NetworkKind::Testnet) => execution_authorization_inner::<TestnetV0>(
+                private_key, recipient, transfer_type, amount, amount_record,
+            ),
+            None => Err(anyhow::anyhow!("unknown network")),
+        };
+        to_cstring(result.unwrap_or_default())
+    })
 }
 
-/// Builds the authorization to migrate an old (version-0) credits record to a
-/// version-1 record via credits.aleo `upgrade`. The encrypted `record` is
-/// decrypted with the key's view key and passed as the single input. Offline.
-/// Returns "" on failure.
-///
-/// SAFETY: the pointer args are NUL-terminated C strings.
+/// Network-generic core of [`upgrade_authorization`].
 fn upgrade_authorization_inner<N: Network>(
     private_key: &str,
     record: &str,
@@ -583,6 +615,12 @@ fn upgrade_authorization_inner<N: Network>(
     Ok(serde_json::to_string(&authorization)?)
 }
 
+/// Builds the authorization to migrate an old (version-0) credits record to a
+/// version-1 record via credits.aleo `upgrade`. The encrypted `record` is
+/// decrypted with the key's view key and passed as the single input. Offline.
+/// Returns "" on failure.
+///
+/// SAFETY: the pointer args are NUL-terminated C strings.
 #[no_mangle]
 pub unsafe extern "C" fn upgrade_authorization(
     private_key: *const c_char,
@@ -590,44 +628,54 @@ pub unsafe extern "C" fn upgrade_authorization(
     _url: *const c_char,
     network: *const c_char,
 ) -> *mut c_char {
-    let (private_key, record) = (read_str(private_key), read_str(record));
-    let result = match parse_network(read_str(network)) {
-        Some(NetworkKind::Mainnet) => upgrade_authorization_inner::<MainnetV0>(private_key, record),
-        Some(NetworkKind::Testnet) => upgrade_authorization_inner::<TestnetV0>(private_key, record),
-        None => Err(anyhow::anyhow!("unknown network")),
-    };
-    to_cstring(result.unwrap_or_default())
+    ffi_legacy_string(|| {
+        let (private_key, record) = (read_str(private_key), read_str(record));
+        let result = match parse_network(read_str(network)) {
+            Some(NetworkKind::Mainnet) => {
+                upgrade_authorization_inner::<MainnetV0>(private_key, record)
+            }
+            Some(NetworkKind::Testnet) => {
+                upgrade_authorization_inner::<TestnetV0>(private_key, record)
+            }
+            None => Err(anyhow::anyhow!("unknown network")),
+        };
+        to_cstring(result.unwrap_or_default())
+    })
+}
+
+/// Network-generic core of [`build_upgrade_transaction_offline`].
+fn build_upgrade_transaction_offline_inner<N: Network>(execution: &str) -> anyhow::Result<String> {
+    let execution: Execution<N> = serde_json::from_str(execution)?;
+    Ok(Transaction::from_execution(execution, None)?.to_string())
 }
 
 /// Assembles a credits.aleo `upgrade` transaction from its execution alone. A
 /// transaction with a single `upgrade` transition is base-fee exempt, so no fee
 /// is attached (`Transaction::from_execution(execution, None)`). Returns "".
 ///
-/// SAFETY: `execution` is a NUL-terminated C string.
-fn build_upgrade_transaction_offline_inner<N: Network>(execution: &str) -> anyhow::Result<String> {
-    let execution: Execution<N> = serde_json::from_str(execution)?;
-    Ok(Transaction::from_execution(execution, None)?.to_string())
-}
-
+/// SAFETY: `execution`/`network` are NUL-terminated C strings.
 #[no_mangle]
 pub unsafe extern "C" fn build_upgrade_transaction_offline(
     execution: *const c_char,
     network: *const c_char,
 ) -> *mut c_char {
-    let execution = read_str(execution);
-    let result = match parse_network(read_str(network)) {
-        Some(NetworkKind::Mainnet) => build_upgrade_transaction_offline_inner::<MainnetV0>(execution),
-        Some(NetworkKind::Testnet) => build_upgrade_transaction_offline_inner::<TestnetV0>(execution),
-        None => Err(anyhow::anyhow!("unknown network")),
-    };
-    to_cstring(result.unwrap_or_default())
+    ffi_legacy_string(|| {
+        let execution = read_str(execution);
+        let result = match parse_network(read_str(network)) {
+            Some(NetworkKind::Mainnet) => {
+                build_upgrade_transaction_offline_inner::<MainnetV0>(execution)
+            }
+            Some(NetworkKind::Testnet) => {
+                build_upgrade_transaction_offline_inner::<TestnetV0>(execution)
+            }
+            None => Err(anyhow::anyhow!("unknown network")),
+        };
+        to_cstring(result.unwrap_or_default())
+    })
 }
 
-/// Assembles a transaction from a serialized execution proof and fee proof
-/// (the split-proof flow). Deterministic; returns "" on failure.
-///
-/// SAFETY: `execution`/`fee`/`_network` are NUL-terminated C strings
-/// (snarkVM serde JSON).
+/// Assembles a transaction from a serialized execution and fee (the split-proof
+/// flow) for network `N`. Deterministic; returns `None` on failure.
 fn build_transaction_offline_inner<N: Network>(execution: &str, fee: &str) -> Option<String> {
     let execution: Execution<N> = serde_json::from_str(execution).ok()?;
     let fee: Fee<N> = serde_json::from_str(fee).ok()?;
@@ -635,19 +683,25 @@ fn build_transaction_offline_inner<N: Network>(execution: &str, fee: &str) -> Op
     Some(transaction.to_string())
 }
 
+/// Assembles a transaction from a serialized execution proof and fee proof (the
+/// split-proof flow). Deterministic; returns "" on failure.
+///
+/// SAFETY: `execution`/`fee`/`network` are NUL-terminated C strings.
 #[no_mangle]
 pub unsafe extern "C" fn build_transaction_offline(
     execution: *const c_char,
     fee: *const c_char,
     network: *const c_char,
 ) -> *mut c_char {
-    let (execution, fee) = (read_str(execution), read_str(fee));
-    let result = match parse_network(read_str(network)) {
-        Some(NetworkKind::Mainnet) => build_transaction_offline_inner::<MainnetV0>(execution, fee),
-        Some(NetworkKind::Testnet) => build_transaction_offline_inner::<TestnetV0>(execution, fee),
-        None => None,
-    };
-    to_cstring(result.unwrap_or_default())
+    ffi_legacy_string(|| {
+        let (execution, fee) = (read_str(execution), read_str(fee));
+        let result = match parse_network(read_str(network)) {
+            Some(NetworkKind::Mainnet) => build_transaction_offline_inner::<MainnetV0>(execution, fee),
+            Some(NetworkKind::Testnet) => build_transaction_offline_inner::<TestnetV0>(execution, fee),
+            None => None,
+        };
+        to_cstring(result.unwrap_or_default())
+    })
 }
 
 /// Computes the record's serial number for `program_id`/`record_name`. Returns
@@ -1040,6 +1094,12 @@ fn global_commitment_set<N: Network>(authorization: &Authorization<N>) -> Vec<St
     global_input_commitments(&ordered)
 }
 
+/// Network-generic core of [`required_commitments`].
+fn required_commitments_inner<N: Network>(authorization: &str) -> anyhow::Result<String> {
+    let authorization: Authorization<N> = serde_json::from_str(authorization)?;
+    Ok(serde_json::to_string(&global_commitment_set(&authorization))?)
+}
+
 /// The input-record commitments whose state paths the caller must fetch before
 /// proving this authorization. Empty for public flows (no record inputs).
 /// Pure: read from the authorization itself, no VM/synthesis or network.
@@ -1057,17 +1117,21 @@ fn global_commitment_set<N: Network>(authorization: &Authorization<N>) -> Vec<St
 /// dropped; for a composite program that spends a record minted by an earlier
 /// transition, that local commitment is correctly excluded.
 ///
-/// SAFETY: `authorization` is a NUL-terminated C string.
+/// SAFETY: `network`/`authorization` are NUL-terminated C strings.
 #[no_mangle]
-pub unsafe extern "C" fn required_commitments(authorization: *const c_char) -> *mut c_char {
-    let inner = || -> anyhow::Result<String> {
-        let authorization: Authorization<Net> = serde_json::from_str(read_str(authorization))?;
-        Ok(serde_json::to_string(&global_commitment_set(&authorization))?)
-    };
-    match inner() {
-        Ok(commitments) => to_cstring(commitments),
-        Err(_) => to_cstring(String::new()),
-    }
+pub unsafe extern "C" fn required_commitments(
+    network: *const c_char,
+    authorization: *const c_char,
+) -> *mut c_char {
+    ffi_legacy_string(|| {
+        let authorization = read_str(authorization);
+        let result = match parse_network(read_str(network)) {
+            Some(NetworkKind::Mainnet) => required_commitments_inner::<MainnetV0>(authorization),
+            Some(NetworkKind::Testnet) => required_commitments_inner::<TestnetV0>(authorization),
+            None => Err(anyhow::anyhow!("unknown network")),
+        };
+        to_cstring(result.unwrap_or_default())
+    })
 }
 
 /// The direct imports of a program, as a JSON array of program ids, so Dart can
@@ -1095,37 +1159,59 @@ pub unsafe extern "C" fn required_imports(program_source: *const c_char) -> *mut
     }
 }
 
+/// Network-generic core of [`state_root_from_paths`].
+fn state_root_from_paths_inner<N: Network>(state_paths_json: &str) -> anyhow::Result<String> {
+    let paths = parse_state_paths::<N>(state_paths_json)?;
+    let state_root =
+        paths.first().ok_or_else(|| anyhow::anyhow!("no state paths"))?.global_state_root();
+    for path in &paths {
+        anyhow::ensure!(
+            path.global_state_root() == state_root,
+            "state paths disagree on the global state root"
+        );
+    }
+    Ok(state_root.to_string())
+}
+
 /// The global state root shared by a non-empty batch of state paths — a
 /// convenience for callers that want the snapshot root for logging/caching
 /// (proving derives it itself). Returns "" if the paths are empty or disagree.
 ///
-/// SAFETY: `state_paths_json` is a NUL-terminated C string.
+/// SAFETY: `network`/`state_paths_json` are NUL-terminated C strings.
 #[no_mangle]
-pub unsafe extern "C" fn state_root_from_paths(state_paths_json: *const c_char) -> *mut c_char {
-    let inner = || -> anyhow::Result<String> {
-        let paths = parse_state_paths::<Net>(read_str(state_paths_json))?;
-        let state_root =
-            paths.first().ok_or_else(|| anyhow::anyhow!("no state paths"))?.global_state_root();
-        for path in &paths {
-            anyhow::ensure!(
-                path.global_state_root() == state_root,
-                "state paths disagree on the global state root"
-            );
-        }
-        Ok(state_root.to_string())
-    };
-    match inner() {
-        Ok(root) => to_cstring(root),
-        Err(_) => to_cstring(String::new()),
-    }
+pub unsafe extern "C" fn state_root_from_paths(
+    network: *const c_char,
+    state_paths_json: *const c_char,
+) -> *mut c_char {
+    ffi_legacy_string(|| {
+        let state_paths_json = read_str(state_paths_json);
+        let result = match parse_network(read_str(network)) {
+            Some(NetworkKind::Mainnet) => state_root_from_paths_inner::<MainnetV0>(state_paths_json),
+            Some(NetworkKind::Testnet) => state_root_from_paths_inner::<TestnetV0>(state_paths_json),
+            None => Err(anyhow::anyhow!("unknown network")),
+        };
+        to_cstring(result.unwrap_or_default())
+    })
 }
 
-/// The consensus version active at `height`, so Dart can pin one version for a
-/// whole transaction without hardcoding upgrade heights. Returns 0 on failure
-/// (only height 0 with no V1 mapping, which never happens for the live network).
+/// The consensus version active at `height` for `network`, so Dart can pin one
+/// version for a whole transaction without hardcoding upgrade heights — which
+/// differ per network, so this must dispatch (a mainnet height maps to a different
+/// version than the same testnet height). Returns 0 on an unknown network or a
+/// height with no version mapping.
+///
+/// SAFETY: `network` is a NUL-terminated C string.
 #[no_mangle]
-pub extern "C" fn consensus_version_for(height: u32) -> u16 {
-    Net::CONSENSUS_VERSION(height).map(|version| version as u16).unwrap_or(0)
+pub unsafe extern "C" fn consensus_version_for(network: *const c_char, height: u32) -> u16 {
+    ffi_legacy_u16(|| match parse_network(read_str(network)) {
+        Some(NetworkKind::Mainnet) => {
+            MainnetV0::CONSENSUS_VERSION(height).map(|v| v as u16).unwrap_or(0)
+        }
+        Some(NetworkKind::Testnet) => {
+            TestnetV0::CONSENSUS_VERSION(height).map(|v| v as u16).unwrap_or(0)
+        }
+        None => 0,
+    })
 }
 
 /// Computes the base fee for `execution` at `height` (→ consensus version),
@@ -1142,6 +1228,10 @@ fn get_base_fee_inner<N: Network>(
     base_fee_at_height::<N>(&execution, program_sources_json, height)
 }
 
+/// The base fee for `execution` on `network` at `height`. Returns 0 on failure or
+/// an unknown network.
+///
+/// SAFETY: `network`/`execution`/`program_sources_json` are NUL-terminated C strings.
 #[no_mangle]
 pub unsafe extern "C" fn get_base_fee(
     network: *const c_char,
@@ -1149,13 +1239,20 @@ pub unsafe extern "C" fn get_base_fee(
     program_sources_json: *const c_char,
     height: u32,
 ) -> u64 {
-    let (execution, program_sources_json) = (read_str(execution), read_str(program_sources_json));
-    let result = match parse_network(read_str(network)) {
-        Some(NetworkKind::Mainnet) => get_base_fee_inner::<MainnetV0>(execution, program_sources_json, height),
-        Some(NetworkKind::Testnet) => get_base_fee_inner::<TestnetV0>(execution, program_sources_json, height),
-        None => Err(anyhow::anyhow!("unknown network")),
-    };
-    result.unwrap_or(0)
+    ffi_legacy_u64(|| {
+        let (execution, program_sources_json) =
+            (read_str(execution), read_str(program_sources_json));
+        let result = match parse_network(read_str(network)) {
+            Some(NetworkKind::Mainnet) => {
+                get_base_fee_inner::<MainnetV0>(execution, program_sources_json, height)
+            }
+            Some(NetworkKind::Testnet) => {
+                get_base_fee_inner::<TestnetV0>(execution, program_sources_json, height)
+            }
+            None => Err(anyhow::anyhow!("unknown network")),
+        };
+        result.unwrap_or(0)
+    })
 }
 
 /// Authorizes the fee for `execution`, offline: `height` (→ consensus version)
@@ -1197,6 +1294,11 @@ fn execution_fee_authorization_inner<N: Network>(
     Ok(serde_json::to_string(&authorization)?)
 }
 
+/// Authorizes the fee for `execution` on `network`. Returns "" on failure or an
+/// unknown network.
+///
+/// SAFETY: `network`/`private_key`/`execution`/`fee_record`/`program_sources_json`
+/// are NUL-terminated C strings.
 #[no_mangle]
 pub unsafe extern "C" fn execution_fee_authorization(
     network: *const c_char,
@@ -1207,22 +1309,24 @@ pub unsafe extern "C" fn execution_fee_authorization(
     program_sources_json: *const c_char,
     height: u32,
 ) -> *mut c_char {
-    let (private_key, execution, fee_record, program_sources_json) = (
-        read_str(private_key),
-        read_str(execution),
-        read_str(fee_record),
-        read_str(program_sources_json),
-    );
-    let result = match parse_network(read_str(network)) {
-        Some(NetworkKind::Mainnet) => execution_fee_authorization_inner::<MainnetV0>(
-            private_key, execution, fee_credits, fee_record, program_sources_json, height,
-        ),
-        Some(NetworkKind::Testnet) => execution_fee_authorization_inner::<TestnetV0>(
-            private_key, execution, fee_credits, fee_record, program_sources_json, height,
-        ),
-        None => Err(anyhow::anyhow!("unknown network")),
-    };
-    to_cstring(result.unwrap_or_default())
+    ffi_legacy_string(|| {
+        let (private_key, execution, fee_record, program_sources_json) = (
+            read_str(private_key),
+            read_str(execution),
+            read_str(fee_record),
+            read_str(program_sources_json),
+        );
+        let result = match parse_network(read_str(network)) {
+            Some(NetworkKind::Mainnet) => execution_fee_authorization_inner::<MainnetV0>(
+                private_key, execution, fee_credits, fee_record, program_sources_json, height,
+            ),
+            Some(NetworkKind::Testnet) => execution_fee_authorization_inner::<TestnetV0>(
+                private_key, execution, fee_credits, fee_record, program_sources_json, height,
+            ),
+            None => Err(anyhow::anyhow!("unknown network")),
+        };
+        to_cstring(result.unwrap_or_default())
+    })
 }
 
 // The plain proving exports (`execute_proof_static` / `execute_fee_proof_static` /
@@ -1232,18 +1336,7 @@ pub unsafe extern "C" fn execution_fee_authorization(
 // unused on purpose — reusing a freed symbol name whose ABI differs across already
 // distributed libraries is the hazard `ffi_abi_version` guards against.
 
-/// Builds an execution authorization for an arbitrary program function, offline.
-/// The referenced program (and its imports) is supplied in-memory via
-/// `program_sources_json` and loaded before authorizing — `vm.authorize` reads
-/// the program's `Stack`, so a non-builtin function cannot be authorized without
-/// it. `arguments` is a JSON array of Aleo value strings (record inputs already
-/// decrypted to plaintext by the caller, as on the old `contract_execution`
-/// path). This is the pure-FFI authorize step the phase-2 Dart orchestration
-/// uses for arbitrary programs, replacing the network-bound
-/// `contract_execution` / `execute_program`. Empty `program_sources_json` works
-/// for a built-in program (credits.aleo). Returns "" on failure.
-///
-/// SAFETY: the pointer args are NUL-terminated C strings.
+/// Network-generic core of [`program_authorization`].
 fn program_authorization_inner<N: Network>(
     private_key: &str,
     program_id: &str,
@@ -1260,6 +1353,15 @@ fn program_authorization_inner<N: Network>(
     Ok(serde_json::to_string(&authorization)?)
 }
 
+/// Builds an execution authorization for an arbitrary program function, offline.
+/// The referenced program (and its imports) is supplied in-memory via
+/// `program_sources_json` and loaded before authorizing — `vm.authorize` reads
+/// the program's `Stack`, so a non-builtin function cannot be authorized without
+/// it. `arguments` is a JSON array of Aleo value strings (record inputs already
+/// decrypted to plaintext by the caller). Empty `program_sources_json` works for a
+/// built-in program (credits.aleo). Returns "" on failure.
+///
+/// SAFETY: the pointer args are NUL-terminated C strings.
 #[no_mangle]
 pub unsafe extern "C" fn program_authorization(
     network: *const c_char,
@@ -1269,23 +1371,25 @@ pub unsafe extern "C" fn program_authorization(
     arguments: *const c_char,
     program_sources_json: *const c_char,
 ) -> *mut c_char {
-    let (private_key, program_id, function_name, arguments, program_sources_json) = (
-        read_str(private_key),
-        read_str(program_id),
-        read_str(function_name),
-        read_str(arguments),
-        read_str(program_sources_json),
-    );
-    let result = match parse_network(read_str(network)) {
-        Some(NetworkKind::Mainnet) => program_authorization_inner::<MainnetV0>(
-            private_key, program_id, function_name, arguments, program_sources_json,
-        ),
-        Some(NetworkKind::Testnet) => program_authorization_inner::<TestnetV0>(
-            private_key, program_id, function_name, arguments, program_sources_json,
-        ),
-        None => Err(anyhow::anyhow!("unknown network")),
-    };
-    to_cstring(result.unwrap_or_default())
+    ffi_legacy_string(|| {
+        let (private_key, program_id, function_name, arguments, program_sources_json) = (
+            read_str(private_key),
+            read_str(program_id),
+            read_str(function_name),
+            read_str(arguments),
+            read_str(program_sources_json),
+        );
+        let result = match parse_network(read_str(network)) {
+            Some(NetworkKind::Mainnet) => program_authorization_inner::<MainnetV0>(
+                private_key, program_id, function_name, arguments, program_sources_json,
+            ),
+            Some(NetworkKind::Testnet) => program_authorization_inner::<TestnetV0>(
+                private_key, program_id, function_name, arguments, program_sources_json,
+            ),
+            None => Err(anyhow::anyhow!("unknown network")),
+        };
+        to_cstring(result.unwrap_or_default())
+    })
 }
 
 // ── Phase 4 FFI result envelope (docs/phase4-plan.md §8 Contract 1) ──────────
@@ -2077,6 +2181,31 @@ mod tests {
         }
     }
 
+    /// Calls a `(network, *const c_char) -> *mut c_char` export (the network-aware
+    /// consumers: required_commitments, state_root_from_paths) and frees the result.
+    fn call_str_net(
+        f: unsafe extern "C" fn(*const c_char, *const c_char) -> *mut c_char,
+        network: &str,
+        arg: &str,
+    ) -> String {
+        unsafe {
+            let n = CString::new(network).unwrap();
+            let c = CString::new(arg).unwrap();
+            let ptr = f(n.as_ptr(), c.as_ptr());
+            let out = CStr::from_ptr(ptr).to_str().unwrap().to_owned();
+            free_string(ptr);
+            out
+        }
+    }
+
+    /// Calls the network-aware consensus_version_for and returns the version.
+    fn consensus_version(network: &str, height: u32) -> u16 {
+        unsafe {
+            let n = CString::new(network).unwrap();
+            consensus_version_for(n.as_ptr(), height)
+        }
+    }
+
     fn recipient_address() -> String {
         Address::<Net>::try_from(&other_key()).unwrap().to_string()
     }
@@ -2094,7 +2223,7 @@ mod tests {
                 &mut rand::thread_rng(),
             )
             .unwrap();
-        let out = call_str(required_commitments, &serde_json::to_string(&authorization).unwrap());
+        let out = call_str_net(required_commitments, "mainnet", &serde_json::to_string(&authorization).unwrap());
         assert_eq!(out, "[]");
     }
 
@@ -2114,7 +2243,7 @@ mod tests {
                 &mut rand::thread_rng(),
             )
             .unwrap();
-        let out = call_str(required_commitments, &serde_json::to_string(&authorization).unwrap());
+        let out = call_str_net(required_commitments, "mainnet", &serde_json::to_string(&authorization).unwrap());
         let commitments: Vec<String> = serde_json::from_str(&out).unwrap();
         assert_eq!(commitments.len(), 1, "got {out}");
         // Each entry is a field element.
@@ -2124,7 +2253,33 @@ mod tests {
     // Malformed authorization JSON returns "" (no panic across the FFI boundary).
     #[test]
     fn required_commitments_malformed_returns_empty() {
-        assert_eq!(call_str(required_commitments, "not json"), "");
+        assert_eq!(call_str_net(required_commitments, "mainnet", "not json"), "");
+    }
+
+    // Regression (PR4a): a TestnetV0 authorization fed to required_commitments with
+    // network="testnet" is handled — the consumer dispatches to the right network,
+    // so it does NOT trip snarkVM's cross-network assertion (which would panic and,
+    // pre-fix, abort across the C ABI). A public transfer has no record inputs → [].
+    #[test]
+    fn required_commitments_testnet_authorization() {
+        let testnet_key = PrivateKey::<TestnetV0>::from_str(OWNER_KEY).unwrap();
+        let vm = new_vm::<TestnetV0>().unwrap();
+        let recipient = Address::<TestnetV0>::try_from(&testnet_key).unwrap().to_string();
+        let auth = vm
+            .authorize(
+                &testnet_key,
+                "credits.aleo",
+                "transfer_public",
+                vec![recipient, "1u64".to_string()],
+                &mut rand::thread_rng(),
+            )
+            .unwrap();
+        let json = serde_json::to_string(&auth).unwrap();
+        assert_eq!(call_str_net(required_commitments, "testnet", &json), "[]");
+        // Backstop: feeding that testnet authorization under the WRONG network would
+        // trip the cross-network assertion inside snarkVM; the catch_unwind backstop
+        // turns that panic into the fail-closed "" rather than aborting the process.
+        assert_eq!(call_str_net(required_commitments, "mainnet", &json), "");
     }
 
     // required_imports lists a program's direct imports.
@@ -2147,18 +2302,18 @@ mod tests {
     // consensus_version_for maps heights to versions at the documented boundaries.
     #[test]
     fn consensus_version_for_known_heights() {
-        assert_eq!(consensus_version_for(0), 1); // V1 at genesis
-        assert_eq!(consensus_version_for(2_800_000), 2); // exact V2 boundary
-        assert_eq!(consensus_version_for(2_800_000 - 1), 1); // just below V2
-        assert_eq!(consensus_version_for(9_430_000), 8); // V8 (inclusion upgrade)
-        assert!(consensus_version_for(u32::MAX) >= 13, "latest version at far future height");
+        assert_eq!(consensus_version("mainnet", 0), 1); // V1 at genesis
+        assert_eq!(consensus_version("mainnet", 2_800_000), 2); // exact V2 boundary
+        assert_eq!(consensus_version("mainnet", 2_800_000 - 1), 1); // just below V2
+        assert_eq!(consensus_version("mainnet", 9_430_000), 8); // V8 (inclusion upgrade)
+        assert!(consensus_version("mainnet", u32::MAX) >= 13, "latest version at far future height");
     }
 
     // No paths (empty or "[]") -> "" (there is no shared root to report).
     #[test]
     fn state_root_from_paths_empty_is_empty() {
-        assert_eq!(call_str(state_root_from_paths, ""), "");
-        assert_eq!(call_str(state_root_from_paths, "[]"), "");
+        assert_eq!(call_str_net(state_root_from_paths, "mainnet", ""), "");
+        assert_eq!(call_str_net(state_root_from_paths, "mainnet", "[]"), "");
     }
 
     // The public flow builds the query from the supplied root and height; with no
@@ -2523,7 +2678,7 @@ mod tests {
         }
         assert!(!outputs.is_empty(), "transfer_private creates output records");
 
-        let out = call_str(required_commitments, &serde_json::to_string(&auth).unwrap());
+        let out = call_str_net(required_commitments, "mainnet", &serde_json::to_string(&auth).unwrap());
         let required: Vec<String> = serde_json::from_str(&out).unwrap();
         assert_eq!(required.len(), 1, "the one spent record; got {out}");
         for commitment in &required {
@@ -2694,6 +2849,7 @@ mod tests {
         assert!(serde_json::from_str::<Authorization<TestnetV0>>(&t).is_ok(), "testnet: {t}");
         assert_eq!(auth_for("bogus"), "", "unknown network must be fail-closed");
     }
+
 
     // End-to-end proof through execute_proof_checked for a PUBLIC transfer: no
     // record inputs, so no state paths — proving only needs a height and a real


### PR DESCRIPTION
Workstream C of Phase 4 — the C-ABI finalization and its lockstep Dart half. This
is the ABI half only; cross-compile + distribution (PR4b) and GPL deletion (PR5)
follow. Spec: `rust/aleo_ffi/docs/pr4a-abi-spec.md`.

## Why
After PR1–PR3 the crate links no HTTP/TLS stack and has the enveloped, network-aware
`*_checked` proving + parameter-provisioning surface, but the public flow still used
the MainnetV0-only `_static` symbols. PR4a finalizes the ABI and switches the public
Dart flow onto the new surface, in lockstep so a renamed/changed symbol never reaches
a stale prebuilt library.

## Rust (the ABI lockstep surface)
- **Delete** the 3 plain proving exports (`execute_proof_static` /
  `execute_fee_proof_static` / `execute_program_proof_static`) — superseded by the
  enveloped `*_checked` ones. Canonical names left unused (no freed-name reuse).
- **Rename + network-aware**: `get_base_fee`, `execution_fee_authorization`,
  `program_authorization` (network is the new first arg; dispatch Mainnet/Testnet;
  unknown → fail-closed).
- **Activate** the previously-ignored `_network` on `join`/`execution`/`upgrade`
  authorization + `build_transaction_offline` + `build_upgrade_transaction_offline`,
  and **genericize the whole authorize/fee helper stack** over `<N: Network>`
  (`transfer_inputs`, `plaintext_record`, `plaintext_record_typed`,
  `base_fee_at_height`, `check_total_fee`) so a TestnetV0 dispatch is type-correct
  end to end — not just at the entry point.
- **Network-activate the consumers** `required_commitments`, `state_root_from_paths`,
  `consensus_version_for` (they deserialize network-typed data / use per-network
  consensus heights) and add a `catch_unwind` backstop to every network-threaded
  legacy export, so a wrong-network or malformed input degrades to the fail-closed
  sentinel instead of panicking across the C ABI (a real testnet regression closed:
  cross-network deserialization panics in snarkVM, which had no `catch_unwind`).
- Add **`ffi_abi_version() -> u32 = 1`** (the Dart loader's ABI guard).
- `rust.yml` exact symbol set 36 → 34 (35 − 3 deleted + `ffi_abi_version`).

## Dart (lockstep)
- **`AleoLib`** (load-time ABI guard): `AleoLib.coerce` validates `ffi_abi_version`
  and is the single chokepoint every public constructor
  (`AleoAccount`/`AleoRecord`/`AleoProgram`/`ParameterProvisioner`) funnels through;
  a bare `DynamicLibrary` or an `AleoLib` are both accepted (non-breaking). A missing
  symbol or version mismatch throws `IncompatibleNativeLibraryException` — turning a
  silent ABI drift (incl. the arity-change segfault) into a loud load-time failure.
- `programs_rust_ffi.dart`: thread `network` through the three consumers, rename +
  network-arg the fee/authorize primitives, delete the 3 dead proving bindings.
- `aleo_programs.dart`: proving now goes through `ParameterProvisioner`
  (preflight → download proving keys → `execute_*_checked`, `restart_required`
  latch); optional `paramDir` (defaults to the lib's `aleo_dir()`). Custom-program
  proving is rejected with `unsupported_feature` (v1 is credits-only).

## Verification
- Rust: `cargo test --lib` 63 passed / 2 ignored; release cdylib exports exactly the
  34-symbol set.
- Dart: `dart analyze` clean (info-only); `dart test` 81 passed / 2 skipped against
  the freshly-built cdylib (`ALEO_NEW_LIB`). Guard fixtures cover fresh-lib-ok,
  missing-symbol-rejected, and version-mismatch-rejected.
- Live private/fee proving end-to-end stays manual (needs ~1.2 GiB params + a
  tx-bearing testnet).

## Not in this PR
- PR4b: cross-compile android/ios/desktop + repoint `dyLib`/`setup_dylib`/`build_android`.
- PR5: delete the GPL `rust/aleo_rust` crate + prebuilt binaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)