### PR TITLE
chore(aleo_flutter): pin artifact SHA-256 to published aleo_ffi-v1.0.0

### DIFF
--- a/packages/aleo_flutter/CHANGELOG.md
+++ b/packages/aleo_flutter/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## 0.0.1
 
+* Pinned the artifact manifest SHA-256 values to the published
+  [`aleo_ffi-v1.0.0`](https://github.com/fxwalletOfficial/fx-wallet-packages/releases/tag/aleo_ffi-v1.0.0)
+  GitHub Release (Android `libaleo_rust-android.zip`, iOS
+  `AleoRust.xcframework.zip`), so the build-time download path is now active
+  (was fail-closed with all-zero placeholders before the release existed).
 * Initial skeleton. Flutter FFI plugin that bundles the prebuilt `aleo_rust`
   native library (Android per-ABI `.so`, iOS dynamic `AleoRust.framework`) at
   build time and exposes the `aleo_dart` API via `AleoFlutter.load()`.

--- a/packages/aleo_flutter/README.md
+++ b/packages/aleo_flutter/README.md
@@ -8,25 +8,24 @@ build per consumer, no runtime download, offline at runtime.
 `DyLib.getDyLibFromCargo()`). `aleo_flutter` is the thin mobile distribution
 layer on top of it.
 
-> **Status — pre-release (v1):** the `aleo_ffi-v1.0.0` GitHub Release is **not
-> published yet**, so the SHA-256 values in
-> [`lib/src/artifact_manifest.dart`](lib/src/artifact_manifest.dart) are still
-> all-zero placeholders and the build-time **download path is disabled**
-> (fail-closed). Until the release is published and the real SHA is pinned, a
-> consumer **must supply the native library locally** — run `rust/build_ios.sh` /
-> `rust/build_android.sh`, or set `ALEO_FFI_IOS_XCFRAMEWORK` /
-> `ALEO_FFI_ANDROID_JNILIBS` (see
-> [Local development](#local-development-before--instead-of-a-release)). The
-> zero-config "just run `flutter build`" flow described below activates once the
-> release is tagged and the SHA is pinned.
+> **Status — released (v1):** the
+> [`aleo_ffi-v1.0.0`](https://github.com/fxwalletOfficial/fx-wallet-packages/releases/tag/aleo_ffi-v1.0.0)
+> GitHub Release is published and the SHA-256 values in
+> [`lib/src/artifact_manifest.dart`](lib/src/artifact_manifest.dart) are pinned to
+> it, so the build-time download path is **active**: a consumer app just runs
+> `flutter build` and the right `libaleo_rust` is fetched once, verified against
+> the pinned SHA-256, and bundled. To build the library locally instead (or to
+> develop without the release), run `rust/build_ios.sh` / `rust/build_android.sh`
+> or set `ALEO_FFI_IOS_XCFRAMEWORK` / `ALEO_FFI_ANDROID_JNILIBS` (see
+> [Local development](#local-development-before--instead-of-a-release)).
 
 ## Why
 
 The native library is ~35 MB per platform and slow to cross-compile (it links
 snarkVM). `aleo_flutter` removes that pain: the consumer app just runs
-`flutter build` and the right `libaleo_rust` is bundled automatically — once a
-tagged release is pinned (see **Status** above; pre-release this requires a local
-build or an `ALEO_FFI_*` override).
+`flutter build` and the right `libaleo_rust` is bundled automatically, verified
+against the pinned SHA-256 (see **Status** above; to build without the release,
+use a local build or an `ALEO_FFI_*` override).
 
 ## Usage
 

--- a/packages/aleo_flutter/lib/src/artifact_manifest.dart
+++ b/packages/aleo_flutter/lib/src/artifact_manifest.dart
@@ -45,9 +45,9 @@ const String aleoAndroidArtifactUrl =
 /// an all-zero hash as "unset" and require a local build (the LOCAL-override
 /// path; see `pr6a-impl-notes.md`).
 const String aleoIosArtifactSha256 =
-    '0000000000000000000000000000000000000000000000000000000000000000';
+    '7f7673c6de687c5ca0de1c2d47515ffda6c7e26e1f3ba27aee10ea4ce32e391f';
 
 /// SHA-256 (lowercase hex) the downloaded Android asset must hash to. See
 /// [aleoIosArtifactSha256].
 const String aleoAndroidArtifactSha256 =
-    '0000000000000000000000000000000000000000000000000000000000000000';
+    'b53634f8aaf6d998cf05e71dcdffefb28b0132c85de24c7a0fc68dc3aa87d8d0';

--- a/packages/aleo_flutter/lib/src/artifact_manifest.dart
+++ b/packages/aleo_flutter/lib/src/artifact_manifest.dart
@@ -40,10 +40,11 @@ const String aleoAndroidArtifactUrl =
 
 /// SHA-256 (lowercase hex) the downloaded iOS asset must hash to.
 ///
-/// Placeholder (all-zero) until the first release is built and uploaded — PR6b
-/// wires the release pipeline and pins these. Until then the build scripts treat
-/// an all-zero hash as "unset" and require a local build (the LOCAL-override
-/// path; see `pr6a-impl-notes.md`).
+/// Pinned to the published [aleoFfiReleaseTag] release asset
+/// (`AleoRust.xcframework.zip`). The build scripts verify the downloaded asset
+/// against this value before bundling. (An all-zero value is treated as "unset"
+/// and forces the LOCAL-override path; see `pr6a-impl-notes.md`. Re-pin with
+/// `tool/pin_artifact_sha.sh` whenever the release is rebuilt.)
 const String aleoIosArtifactSha256 =
     '7f7673c6de687c5ca0de1c2d47515ffda6c7e26e1f3ba27aee10ea4ce32e391f';
 


### PR DESCRIPTION
## What

Pin `packages/aleo_flutter/lib/src/artifact_manifest.dart` (the in-package integrity anchor) to the **real** SHA-256 of the native assets published by the `aleo_ffi-v1.0.0` release (built from `e01849a`, after the cross-target build fix #71):

| asset | sha256 |
|---|---|
| `libaleo_rust-android.zip` | `b53634f8aaf6d998cf05e71dcdffefb28b0132c85de24c7a0fc68dc3aa87d8d0` |
| `AleoRust.xcframework.zip` | `7f7673c6de687c5ca0de1c2d47515ffda6c7e26e1f3ba27aee10ea4ce32e391f` |

These were **independently verified**: downloaded both release assets and recomputed sha256 locally → matches the release `SHA256SUMS` (both `OK`).

## Effect

- Activates the build-time download path (was fail-closed with all-zero placeholders before the release existed).
- README **Status** flipped pre-release → released; CHANGELOG entry added.
- Release **tag/URL unchanged** (`aleo_ffi-v1.0.0`); only the two SHA consts changed in the manifest.

## CI

Touches `packages/aleo_flutter` Dart + docs → `ci.yml` (melos analyze/format/test) runs; `rust.yml` does not (no `rust/**` or `aleo_dart` change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)