### PR TITLE
build(aleo): cross-compile android/ios + repoint distribution (Phase 4, PR4b)

### DIFF
--- a/packages/aleo_dart/CHANGELOG.md
+++ b/packages/aleo_dart/CHANGELOG.md
@@ -19,6 +19,10 @@
   `AleoProgram`, or `ParameterProvisioner` (a bare `DynamicLibrary` or an `AleoLib`
   are both accepted). An incompatible or stale library now fails loudly at load
   time instead of mis-binding a renamed symbol or an argument slot.
+- Mobile loading via `DyLib.getMobileDyLib`: Android opens the per-ABI
+  `libaleo_rust.so` bundled in the app's `jniLibs`; iOS uses
+  `DynamicLibrary.process()` against the statically-linked xcframework. Build them
+  with `rust/build_android.sh` / `rust/build_ios.sh` (no runtime download in v1).
 
 ### Changed
 
@@ -31,6 +35,16 @@
   `executeProgramProof` now reject a non-`credits.aleo` program with
   `unsupported_feature`, deterministically and before any node I/O. The methods are
   retained for API stability; arbitrary-program support is a future version.
+- `DyLib`'s `getDyLibFromCargo` paths now point at the clean-room `aleo_ffi` crate's
+  build output (`../../rust/aleo_ffi/target/release/`) instead of the GPL
+  `aleo_rust` crate; the artifact filename is unchanged (`libaleo_rust`).
+
+### Deprecated
+
+- `setUpDynamicLibrary` (the runtime library downloader / `dart run aleo_dart:setup`):
+  v1 does not download the native library at runtime. Build from source on desktop
+  (`DyLib.getDyLibFromCargo`) or bundle at build time on mobile
+  (`DyLib.getMobileDyLib`). Its pinned source is a stale GPL-era artifact.
 
 ## [1.0.0]
 

--- a/packages/aleo_dart/README.md
+++ b/packages/aleo_dart/README.md
@@ -1,13 +1,13 @@
 # aleo_dart
 
