### PR TITLE
fix(rust): install cross-compile targets in build_android/ios scripts

### DIFF
--- a/rust/build_android.sh
+++ b/rust/build_android.sh
@@ -39,6 +39,13 @@ readelf_bin() {
 }
 READELF="$(readelf_bin)"
 
+# Ensure the Rust std for every Android ABI is present. cargo-ndk does NOT add
+# targets itself, and a fresh toolchain (CI's `rustup show`, or a clean machine)
+# only has the host target -> otherwise the build dies with
+# `can't find crate for core` / "target may not be installed". Idempotent:
+# `rustup target add` is a no-op when the target is already installed.
+rustup target add aarch64-linux-android armv7-linux-androideabi x86_64-linux-android
+
 echo "Building Android ABIs (arm64-v8a, armeabi-v7a, x86_64) into $OUT ..."
 cargo ndk \
   -t arm64-v8a -t armeabi-v7a -t x86_64 \

--- a/rust/build_ios.sh
+++ b/rust/build_ios.sh
@@ -48,6 +48,12 @@ if [ "$(cat "$STAMP" 2>/dev/null || true)" != "$MIN_IOS" ]; then
   rm -f "$STAMP"
 fi
 
+# Ensure the Rust std for every iOS slice is present. A fresh toolchain (CI's
+# `rustup show`, or a clean machine) only has the host target -> otherwise the
+# build dies with `can't find crate for core` / "target may not be installed".
+# Idempotent: `rustup target add` is a no-op when the target is already installed.
+rustup target add aarch64-apple-ios aarch64-apple-ios-sim x86_64-apple-ios
+
 echo "Building iOS dynamic library (device + simulator slices) for iOS $MIN_IOS ..."
 cargo build --release --target aarch64-apple-ios      # device   (arm64)
 cargo build --release --target aarch64-apple-ios-sim  # simulator (arm64)


### PR DESCRIPTION
## Why

The first real run of `release-aleo.yml` (tag `aleo_ffi-v1.0.0`) **failed in both the `android` and `ios` jobs** with:

```
error[E0463]: can't find crate for `core`
note: the `aarch64-linux-android` / `aarch64-apple-ios` target may not be installed
```

The build scripts documented `rustup target add ...` as a *manual prerequisite* (in comments) but never ran it. On a fresh CI toolchain (`rustup show` installs only the host target) the cross targets are absent. Local builds passed only because the dev machine already had them. `cargo-ndk` does **not** add targets itself.

## Fix

Add an **idempotent** `rustup target add` to each script for exactly the targets it builds, so the scripts are self-contained on any clean machine / runner:

- `build_android.sh`: `aarch64-linux-android armv7-linux-androideabi x86_64-linux-android`
- `build_ios.sh`: `aarch64-apple-ios aarch64-apple-ios-sim x86_64-apple-ios`

`rustup target add` is a no-op when the target is already present, so no impact on machines that already have them.

## After merge

Re-point the `aleo_ffi-v1.0.0` tag to the merged main commit and re-run the release (the failed run published **no** assets / created **no** release, so the tag is safe to reuse).

## CI

Build-script-only change under `rust/` → `ci.yml` is skipped (paths-ignore `rust/**`); `rust.yml` runs (host build + FFI tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)