### PR TITLE
ci: cancel superseded runs + path-filter the Dart CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,31 @@
 name: CI
 
+# Monorepo-wide Dart/Flutter CI: melos bootstrap + analyze/format/test across all
+# packages. Path-filtered with `paths-ignore` so changes that can't affect the Dart
+# build — the Rust crate (covered by rust.yml) plus docs/license — don't trigger a
+# full melos run. `paths-ignore` (rather than an allow-list) fails toward running
+# CI, so a newly-added Dart path is never silently skipped.
 on:
   push:
     branches: [ main, 'epic/**' ]
+    paths-ignore:
+      - 'rust/**'
+      - '**.md'
+      - 'LICENSE'
+      - '.github/workflows/rust.yml'
   pull_request:
     branches: [ main, 'epic/**' ]
+    paths-ignore:
+      - 'rust/**'
+      - '**.md'
+      - 'LICENSE'
+      - '.github/workflows/rust.yml'
+
+# Cancel a superseded in-progress run on the same ref (e.g. rapid pushes to a PR)
+# so only the latest commit keeps a runner.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   test:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,6 +12,12 @@ on:
     branches: [ main, 'epic/**' ]
     paths: [ 'rust/**', 'packages/aleo_dart/**', '.github/workflows/rust.yml' ]
 
+# Cancel a superseded in-progress run on the same ref (e.g. rapid pushes to a PR)
+# so only the latest commit keeps a runner — the snarkVM build is heavy.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What

- **`concurrency` (cancel-in-progress)** on both `ci.yml` and `rust.yml`, keyed by
  `${{ github.workflow }}-${{ github.ref }}` — a rapid push to a PR cancels the
  obsolete in-flight run instead of letting it finish, freeing runners and giving
  faster feedback.
- **`paths-ignore` on `ci.yml`** so the monorepo-wide `melos` run no longer fires
  on changes that can't affect the Dart build: the Rust crate (`rust/**`, already
  covered by `rust.yml`), docs (`**.md`), `LICENSE`, and `rust.yml` itself.

## Notes

- `paths-ignore` (rather than an allow-list) fails toward **running** CI, so a
  newly-added Dart path is never silently skipped.
- **Branch-protection caveat:** if `CI` is a required status check and a PR touches
  only ignored paths (e.g. a Rust-only or docs-only change), the check is skipped
  and may show as pending → can block merge. If `CI` is required, add a companion
  skip-job or relax the requirement. (Not configured here; flagging for awareness.)
- Base is `epic/aleo-dart-monorepo` because `rust.yml` only exists on the epic line;
  this rides the epic→main convergence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)