-A Dart SDK for the [Aleo](https://aleo.org) blockchain. Provides account, record and transaction APIs through FFI bindings to the `aleo_rust` native library (built from the `rust/aleo_rust` crate in this monorepo).
+A Dart SDK for the [Aleo](https://aleo.org) blockchain. Provides account, record and transaction APIs through FFI bindings to the `aleo_rust` native library (built from the `rust/aleo_ffi` crate in this monorepo).
 
 ## Features
 
 - Mnemonic / seed / private key / view key / address derivation
 - Encrypted record (ciphertext) decryption
 - Transfer building and submission (`transfer_public`, `transfer_private`, ...)
-- Pluggable native library loading: prebuilt download, local cargo build, or arbitrary path
+- Native library loading: build-from-source (desktop) or build-time bundle (mobile), with a load-time ABI-version guard
 
 ## Installation
 
@@ -16,20 +16,17 @@ dependencies:
   aleo_dart: ^1.0.0
 ```
 
-The package depends on a platform-specific dynamic library (`libaleo_rust.so` / `.dylib` / `.dll`). Fetch a prebuilt one with:
+The package depends on a platform-specific native library (`libaleo_rust.so` / `.dylib` / `.a`). It is **not downloaded at runtime** — you build it from source (desktop/CI) or bundle it at build time (mobile). See [Native library](#native-library) below.
 
-```bash
-dart run aleo_dart:setup
-```
-
-This drops the library into `.dart_tool/dart_aleo/` and `DyLib.getDyLibFromGit()` will pick it up.
+The library's ABI is validated when you construct `AleoAccount` / `AleoRecord` / `AleoProgram` / `ParameterProvisioner`: an incompatible or stale library is rejected at load time with `IncompatibleNativeLibraryException` (rather than mis-binding a symbol).
 
 ## Quick Start
 
 ```dart
 import 'package:aleo_dart/aleo.dart';
 
-final dyLib = DyLib.getDyLibFromGit();
+// Desktop: built by `cargo build --release` in rust/aleo_ffi (see below).
+final dyLib = DyLib.getDyLibFromCargo();
 final account = AleoAccount(dyLib);
 
 final mnemonic = 'fly lecture gasp juice hover ice business census bless weapon polar upgrade';
@@ -40,30 +37,36 @@ final viewKey    = account.privateKeyToViewKey(privateKey);
 
 For record decryption and transaction building, see the demos under `test/`.
 
-## Native library options
+## Native library
 
-```dart
-// Prebuilt, downloaded by `dart run aleo_dart:setup` (recommended).
-final dyLib = DyLib.getDyLibFromGit();
-
-// Local cargo build at rust/aleo_rust/target/release/.
-final dyLib = DyLib.getDyLibFromCargo();
-
-// Arbitrary path.
-final dyLib = DyLib.getDyLibByPosition('/abs/path/to/libaleo_rust.so');
-```
-
-## Building the native library locally
-
-The Rust source lives at [`rust/aleo_rust`](../../rust/aleo_rust) in this monorepo.
+### Desktop / CI — build from source
 
 ```bash
-cd rust/aleo_rust
+cd rust/aleo_ffi
 cargo build --release
 # library at: target/release/libaleo_rust.{so,dylib,dll}
 ```
 
-For Android cross-compilation see [`rust/build_android.sh`](../../rust/build_android.sh).
+```dart
+final dyLib = DyLib.getDyLibFromCargo();                 // ../../rust/aleo_ffi/target/release
+// or an explicit path:
+final dyLib = DyLib.getDyLibByPosition('/abs/path/to/libaleo_rust.so');
+```
+
+### Mobile — bundle at build time
+
+```bash
+rust/build_android.sh   # → rust/android_lib/jniLibs/<abi>/libaleo_rust.so   (bundle in the app's jniLibs)
+rust/build_ios.sh       # → rust/ios_lib/AleoRust.xcframework               (link into the app target)
+```
+
+```dart
+final dyLib = DyLib.getMobileDyLib(); // Android: open('libaleo_rust.so'); iOS: process()
+```
+
+See [`rust/aleo_ffi/docs/cross-compile.md`](../../rust/aleo_ffi/docs/cross-compile.md) for the full per-platform build/distribution model (16k-page alignment on Android; the `-force_load` / `nm` dead-strip retention step iOS apps must apply).
+
+> `dart run aleo_dart:setup` (runtime download) is **deprecated** and not used in this version: its pinned source is a stale, ABI-incompatible GPL-era artifact that the ABI guard would reject.
 
 ## License
 

--- a/packages/aleo_dart/bin/setup.dart
+++ b/packages/aleo_dart/bin/setup.dart
@@ -1,5 +1,10 @@
 import 'package:aleo_dart/src/rust_lib/setup/setup_dylib.dart';
 
+/// DEPRECATED in v1: the native library is built from source (desktop/CI) or
+/// bundled at build time (mobile), not downloaded. Kept so the
+/// `dart run aleo_dart:setup` entry point still resolves; it delegates to the
+/// deprecated downloader (which targets a stale GPL-era artifact).
 void main() async {
+  // ignore: deprecated_member_use_from_same_package
   await setUpDynamicLibrary();
 }

--- a/packages/aleo_dart/lib/src/rust_lib/dyLib.dart
+++ b/packages/aleo_dart/lib/src/rust_lib/dyLib.dart
@@ -73,12 +73,17 @@ class AleoLib {
   }
 }
 
+// Desktop dev / CI build-from-source paths, relative to the package directory
+// (`packages/aleo_dart`). PR4b repointed these from the GPL `aleo_rust` crate to
+// the clean-room `aleo_ffi` crate; the `[lib] name` is still `aleo_rust`, so the
+// artifact filename is unchanged. `cargo build --release` in rust/aleo_ffi
+// produces them. (Mobile does not use these — see getMobileDyLib.)
 const DEFAULT_RUST_LIB_CARGO_SO =
-    './aleo_rust/target/release/libaleo_rust.so'; // linux
+    '../../rust/aleo_ffi/target/release/libaleo_rust.so'; // linux
 const DEFAULT_RUST_LIB_CARGO_DLL =
-    'aleo_rust/target/release/aleo_rust.dll'; // windows
+    '../../rust/aleo_ffi/target/release/aleo_rust.dll'; // windows
 const DEFAULT_RUST_LIB_CARGO_LIB =
-    './aleo_rust/target/release/libaleo_rust.dylib'; // ios
+    '../../rust/aleo_ffi/target/release/libaleo_rust.dylib'; // macOS
 
 const DEFAULT_RUST_LIB_GIT_SO = '.dart_tool/dart_aleo/libaleo_rust.so';
 const DEFAULT_RUST_LIB_GIT_DLL = '.dart_tool/dart_aleo/aleo_rust.dll';
@@ -114,6 +119,24 @@ class DyLib {
       return ffi.DynamicLibrary.open(DEFAULT_RUST_LIB_GIT_DLL);
     } else {
       throw Exception("error platform");
+    }
+  }
+
+  /// Loads the build-time-bundled native library on mobile (v1 does not download
+  /// at runtime). Android resolves the per-ABI `libaleo_rust.so` the app bundles
+  /// in its jniLibs (see `rust/build_android.sh`); iOS statically links the
+  /// xcframework (see `rust/build_ios.sh`), so the symbols live in the running
+  /// process and are found via `DynamicLibrary.process()`.
+  ///
+  /// Wrap the result in `AleoLib.coerce` (the public constructors already do) so
+  /// the ABI version is validated before any FFI call.
+  static ffi.DynamicLibrary getMobileDyLib() {
+    if (Platform.isAndroid) {
+      return ffi.DynamicLibrary.open('libaleo_rust.so');
+    } else if (Platform.isIOS) {
+      return ffi.DynamicLibrary.process();
+    } else {
+      throw Exception('getMobileDyLib is for Android/iOS only');
     }
   }
 }

--- a/packages/aleo_dart/lib/src/rust_lib/setup/setup_dylib.dart
+++ b/packages/aleo_dart/lib/src/rust_lib/setup/setup_dylib.dart
@@ -6,9 +6,20 @@ import 'package:aleo_dart/src/rust_lib/setup/cpu_architecture.dart';
 import 'package:aleo_dart/src/rust_lib/setup/library_locator.dart'
     show dynamicLibraryEnvVariable, getDesktopLibName, libBuildOutDir;
 
+// DEPRECATED runtime-download source. This points at the pre-clean-room GPL-era
+// `pzhun/aleo_dart` release (a stale, ABI-incompatible library) and is NOT used in
+// v1: the native library is now obtained build-from-source on desktop/CI
+// (`cargo build` in rust/aleo_ffi, see DyLib.getDyLibFromCargo) and build-time
+// bundled on mobile (rust/build_android.sh, rust/build_ios.sh — see
+// DyLib.getMobileDyLib). A runtime-download path with an in-package integrity
+// anchor may return later; until then a downloaded library would be rejected by
+// the ffi_abi_version load-time guard (AleoLib) anyway.
 final BASE_URL = 'https://github.com/pzhun/aleo_dart/releases/download';
 final VERSION = 'v0.0.1-dev.1';
 
+@Deprecated('v1 does not download the native library at runtime; build from '
+    'source (DyLib.getDyLibFromCargo) or bundle at build time '
+    '(DyLib.getMobileDyLib). The pinned source is a stale GPL-era artifact.')
 Future<void> setUpDynamicLibrary(
     {String? dynamicLibraryPath, String? userUrl, String? userVersion}) async {
   /// Get the CPU architecture.

--- a/packages/aleo_dart/test/support/test_dylib.dart
+++ b/packages/aleo_dart/test/support/test_dylib.dart
@@ -4,35 +4,36 @@ import 'dart:io';
 import 'package:aleo_dart/aleo.dart';
 
 /// Reason shown when FFI-backed tests are skipped because the native
-/// `aleo_rust` library could not be loaded (e.g. on CI where it is neither
-/// prebuilt nor compiled from source).
+/// `aleo_rust` library could not be loaded (e.g. on CI before it is built).
 const nativeLibMissingReason =
-    'native libaleo_rust not available; set ALEO_NEW_LIB to a built library, '
-    'or fetch a prebuilt copy with `dart run aleo_dart:setup` '
-    '(loaded via DyLib.getDyLibFromGit)';
+    'native libaleo_rust not available; set ALEO_NEW_LIB to a freshly built '
+    'library, or build it from source (`cargo build --release` in rust/aleo_ffi)';
 
-/// Attempts to load the native `aleo_rust` dynamic library for tests.
+/// Attempts to load the native `aleo_rust` dynamic library for tests, returning
+/// only an **ABI-compatible** library (or null).
 ///
-/// An `ALEO_NEW_LIB` path takes priority and fails loudly when unloadable (CI
-/// sets it to the freshly built cdylib, and a typo there should not silently
-/// skip the suite). Otherwise tries the local cargo build, then a prebuilt
-/// copy fetched by `dart run aleo_dart:setup`, and returns `null` when none
-/// is available so that suites can [skip] gracefully instead of crashing at
-/// load time.
+/// `ALEO_NEW_LIB` takes priority and fails loudly: a bad path or an ABI mismatch
+/// is a misconfiguration the suite must not silently skip (CI sets it to the
+/// freshly built cdylib). Otherwise the local cargo build is used *only if it is
+/// present and ABI-compatible*; anything else returns null so suites [skip]
+/// gracefully instead of throwing at construction mid-test.
+///
+/// The deprecated `dart run aleo_dart:setup` download path is intentionally NOT a
+/// fallback: a previously-downloaded GPL-era library is ABI-incompatible and would
+/// be rejected by the `ffi_abi_version` guard anyway — returning it here would turn
+/// a graceful skip into a mid-test `IncompatibleNativeLibraryException`.
 DynamicLibrary? tryLoadAleoLib() {
   final override = Platform.environment['ALEO_NEW_LIB'];
   if (override != null && override.isNotEmpty) {
-    return DynamicLibrary.open(override);
+    final lib = DynamicLibrary.open(override);
+    AleoLib.fromDynamicLibrary(lib); // throws on an ABI mismatch (loud, by design)
+    return lib;
   }
-  for (final loader in <DynamicLibrary Function()>[
-    DyLib.getDyLibFromCargo,
-    DyLib.getDyLibFromGit,
-  ]) {
-    try {
-      return loader();
-    } catch (_) {
-      // Try the next loader.
-    }
+  try {
+    final lib = DyLib.getDyLibFromCargo();
+    AleoLib.fromDynamicLibrary(lib); // reject a not-rebuilt / incompatible local lib
+    return lib;
+  } catch (_) {
+    return null; // not built or incompatible → suites skip gracefully
   }
-  return null;
 }

--- a/rust/.gitignore
+++ b/rust/.gitignore
@@ -1,0 +1,5 @@
+# Cross-compile outputs (build-time bundled by the app; not committed — v1 does
+# not download or vendor prebuilt libraries). Produced by build_android.sh /
+# build_ios.sh.
+/android_lib/
+/ios_lib/

--- a/rust/aleo_ffi/Cargo.toml
+++ b/rust/aleo_ffi/Cargo.toml
@@ -14,8 +14,12 @@ panic = "unwind"
 
 [lib]
 name = "aleo_rust"
-# rlib in addition to cdylib so `cargo test` can build a unit-test harness.
-crate-type = ["cdylib", "rlib"]
+# cdylib: the shared library for Android (.so) and desktop (.so/.dylib/.dll),
+# loaded via DynamicLibrary.open.
+# staticlib: the static archive (.a) bundled into the iOS xcframework and
+# statically linked into the app, loaded via DynamicLibrary.process().
+# rlib: lets `cargo test` build a unit-test harness.
+crate-type = ["cdylib", "staticlib", "rlib"]
 
 [dependencies]
 snarkvm-console = "=4.5.0"

--- a/rust/aleo_ffi/docs/cross-compile.md
+++ b/rust/aleo_ffi/docs/cross-compile.md
@@ -1,0 +1,71 @@
+# aleo_ffi — cross-compile & distribution (Phase 4, PR4b)
+
+How the native `libaleo_rust` library is produced and consumed per platform. v1
+does **not** download the library at runtime: desktop/CI build it from source,
+mobile bundles it at build time. (A runtime-download path with an in-package
+integrity anchor may return in a later version.)
+
+Since workstreams A (curl) and B (ureq) removed the HTTP/TLS stack, there is **no
+OpenSSL** to cross-compile or carry — the old `OPENSSL_BASE_PATH` is gone.
+
+## crate-type
+
+`rust/aleo_ffi/Cargo.toml` builds three artifacts (`[lib] name = "aleo_rust"`):
+
+| crate-type | artifact | used by |
+|---|---|---|
+| `cdylib` | `libaleo_rust.{so,dylib,dll}` | Android (.so) + desktop, `DynamicLibrary.open` |
+| `staticlib` | `libaleo_rust.a` | iOS (xcframework), `DynamicLibrary.process()` |
+| `rlib` | — | `cargo test` harness |
+
+## Android — `rust/build_android.sh`
+
+Build-time bundled into the app's `jniLibs`. Requirements:
+
+```
+rustup target add aarch64-linux-android armv7-linux-androideabi x86_64-linux-android
+cargo install cargo-ndk
+export ANDROID_NDK_HOME=<your NDK>        # e.g. ~/Library/Android/sdk/ndk/28.2.13676358
+```
+
+`rust/build_android.sh` produces `rust/android_lib/jniLibs/<abi>/libaleo_rust.so`
+for `arm64-v8a`, `armeabi-v7a`, `x86_64`, built with the 16k page-size link args
+(mandatory on Android 15+) and **fails if any LOAD segment is not 16k-aligned**.
+The app bundles `jniLibs/` and loads via `DynamicLibrary.open('libaleo_rust.so')`
+(`DyLib.getMobileDyLib`).
+
+## iOS — `rust/build_ios.sh`
+
+Statically linked. Requirements (macOS + Xcode):
+
+```
+rustup target add aarch64-apple-ios aarch64-apple-ios-sim x86_64-apple-ios
+```
+
+`rust/build_ios.sh` builds the device slice (`aarch64-apple-ios`) + a fat simulator
+slice (`aarch64-apple-ios-sim` + `x86_64-apple-ios` via `lipo`) and packages
+`rust/ios_lib/AleoRust.xcframework`.
+
+**Dead-strip retention (done in the app repo).** A static linker drops the
+`#[no_mangle]` exports that nothing in the app references directly, and
+`DynamicLibrary.process()` lookups would then fail at runtime. The app target must
+either `-force_load` the archive or supply an `-exported_symbols_list`, then verify
+on the **final app binary** (not just the `.a`):
+
+```
+nm -gU <app-binary> | grep -E 'ffi_abi_version|execute_proof_checked'
+```
+
+## Desktop / CI
+
+Build from source: `cargo build --release` in `rust/aleo_ffi` →
+`target/release/libaleo_rust.{so,dylib,dll}`. `DyLib.getDyLibFromCargo` points
+there; tests use `ALEO_NEW_LIB=<built lib>`.
+
+## ABI guard
+
+Whatever the platform, the Dart layer validates the library's `ffi_abi_version`
+when constructing `AleoAccount`/`AleoRecord`/`AleoProgram`/`ParameterProvisioner`
+(`AleoLib.coerce`); an incompatible/stale library is rejected at load time
+(`IncompatibleNativeLibraryException`). Build outputs (`android_lib/`, `ios_lib/`)
+are git-ignored — they are produced on demand, not committed.

--- a/rust/build_android.sh
+++ b/rust/build_android.sh
@@ -1,117 +1,71 @@
 #!/bin/bash
+#
+# Cross-compiles aleo_ffi to the Android per-ABI shared libraries for build-time
+# bundling into an app's jniLibs. v1 does NOT download the native library at
+# runtime — the app bundles these .so files and loads them with
+# DynamicLibrary.open('libaleo_rust.so').
+#
+# No OpenSSL: workstreams A (curl) and B (ureq) removed the HTTP/TLS stack, so
+# there is nothing to cross-compile or carry. The only flags needed are the 16k
+# page-size link args (mandatory on Android 15+).
+#
+# Requirements:
+#   rustup target add aarch64-linux-android armv7-linux-androideabi x86_64-linux-android
+#   cargo install cargo-ndk
+#   an Android NDK on ANDROID_NDK_HOME (or auto-detected by cargo-ndk)
+#
+# Usage: rust/build_android.sh   (output: rust/android_lib/jniLibs/<abi>/libaleo_rust.so)
 
-# Android Cross-Compilation Script
-# For building aleo_rust library for Android with 16k pages support
+set -euo pipefail
 
-echo "Starting Android cross-compilation with 16k pages support..."
+cd "$(dirname "$0")/aleo_ffi"
 
-# Enter aleo_rust directory
-# OpenSSL base path
-OPENSSL_BASE_PATH="/home/zhun/openssl-3.1.5/android"
+OUT="../android_lib/jniLibs"
 
-cd aleo_rust
-
-# Create output directories
-mkdir -p ../android_lib/arm64
-mkdir -p ../android_lib/x86_64
-mkdir -p ../android_lib/armv7
-
-# Set 16k pages compatibility flags
+# 16k page alignment for Android 15+ (applies to every target built below).
 export RUSTFLAGS="-C link-arg=-Wl,-z,max-page-size=16384 -C link-arg=-Wl,-z,common-page-size=16384"
 
-echo "=========================================="
-echo "Building ARM64 Architecture"
-echo "=========================================="
+# Resolve an ELF reader: the NDK ships llvm-readelf; fall back to a system readelf
+# (macOS has neither by default, so the NDK's is preferred).
+readelf_bin() {
+  if command -v llvm-readelf >/dev/null 2>&1; then echo llvm-readelf; return; fi
+  if command -v readelf >/dev/null 2>&1; then echo readelf; return; fi
+  local ndk="${ANDROID_NDK_HOME:-}"
+  for f in "$ndk"/toolchains/llvm/prebuilt/*/bin/llvm-readelf; do
+    [ -x "$f" ] && { echo "$f"; return; }
+  done
+  echo "ERROR: no readelf/llvm-readelf found (install binutils or set ANDROID_NDK_HOME)" >&2
+  exit 1
+}
+READELF="$(readelf_bin)"
 
-export OPENSSL_INCLUDE_DIR=${OPENSSL_BASE_PATH}/arm64/include
-export OPENSSL_LIB_DIR=${OPENSSL_BASE_PATH}/arm64/lib
+echo "Building Android ABIs (arm64-v8a, armeabi-v7a, x86_64) into $OUT ..."
+cargo ndk \
+  -t arm64-v8a -t armeabi-v7a -t x86_64 \
+  --platform 21 \
+  -o "$OUT" \
+  build --release
 
-echo "Using OpenSSL:"
-echo "  Include: $OPENSSL_INCLUDE_DIR"
-echo "  Lib: $OPENSSL_LIB_DIR"
-echo "Using 16k pages flags: $RUSTFLAGS"
+# Every LOAD segment must be 16k-aligned (0x4000) or larger; fail the build
+# otherwise. The previous script only printed a warning, so a 4k-aligned library
+# (which Android 15+ rejects at load) would still "succeed".
+fail=0
+for so in "$OUT"/*/libaleo_rust.so; do
+  bad=""
+  # Each LOAD segment's Align is the last field (hex, e.g. 0x4000). Convert via
+  # shell printf (portable: BSD awk on macOS lacks gawk's strtonum) and require
+  # >= 16384.
+  for a in $("$READELF" -lW "$so" | awk '$1=="LOAD"{print $NF}'); do
+    dec=$(printf '%d' "$a" 2>/dev/null || echo 0)
+    [ "$dec" -ge 16384 ] || bad="$bad $a"
+  done
+  if [ -n "$bad" ]; then
+    echo "ERROR: $so has a LOAD segment aligned below 16k:$bad" >&2
+    fail=1
+  else
+    echo "  OK: $so is 16k-aligned"
+  fi
+done
+[ "$fail" -eq 0 ] || exit 1
 
-echo "Starting ARM64 build..."
-if cargo ndk --target aarch64-linux-android build --release; then
-    echo "✅ ARM64 build successful!"
-    cp target/aarch64-linux-android/release/libaleo_rust.so ../android_lib/arm64/
-    echo "📁 Copied to: ../android_lib/arm64/"
-    
-    # Verify 16k pages alignment
-    echo "🔍 Verifying 16k pages alignment for ARM64..."
-    readelf -l target/aarch64-linux-android/release/libaleo_rust.so | grep -E "LOAD.*0x[0-9a-f]+.*0x[0-9a-f]+.*0x[0-9a-f]+.*0x4000" && echo "✅ ARM64: 16k pages aligned" || echo "⚠️  ARM64: May not be fully 16k aligned"
-else
-    echo "❌ ARM64 build failed!"
-    exit 1
-fi
-
-echo ""
-echo "=========================================="
-echo "Building x86_64 Architecture"
-echo "=========================================="
-
-export OPENSSL_INCLUDE_DIR=${OPENSSL_BASE_PATH}/x86_64/include
-export OPENSSL_LIB_DIR=${OPENSSL_BASE_PATH}/x86_64/lib
-
-echo "Using OpenSSL:"
-echo "  Include: $OPENSSL_INCLUDE_DIR"
-echo "  Lib: $OPENSSL_LIB_DIR"
-echo "Using 16k pages flags: $RUSTFLAGS"
-
-echo "Starting x86_64 build..."
-if cargo ndk --target x86_64-linux-android build --release; then
-    echo "✅ x86_64 build successful!"
-    cp target/x86_64-linux-android/release/libaleo_rust.so ../android_lib/x86_64/
-    echo "📁 Copied to: ../android_lib/x86_64/"
-    
-    # Verify 16k pages alignment
-    echo "🔍 Verifying 16k pages alignment for x86_64..."
-    readelf -l target/x86_64-linux-android/release/libaleo_rust.so | grep -E "LOAD.*0x[0-9a-f]+.*0x[0-9a-f]+.*0x[0-9a-f]+.*0x4000" && echo "✅ x86_64: 16k pages aligned" || echo "⚠️  x86_64: May not be fully 16k aligned"
-else
-    echo "❌ x86_64 build failed!"
-    exit 1
-fi
-
-echo ""
-echo "=========================================="
-echo "Building ARMv7 Architecture"
-echo "=========================================="
-
-export OPENSSL_INCLUDE_DIR=${OPENSSL_BASE_PATH}/armv7/include
-export OPENSSL_LIB_DIR=${OPENSSL_BASE_PATH}/armv7/lib
-
-echo "Using OpenSSL:"
-echo "  Include: $OPENSSL_INCLUDE_DIR"
-echo "  Lib: $OPENSSL_LIB_DIR"
-echo "Using 16k pages flags: $RUSTFLAGS"
-
-echo "Starting ARMv7 build..."
-if cargo ndk --target armv7-linux-androideabi build --release; then
-    echo "✅ ARMv7 build successful!"
-    cp target/armv7-linux-androideabi/release/libaleo_rust.so ../android_lib/armv7/
-    echo "📁 Copied to: ../android_lib/armv7/"
-    
-    # Verify 16k pages alignment
-    echo "🔍 Verifying 16k pages alignment for ARMv7..."
-    readelf -l target/armv7-linux-androideabi/release/libaleo_rust.so | grep -E "LOAD.*0x[0-9a-f]+.*0x[0-9a-f]+.*0x[0-9a-f]+.*0x4000" && echo "✅ ARMv7: 16k pages aligned" || echo "⚠️  ARMv7: May not be fully 16k aligned"
-else
-    echo "❌ ARMv7 build failed!"
-    exit 1
-fi
-
-echo ""
-echo "=========================================="
-echo "🎉 All architectures built successfully!"
-echo "=========================================="
-
-echo "Output file locations:"
-echo "  ARM64:   android_lib/arm64/libaleo_rust.so"
-echo "  x86_64:  android_lib/x86_64/libaleo_rust.so"
-echo "  ARMv7:   android_lib/armv7/libaleo_rust.so"
-
-echo ""
-echo "📋 16k Pages Compatibility Summary:"
-echo "All libraries have been built with 16k pages support flags:"
-echo "  - max-page-size=16384"
-echo "  - common-page-size=16384"
-echo "This ensures compatibility with Android devices using 16k memory pages."
+echo "All Android ABIs built + 16k-verified. Bundle $OUT/<abi>/libaleo_rust.so into the app's jniLibs."

--- a/rust/build_ios.sh
+++ b/rust/build_ios.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+#
+# Builds the aleo_ffi iOS staticlib and packages it as an xcframework (device +
+# simulator). v1 links the library statically into the app and loads it via
+# DynamicLibrary.process() — there is no runtime download.
+#
+# No OpenSSL: workstreams A (curl) and B (ureq) removed the HTTP/TLS stack.
+#
+# Requirements (macOS + Xcode):
+#   rustup target add aarch64-apple-ios aarch64-apple-ios-sim x86_64-apple-ios
+#
+# Usage: rust/build_ios.sh   (output: rust/ios_lib/AleoRust.xcframework)
+
+set -euo pipefail
+
+cd "$(dirname "$0")/aleo_ffi"
+
+OUT="../ios_lib"
+NAME="libaleo_rust.a"
+
+echo "Building iOS staticlib (device + simulator slices) ..."
+cargo build --release --target aarch64-apple-ios      # device   (arm64)
+cargo build --release --target aarch64-apple-ios-sim  # simulator (arm64)
+cargo build --release --target x86_64-apple-ios       # simulator (x86_64)
+
+mkdir -p "$OUT"
+
+# A single fat simulator archive (arm64 + x86_64); device stays its own slice.
+SIM_FAT="$OUT/libaleo_rust-sim.a"
+lipo -create \
+  "target/aarch64-apple-ios-sim/release/$NAME" \
+  "target/x86_64-apple-ios/release/$NAME" \
+  -output "$SIM_FAT"
+
+XCF="$OUT/AleoRust.xcframework"
+rm -rf "$XCF"
+xcodebuild -create-xcframework \
+  -library "target/aarch64-apple-ios/release/$NAME" \
+  -library "$SIM_FAT" \
+  -output "$XCF"
+
+echo
+echo "Built $XCF"
+echo
+echo "App integration (performed in the app repo):"
+echo "  1. Link AleoRust.xcframework into the app target."
+echo "  2. RETAIN the FFI symbols through dead-strip — a static linker drops the"
+echo "     #[no_mangle] exports that nothing in the app references directly, and"
+echo "     DynamicLibrary.process() lookups would then fail at runtime. Add:"
+echo "       -force_load <path>/AleoRust.xcframework/<slice>/libaleo_rust.a"
+echo "     (or an -exported_symbols_list listing ffi_abi_version, execute_*_checked,"
+echo "      parameter_preflight, the account/record/authorize exports, free_string)."
+echo "  3. Verify on the FINAL app binary (not just the .a):"
+echo "       nm -gU <app-binary> | grep -E 'ffi_abi_version|execute_proof_checked'"
+echo "     Both must be present; if not, the -force_load/exported-symbols step is"
+echo "     missing."


### PR DESCRIPTION
Workstream D of Phase 4 — cross-compile + distribution. v1 does **not** download the
native library at runtime: desktop/CI build from source, mobile bundles at build
time. No OpenSSL (workstreams A+B removed the HTTP/TLS stack). PR5 deletes the GPL
`rust/aleo_rust` crate. Docs: `rust/aleo_ffi/docs/cross-compile.md`.

## Decisions (locked)
- v1 = no runtime lib download; mobile build-time bundles, desktop/CI build from source.
- iOS = this repo ships the staticlib crate-type + xcframework script + docs; the app
  repo applies `-force_load` + device smoke.
- CI = scripts + crate-type + Dart + docs only (no cross-compile in CI).

## Changes
- **Cargo.toml**: add `staticlib` crate-type (iOS xcframework) alongside `cdylib`
  (Android/desktop) + `rlib` (tests).
- **rust/build_android.sh**: rewritten — `cd aleo_ffi`, drop the hard-coded personal
  `OPENSSL_BASE_PATH`, `cargo-ndk` arm64-v8a/armeabi-v7a/x86_64 with the 16k
  page-size link args, jniLibs output, and **fail the build if any LOAD segment is
  not 16k-aligned** (the old script only printed a warning).
- **rust/build_ios.sh** (new): staticlib device slice + a fat simulator slice (lipo)
  → `AleoRust.xcframework`; documents the app-side dead-strip retention
  (`-force_load` / `-exported_symbols_list`) + `nm`-on-final-binary check.
- **dyLib.dart**: repoint `getDyLibFromCargo` off the GPL `aleo_rust` crate to the
  clean-room `aleo_ffi` build output (filename unchanged); add `getMobileDyLib`
  (Android `DynamicLibrary.open('libaleo_rust.so')` / iOS `DynamicLibrary.process()`).
- **setup_dylib.dart** + **bin/setup.dart**: `@Deprecated` the runtime downloader
  (its pinned `pzhun`/S3 source is a stale GPL-era artifact).
- **rust/.gitignore** (new): ignore `android_lib/` + `ios_lib/` (build outputs, not
  committed).

## Verified locally
- `build_android.sh` → 3 ABIs, every LOAD segment 16k-aligned,
  `ffi_abi_version`/`execute_proof_checked`/`get_base_fee` exported.
- `build_ios.sh` → xcframework (`ios-arm64` + `ios-arm64_x86_64-simulator`, the sim
  slice fat = arm64 + x86_64); device slice exports the FFI symbols.
- desktop `cargo build --release` → cdylib (exactly 34 symbols, unchanged) +
  staticlib; `dart analyze` clean; `dart test` 88 passed / 2 skipped.

## Not in this PR
- manifest-drift CI: redundant — the param manifest is generated at runtime from the
  vendored snarkVM metadata and is already asserted by the `cargo test --lib`
  manifest tests, with snarkVM pinned `=4.5.0`.
- PR5: delete the GPL `rust/aleo_rust` crate + prebuilt binaries; `cargo-license`
  zero GPL; pub.dev dry-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)