### PR TITLE
fix(ur): harden UR protocol decoding for correctness & core stability

### DIFF
--- a/packages/bc_ur_dart/lib/src/models/common/fragment.dart
+++ b/packages/bc_ur_dart/lib/src/models/common/fragment.dart
@@ -3,6 +3,7 @@ import 'dart:typed_data';
 import 'package:bc_ur_dart/src/models/common/seq.dart';
 import 'package:bc_ur_dart/src/ur.dart';
 import 'package:bc_ur_dart/src/utils/byte_words.dart';
+import 'package:bc_ur_dart/src/utils/error.dart';
 import 'package:bc_ur_dart/src/utils/utils.dart';
 import 'package:cbor/cbor.dart';
 import 'package:convert/convert.dart';
@@ -10,6 +11,8 @@ import 'package:xrandom/xrandom.dart';
 
 /// Fragment of UR.
 class FragmentUR extends UR {
+  static const int maxUint32 = 0xffffffff;
+
   final int messageLength;
   final int checksum;
   final Uint8List part;
@@ -18,40 +21,61 @@ class FragmentUR extends UR {
   List<int> get indexes => _indexes;
   bool get isSimple => _indexes.length == 1;
 
-  FragmentUR({required super.type, required URSeq seq, required this.messageLength, required this.checksum, required this.part}) : super.fromCBOR(
-    seq: seq,
-    value: CborList([
-      CborSmallInt(seq.num),
-      CborSmallInt(seq.length),
-      CborSmallInt(messageLength),
-      CborSmallInt(checksum),
-      CborBytes(part)
-    ])
-  ) {
+  FragmentUR({required super.type, required URSeq seq, required this.messageLength, required this.checksum, required this.part})
+      : super.fromCBOR(seq: seq, value: CborList([CborSmallInt(seq.num), CborSmallInt(seq.length), CborSmallInt(messageLength), CborSmallInt(checksum), CborBytes(part)])) {
     setIndexes();
   }
 
   /// Generate fragment from simple UR. Only UR with valid seq can be generate.
   static FragmentUR fromUR({required UR ur}) {
-    final data = ur.decodeCBOR();
-    if (data is! CborList || data.length != 5) throw Exception('Invalid fragment ur');
+    late final CborValue data;
+    try {
+      data = ur.decodeCBOR();
+    } catch (_) {
+      throw InvalidFormatURException(input: ur.encode());
+    }
+    if (data is! CborList || data.length != 5) throw InvalidFormatURException(input: ur.encode());
+    if (data[0] is! CborInt || data[1] is! CborInt || data[2] is! CborInt || data[3] is! CborInt || data[4] is! CborBytes) {
+      throw InvalidFormatURException(input: ur.encode());
+    }
 
     final seqNum = (data[0] as CborInt).toInt();
     final seqLength = (data[1] as CborInt).toInt();
     final messageLength = (data[2] as CborInt).toInt();
     final checksum = (data[3] as CborInt).toInt();
     final part = Uint8List.fromList((data[4] as CborBytes).bytes);
-
-    final item = FragmentUR(
-      seq: URSeq(num: seqNum, length: seqLength),
+    _validateFields(
+      seqNum: seqNum,
+      seqLength: seqLength,
       messageLength: messageLength,
       checksum: checksum,
       part: part,
-      type: ur.type
+      input: ur.encode(),
     );
+
+    final item = FragmentUR(seq: URSeq(num: seqNum, length: seqLength), messageLength: messageLength, checksum: checksum, part: part, type: ur.type);
 
     item.setIndexes();
     return item;
+  }
+
+  static void _validateFields({
+    required int seqNum,
+    required int seqLength,
+    required int messageLength,
+    required int checksum,
+    required Uint8List part,
+    required String input,
+  }) {
+    if (seqNum <= 0 || seqNum > maxUint32 || seqLength <= 0 || seqLength > maxUint32 || messageLength <= 0 || checksum < 0 || checksum > maxUint32 || part.isEmpty) {
+      throw InvalidSequenceURException(value: input);
+    }
+
+    final minMessageLength = (seqLength - 1) * part.length;
+    final maxMessageLength = seqLength * part.length;
+    if (messageLength <= minMessageLength || messageLength > maxMessageLength) {
+      throw InvalidSequenceURException(value: input);
+    }
   }
 
   /// Generate fragment indexes for packet final UR.
@@ -62,7 +86,7 @@ class FragmentUR extends UR {
     }
 
     if (seq.num <= seq.length) {
-      _indexes = [seq.num -1];
+      _indexes = [seq.num - 1];
       return;
     }
 

--- a/packages/bc_ur_dart/lib/src/models/common/fragment.dart
+++ b/packages/bc_ur_dart/lib/src/models/common/fragment.dart
@@ -13,6 +13,12 @@ import 'package:xrandom/xrandom.dart';
 class FragmentUR extends UR {
   static const int maxUint32 = 0xffffffff;
 
+  /// Defensive upper bound on fragment count. Far beyond any real animated-QR
+  /// message, it stops a hostile `seqLen` from OOM-ing `List.generate(seqLen)`
+  /// on the streaming read path (a Dart Error that would escape read()'s
+  /// `on URException` catch and kill the scan loop).
+  static const int maxSeqLength = 0x10000;
+
   final int messageLength;
   final int checksum;
   final Uint8List part;
@@ -67,7 +73,7 @@ class FragmentUR extends UR {
     required Uint8List part,
     required String input,
   }) {
-    if (seqNum <= 0 || seqNum > maxUint32 || seqLength <= 0 || seqLength > maxUint32 || messageLength <= 0 || checksum < 0 || checksum > maxUint32 || part.isEmpty) {
+    if (seqNum <= 0 || seqNum > maxUint32 || seqLength <= 0 || seqLength > maxSeqLength || messageLength <= 0 || checksum < 0 || checksum > maxUint32 || part.isEmpty) {
       throw InvalidSequenceURException(value: input);
     }
 

--- a/packages/bc_ur_dart/lib/src/models/common/seq.dart
+++ b/packages/bc_ur_dart/lib/src/models/common/seq.dart
@@ -1,3 +1,5 @@
+import 'package:bc_ur_dart/src/utils/error.dart';
+
 class URSeq {
   int length;
   int num;
@@ -10,9 +12,10 @@ class URSeq {
     final components = value.split('-');
     if (components.length != 2) return URSeq(num: 0, length: 0);
 
-    final num = int.parse(components[0]);
-    final length = int.parse(components[1]);
-    if (num <= 0 || length <= 0) return URSeq(num: 0, length: 0);
+    final num = int.tryParse(components[0]);
+    final length = int.tryParse(components[1]);
+    if (num == null || length == null) throw InvalidSequenceURException(value: value);
+    if (num <= 0 || length <= 0) throw InvalidSequenceURException(value: value);
 
     return URSeq(num: num, length: length);
   }

--- a/packages/bc_ur_dart/lib/src/ur.dart
+++ b/packages/bc_ur_dart/lib/src/ur.dart
@@ -65,7 +65,7 @@ class UR {
 
   UR({String type = '', Uint8List? payload, URSeq? seq, this.minLength = 10, this.maxLength = 100}) {
     _type = type;
-    _payload = payload ?? Uint8List(0);
+    _setPayload(payload ?? Uint8List(0));
     _seq.copy(seq);
   }
 
@@ -84,7 +84,7 @@ class UR {
   /// Generate UR by CBOR object.
   UR.fromCBOR({required String type, required CborValue value, URSeq? seq, this.minLength = 10, this.maxLength = 100}) {
     _type = type;
-    _payload = Uint8List.fromList(cbor.encode(value));
+    _setPayload(Uint8List.fromList(cbor.encode(value)));
     if (seq != null) _seq.copy(seq);
   }
 
@@ -98,15 +98,27 @@ class UR {
   bool read(String value) {
     if (isComplete) return false;
 
-    final ur = UR.decode(value);
+    late final UR ur;
+    try {
+      ur = UR.decode(value);
+    } on URException {
+      return false;
+    }
+
     // It is only a single body, just get data and return.
     if (!ur.isFragment) {
+      if (_type.isNotEmpty) return false;
       _type = ur.type;
-      _payload = ur.payload;
+      _setPayload(ur.payload);
       return true;
     }
 
-    final fragment = FragmentUR.fromUR(ur: ur);
+    late final FragmentUR fragment;
+    try {
+      fragment = FragmentUR.fromUR(ur: ur);
+    } on URException {
+      return false;
+    }
     if (!_check(fragment) || !(fragment.seq == ur.seq)) return false;
 
     _queuedParts.add(fragment);
@@ -120,11 +132,7 @@ class UR {
   /// Check expected target when read fragment UR. Set data when read first and compare others.
   bool _check(FragmentUR ur) {
     if (_type.isNotEmpty) {
-      return _type == ur.type &&
-        seq.length == ur.seq.length &&
-        _expectedMessageLength == ur.messageLength &&
-        _expectedChecksum == ur.checksum &&
-        _expectedFragmentLength == ur.part.length;
+      return _type == ur.type && seq.length == ur.seq.length && _expectedMessageLength == ur.messageLength && _expectedChecksum == ur.checksum && _expectedFragmentLength == ur.part.length;
     }
 
     _type = ur.type;
@@ -133,10 +141,8 @@ class UR {
     _expectedChecksum = ur.checksum;
     _expectedFragmentLength = ur.part.length;
 
-    if (seq.length > 0) {
-      _expectedPartIndexes.clear();
-      _expectedPartIndexes.addAll(List.generate(ur.seq.length, (i) => i));
-    }
+    _expectedPartIndexes.clear();
+    _expectedPartIndexes.addAll(List.generate(ur.seq.length, (i) => i));
 
     return true;
   }
@@ -162,7 +168,16 @@ class UR {
     if (arraysEqual(_receivedPartIndexes, _expectedPartIndexes)) {
       // Reassemble the message from its fragments
       _simpleParts.sort((a, b) => (a.indexes[0] - b.indexes[0]));
-      _payload = _simpleParts.map((e) => e.part).reduce((a, b) => Uint8List.fromList(a + b)).sublist(0, _expectedMessageLength);
+      final builder = BytesBuilder(copy: false);
+      for (final part in _simpleParts) {
+        builder.add(part.part);
+      }
+      final payload = builder.takeBytes().sublist(0, _expectedMessageLength);
+      if (CRC32.compute(payload) != _expectedChecksum) {
+        _resetReadState();
+        return;
+      }
+      _setPayload(payload);
     } else {
       _reduceMixedBy(fragment);
     }
@@ -189,7 +204,7 @@ class UR {
 
     for (final item in _mixedParts) {
       final ur = _reducePartByPart(item, fragment);
-      ur.isSimple ? _queuedParts.add(item) : newMixed.add(ur);
+      ur.isSimple ? _queuedParts.add(ur) : newMixed.add(ur);
     }
 
     _mixedParts.clear();
@@ -207,13 +222,7 @@ class UR {
       newPart[i] = a.part[i] ^ b.part[i];
     }
 
-    final item = FragmentUR(
-      type: a.type,
-      seq: URSeq(num: a.seq.num, length: a.seq.length),
-      messageLength: _expectedMessageLength,
-      checksum: a.crc,
-      part: newPart
-    );
+    final item = FragmentUR(type: a.type, seq: URSeq(num: a.seq.num, length: a.seq.length), messageLength: a.messageLength, checksum: a.checksum, part: newPart);
     item.setIndexes(value: newIndexes);
     return item;
   }
@@ -224,32 +233,44 @@ class UR {
     return _crc;
   }
 
+  void _setPayload(Uint8List value) {
+    _payload = value;
+    _crc = -1;
+  }
+
+  void _resetReadState() {
+    _type = '';
+    _setPayload(Uint8List(0));
+    seq.num = 0;
+    seq.length = 0;
+    _expectedMessageLength = 0;
+    _expectedChecksum = 0;
+    _expectedFragmentLength = 0;
+    _expectedPartIndexes.clear();
+    _receivedPartIndexes.clear();
+    _mixedParts.clear();
+    _queuedParts.clear();
+    _simpleParts.clear();
+  }
+
+  void reset() {
+    _resetReadState();
+  }
+
   /// Get next UR. If payload is shorter than [maxLength], it will return the same value of [encode]. If not, it will return fragment.
   /// Be ensure to return enough fragments to complete full data.
   String next() {
     if (_fragments.isEmpty) _partition();
     if (_fragments.length <= 1) return encode();
 
-    _seqNum++;
-    final item = FragmentUR(
-      type: type,
-      seq: URSeq(num: _seqNum, length: _fragments.length),
-      messageLength: payload.length,
-      checksum: crc,
-      part: Uint8List(0)
-    );
+    _seqNum = (_seqNum % FragmentUR.maxUint32) + 1;
+    final item = FragmentUR(type: type, seq: URSeq(num: _seqNum, length: _fragments.length), messageLength: payload.length, checksum: crc, part: Uint8List(0));
     item.setIndexes();
 
     final indexes = List<int>.from(item.indexes);
     final mixed = _mix(indexes);
 
-    final fragment = FragmentUR(
-      type: type,
-      seq: URSeq(num: _seqNum, length: _fragments.length),
-      messageLength: payload.length,
-      checksum: crc,
-      part: mixed
-    );
+    final fragment = FragmentUR(type: type, seq: URSeq(num: _seqNum, length: _fragments.length), messageLength: payload.length, checksum: crc, part: mixed);
     fragment.setIndexes(value: indexes);
 
     return fragment.encode();
@@ -258,16 +279,13 @@ class UR {
   /// Split data to fragment.
   void _partition() {
     final length = _getFragmentLength();
-    List<int> remaining = List.from(payload);
     final items = <Uint8List>[];
 
-    while (remaining.isNotEmpty) {
-      final len = length > remaining.length ? remaining.length : length;
-      List<int> item = remaining.sublist(0, len);
-      remaining = remaining.sublist(len);
-
-      if (item.length < length) item = item + List.filled(length - item.length, 0);
-      items.add(Uint8List.fromList(item));
+    for (var offset = 0; offset < payload.length; offset += length) {
+      final end = min(offset + length, payload.length);
+      final item = Uint8List(length);
+      item.setRange(0, end - offset, payload, offset);
+      items.add(item);
     }
 
     _fragments.clear();

--- a/packages/bc_ur_dart/lib/src/utils/byte_words.dart
+++ b/packages/bc_ur_dart/lib/src/utils/byte_words.dart
@@ -1,49 +1,61 @@
 import 'dart:typed_data';
 
 import 'package:bc_ur_dart/src/utils/crc32.dart';
+import 'package:bc_ur_dart/src/utils/error.dart';
 import 'package:convert/convert.dart';
 
-final RegExp _urPartition = RegExp(r'([a-z]{2})');
+final RegExp _minimalByteWords = RegExp(r'^[a-z]+$');
 
 const int BYTE_WORD_NUM = 256;
 const int BYTE_WORD_LENGTH = 4;
 const int DIM = 26;
 
-const String BYTE_WORDS = 'ableacidalsoapexaquaarchatomauntawayaxisbackbaldbarnbeltbetabiasbluebodybragbrewbulbbuzzcalmcashcatschefcityclawcodecolacookcostcruxcurlcuspcyandarkdatadaysdelidicedietdoordowndrawdropdrumdulldutyeacheasyechoedgeepicevenexamexiteyesfactfairfernfigsfilmfishfizzflapflewfluxfoxyfreefrogfuelfundgalagamegeargemsgiftgirlglowgoodgraygrimgurugushgyrohalfhanghardhawkheathelphighhillholyhopehornhutsicedideaidleinchinkyintoirisironitemjadejazzjoinjoltjowljudojugsjumpjunkjurykeepkenokeptkeyskickkilnkingkitekiwiknoblamblavalazyleaflegsliarlimplionlistlogoloudloveluaulucklungmainmanymathmazememomenumeowmildmintmissmonknailnavyneednewsnextnoonnotenumbobeyoboeomitonyxopenovalowlspaidpartpeckplaypluspoempoolposepuffpumapurrquadquizraceramprealredorichroadrockroofrubyruinrunsrustsafesagascarsetssilkskewslotsoapsolosongstubsurfswantacotasktaxitenttiedtimetinytoiltombtoystriptunatwinuglyundouniturgeuservastveryvetovialvibeviewvisavoidvowswallwandwarmwaspwavewaxywebswhatwhenwhizwolfworkyankyawnyellyogayurtzapszerozestzinczonezoom';
+const String BYTE_WORDS =
+    'ableacidalsoapexaquaarchatomauntawayaxisbackbaldbarnbeltbetabiasbluebodybragbrewbulbbuzzcalmcashcatschefcityclawcodecolacookcostcruxcurlcuspcyandarkdatadaysdelidicedietdoordowndrawdropdrumdulldutyeacheasyechoedgeepicevenexamexiteyesfactfairfernfigsfilmfishfizzflapflewfluxfoxyfreefrogfuelfundgalagamegeargemsgiftgirlglowgoodgraygrimgurugushgyrohalfhanghardhawkheathelphighhillholyhopehornhutsicedideaidleinchinkyintoirisironitemjadejazzjoinjoltjowljudojugsjumpjunkjurykeepkenokeptkeyskickkilnkingkitekiwiknoblamblavalazyleaflegsliarlimplionlistlogoloudloveluaulucklungmainmanymathmazememomenumeowmildmintmissmonknailnavyneednewsnextnoonnotenumbobeyoboeomitonyxopenovalowlspaidpartpeckplaypluspoempoolposepuffpumapurrquadquizraceramprealredorichroadrockroofrubyruinrunsrustsafesagascarsetssilkskewslotsoapsolosongstubsurfswantacotasktaxitenttiedtimetinytoiltombtoystriptunatwinuglyundouniturgeuservastveryvetovialvibeviewvisavoidvowswallwandwarmwaspwavewaxywebswhatwhenwhizwolfworkyankyawnyellyogayurtzapszerozestzinczonezoom';
 
-enum ByteWordsStyle {
-  STANDARD,
-  URI,
-  MINIMAL
-}
+enum ByteWordsStyle { STANDARD, URI, MINIMAL }
 
 class ByteWords {
   static Uint8List decode(String value) {
-    final part = _urPartition.allMatches(value).map((e) => e.group(0)!);
+    final normalized = value.toLowerCase();
+    if (normalized.length < 8 || normalized.length.isOdd || !_minimalByteWords.hasMatch(normalized)) {
+      throw InvalidFormatURException(input: value);
+    }
+
     final words = <int>[];
-    for (final item in part) {
+    for (var i = 0; i < normalized.length; i += 2) {
+      final item = normalized.substring(i, i + 2);
       final x = item[0].toLowerCase().codeUnitAt(0) - 'a'.codeUnitAt(0);
       final y = item[1].toLowerCase().codeUnitAt(0) - 'a'.codeUnitAt(0);
 
       final offset = y * DIM + x;
-      final value = lookUpTable[offset];
-      words.add(value);
+      final byte = lookUpTable[offset];
+      if (byte < 0) throw InvalidFormatURException(input: value);
+      words.add(byte);
     }
 
-    return Uint8List.fromList(words.sublist(0, words.length - 4));
+    final payload = Uint8List.fromList(words.sublist(0, words.length - 4));
+    final expected = int.parse(hex.encode(words.sublist(words.length - 4)), radix: 16);
+    final actual = CRC32.compute(payload);
+    if (actual != expected) {
+      throw InvalidChecksumURException(value: value);
+    }
+
+    return payload;
   }
 
   static String encode(Uint8List data) {
     final crc = CRC32.compute(data).toRadixString(16).padLeft(8, '0');
     final buf = data + hex.decode(crc);
 
-    String msg = '';
+    final msg = StringBuffer();
     for (final item in buf) {
       final word = BYTE_WORDS.substring(item * BYTE_WORD_LENGTH, (item * BYTE_WORD_LENGTH) + BYTE_WORD_LENGTH);
-      msg = msg + word[0] + word[BYTE_WORD_LENGTH - 1];
+      msg.write(word[0]);
+      msg.write(word[BYTE_WORD_LENGTH - 1]);
     }
 
-    return msg;
+    return msg.toString();
   }
 
   static List<int> _lookUpTable = [];

--- a/packages/bc_ur_dart/lib/src/utils/error.dart
+++ b/packages/bc_ur_dart/lib/src/utils/error.dart
@@ -13,15 +13,14 @@ class InvalidFormatURException extends URException {
 }
 
 class InvalidSequenceURException extends URException {
-  InvalidSequenceURException({required String value}) : super(type: URExceptionType.invalidFormat, message: value);
+  InvalidSequenceURException({required String value}) : super(type: URExceptionType.invalidSequence, message: value);
 }
 
-enum URExceptionType {
-  invalidFormat,
-  invalidSequence,
-  invalidType,
-  invalidParams
+class InvalidChecksumURException extends URException {
+  InvalidChecksumURException({required String value}) : super(type: URExceptionType.invalidChecksum, message: value);
 }
+
+enum URExceptionType { invalidFormat, invalidSequence, invalidType, invalidParams, invalidChecksum }
 
 extension _URExceptionTypeExtension on URExceptionType {
   String toPrettyDescription() {
@@ -34,6 +33,8 @@ extension _URExceptionTypeExtension on URExceptionType {
         return 'Invalid Type';
       case URExceptionType.invalidParams:
         return 'Invalid Params';
+      case URExceptionType.invalidChecksum:
+        return 'Invalid Checksum';
     }
   }
 }

--- a/packages/bc_ur_dart/lib/src/utils/type.dart
+++ b/packages/bc_ur_dart/lib/src/utils/type.dart
@@ -1,4 +1,4 @@
-final RegExp _urExp = RegExp(r'^ur:([a-z\-]+)(/(\d+-\d+)){0,1}/([a-z]+)$');
+final RegExp _urExp = RegExp(r'^ur:([a-z0-9-]+)(/(\d+-\d+)){0,1}/([a-z]+)$');
 
 extension URType on String {
   bool get isUR => _urExp.hasMatch(toLowerCase());

--- a/packages/bc_ur_dart/test/golden_vectors_test.dart
+++ b/packages/bc_ur_dart/test/golden_vectors_test.dart
@@ -1,0 +1,104 @@
+// BCR cross-implementation golden vectors.
+//
+// SOURCE: Blockchain Commons "Wolf" test vectors, published in
+//   https://github.com/BlockchainCommons/bc-ur  (mirrored in bc-ur-rust, URKit).
+// Verified: 2026-06-30; see docs/superpowers/plans/2026-06-30-ur-protocol-correctness.md
+// for provenance details. These tests are hermetic: normal local/CI runs must
+// not fetch the network.
+// These expected values are copied from that upstream reference and MUST NOT be
+// regenerated from bc_ur_dart. They verify protocol compatibility (BCR-2020-005,
+// BCR-2020-012, BCR-2024-001), not internal round-trip consistency.
+
+import 'dart:typed_data';
+
+import 'package:bc_ur_dart/src/ur.dart';
+import 'package:bc_ur_dart/src/utils/byte_words.dart';
+import 'package:convert/convert.dart';
+import 'package:test/test.dart';
+
+void main() {
+  const payload50Hex = '5832916ec65cf77cadf55cd7f9cda1a1030026ddd42e905b77adc36e4f2d3ccba44f7f04f2de44f42d84c374a0e149136f25b018';
+  const payload50Words = 'hdeymejtswhhylkepmykhhtsytsnoyoyaxaedsuttydmmhhpktpmsrjtgwdpfnsboxgwlbaawzuefywkdplrsrjynbvygabwjldapfcsdwkbrkch';
+  const singlePartUR = 'UR:BYTES/HDEYMEJTSWHHYLKEPMYKHHTSYTSNOYOYAXAEDSUTTYDMMHHPKTPMSRJTGWDPFNSBOXGWLBAAWZUEFYWKDPLRSRJYNBVYGABWJLDAPFCSDWKBRKCH';
+
+  const payload256Hex =
+      '590100916ec65cf77cadf55cd7f9cda1a1030026ddd42e905b77adc36e4f2d3ccba44f7f04f2de44f42d84c374a0e149136f25b01852545961d55f7f7a8cde6d0e2ec43f3b2dcb644a2209e8c9e34af5c4747984a5e873c9cf5f965e25ee29039fdf8ca74f1c769fc07eb7ebaec46e0695aea6cbd60b3ec4bbff1b9ffe8a9e7240129377b9d3711ed38d412fbb4442256f1e6f595e0fc57fed451fb0a0101fb76b1fb1e1b88cfdfdaa946294a47de8fff173f021c0e6f65b05c0a494e50791270a0050a73ae69b6725505a2ec8a5791457c9876dd34aadd192a53aa0dc66b556c0c215c7ceb8248b717c22951e65305b56a3706e3e86eb01c803bbf915d80edcd64d4d';
+
+  const expectedParts = <String>[
+    'ur:bytes/1-9/lpadascfadaxcywenbpljkhdcahkadaemejtswhhylkepmykhhtsytsnoyoyaxaedsuttydmmhhpktpmsrjtdkgslpgh',
+    'ur:bytes/2-9/lpaoascfadaxcywenbpljkhdcagwdpfnsboxgwlbaawzuefywkdplrsrjynbvygabwjldapfcsgmghhkhstlrdcxaefz',
+    'ur:bytes/3-9/lpaxascfadaxcywenbpljkhdcahelbknlkuejnbadmssfhfrdpsbiegecpasvssovlgeykssjykklronvsjksopdzmol',
+    'ur:bytes/4-9/lpaaascfadaxcywenbpljkhdcasotkhemthydawydtaxneurlkosgwcekonertkbrlwmplssjtammdplolsbrdzcrtas',
+    'ur:bytes/5-9/lpahascfadaxcywenbpljkhdcatbbdfmssrkzmcwnezelennjpfzbgmuktrhtejscktelgfpdlrkfyfwdajldejokbwf',
+    'ur:bytes/6-9/lpamascfadaxcywenbpljkhdcackjlhkhybssklbwefectpfnbbectrljectpavyrolkzczcpkmwidmwoxkilghdsowp',
+    'ur:bytes/7-9/lpatascfadaxcywenbpljkhdcavszmwnjkwtclrtvaynhpahrtoxmwvwatmedibkaegdosftvandiodagdhthtrlnnhy',
+    'ur:bytes/8-9/lpayascfadaxcywenbpljkhdcadmsponkkbbhgsoltjntegepmttmoonftnbuoiyrehfrtsabzsttorodklubbuyaetk',
+    'ur:bytes/9-9/lpasascfadaxcywenbpljkhdcajskecpmdckihdyhphfotjojtfmlnwmadspaxrkytbztpbauotbgtgtaeaevtgavtny',
+    'ur:bytes/10-9/lpbkascfadaxcywenbpljkhdcahkadaemejtswhhylkepmykhhtsytsnoyoyaxaedsuttydmmhhpktpmsrjtwdkiplzs',
+    'ur:bytes/11-9/lpbdascfadaxcywenbpljkhdcahelbknlkuejnbadmssfhfrdpsbiegecpasvssovlgeykssjykklronvsjkvetiiapk',
+    'ur:bytes/12-9/lpbnascfadaxcywenbpljkhdcarllaluzmdmgstospeyiefmwejlwtpedamktksrvlcygmzemovovllarodtmtbnptrs',
+    'ur:bytes/13-9/lpbtascfadaxcywenbpljkhdcamtkgtpknghchchyketwsvwgwfdhpgmgtylctotzopdrpayoschcmhplffziachrfgd',
+    'ur:bytes/14-9/lpbaascfadaxcywenbpljkhdcapazewnvonnvdnsbyleynwtnsjkjndeoldydkbkdslgjkbbkortbelomueekgvstegt',
+    'ur:bytes/15-9/lpbsascfadaxcywenbpljkhdcaynmhpddpzmversbdqdfyrehnqzlugmjzmnmtwmrouohtstgsbsahpawkditkckynwt',
+    'ur:bytes/16-9/lpbeascfadaxcywenbpljkhdcawygekobamwtlihsnpalnsghenskkiynthdzotsimtojetprsttmukirlrsbtamjtpd',
+    'ur:bytes/17-9/lpbyascfadaxcywenbpljkhdcamklgftaxykpewyrtqzhydntpnytyisincxmhtbceaykolduortotiaiaiafhiaoyce',
+    'ur:bytes/18-9/lpbgascfadaxcywenbpljkhdcahkadaemejtswhhylkepmykhhtsytsnoyoyaxaedsuttydmmhhpktpmsrjtntwkbkwy',
+    'ur:bytes/19-9/lpbwascfadaxcywenbpljkhdcadekicpaajootjzpsdrbalpeywllbdsnbinaerkurspbncxgslgftvtsrjtksplcpeo',
+    'ur:bytes/20-9/lpbbascfadaxcywenbpljkhdcayapmrleeleaxpasfrtrdkncffwjyjzgyetdmlewtkpktgllepfrltataztksmhkbot',
+  ];
+
+  test('GOLDEN Bytewords minimal encode matches upstream (BCR-2020-012)', () {
+    final payload = Uint8List.fromList(hex.decode(payload50Hex));
+    expect(ByteWords.encode(payload), payload50Words);
+    expect(hex.encode(ByteWords.decode(payload50Words)), payload50Hex);
+  });
+
+  test('GOLDEN single-part UR encode matches upstream (BCR-2020-005)', () {
+    final payload = Uint8List.fromList(hex.decode(payload50Hex));
+    final code = UR(type: 'bytes', payload: payload).encode();
+    expect(code, singlePartUR);
+
+    final decoded = UR.decode(singlePartUR);
+    expect(decoded.type, 'bytes');
+    expect(hex.encode(decoded.payload), payload50Hex);
+  });
+
+  test('GOLDEN multipart fixed-rate parts match upstream (BCR-2024-001)', () {
+    final payload = Uint8List.fromList(hex.decode(payload256Hex));
+    final encoder = UR(type: 'bytes', payload: payload, maxLength: 30);
+
+    for (var i = 0; i < 9; i++) {
+      expect(
+        encoder.next().toLowerCase(),
+        expectedParts[i],
+        reason: 'fixed-rate part ${i + 1} diverged from upstream vector',
+      );
+    }
+  });
+
+  test('GOLDEN multipart rateless parts match upstream (BCR-2024-001)', () {
+    final payload = Uint8List.fromList(hex.decode(payload256Hex));
+    final encoder = UR(type: 'bytes', payload: payload, maxLength: 30);
+
+    for (var i = 0; i < 9; i++) {
+      encoder.next();
+    }
+    for (var i = 9; i < expectedParts.length; i++) {
+      expect(
+        encoder.next().toLowerCase(),
+        expectedParts[i],
+        reason: 'rateless part ${i + 1} diverged from upstream vector',
+      );
+    }
+  });
+
+  test('GOLDEN decode of upstream multipart parts recovers exact payload', () {
+    final decoder = UR(maxLength: 30);
+    for (final part in expectedParts) {
+      decoder.read(part);
+      if (decoder.isComplete) break;
+    }
+    expect(decoder.isComplete, isTrue);
+    expect(hex.encode(decoder.payload), payload256Hex);
+  });
+}

--- a/packages/bc_ur_dart/test/ur_test.dart
+++ b/packages/bc_ur_dart/test/ur_test.dart
@@ -2,14 +2,18 @@ import 'dart:typed_data';
 
 import 'package:bc_ur_dart/src/models/common/fragment.dart';
 import 'package:bc_ur_dart/src/ur.dart';
+import 'package:bc_ur_dart/src/utils/byte_words.dart';
+import 'package:cbor/cbor.dart';
 import 'package:convert/convert.dart';
 import 'package:test/test.dart';
 
 void main() {
   test('Encode/Decode single part UR', () {
     final type = 'bytes';
-    final payload = '5832916ec65cf77cadf55cd7f9cda1a1030026ddd42e905b77adc36e4f2d3ccba44f7f04f2de44f42d84c374a0e149136f25b018';
-    final code = 'ur:bytes/hdeymejtswhhylkepmykhhtsytsnoyoyaxaedsuttydmmhhpktpmsrjtgwdpfnsboxgwlbaawzuefywkdplrsrjynbvygabwjldapfcsdwkbrkch';
+    final payload =
+        '5832916ec65cf77cadf55cd7f9cda1a1030026ddd42e905b77adc36e4f2d3ccba44f7f04f2de44f42d84c374a0e149136f25b018';
+    final code =
+        'ur:bytes/hdeymejtswhhylkepmykhhtsytsnoyoyaxaedsuttydmmhhpktpmsrjtgwdpfnsboxgwlbaawzuefywkdplrsrjynbvygabwjldapfcsdwkbrkch';
     final ur = UR.decode(code);
 
     expect(ur.type, type);
@@ -66,7 +70,9 @@ void main() {
   });
 
   test('Read rejects corrupt single-part UR without throwing', () {
-    final code = UR(type: 'bytes', payload: Uint8List.fromList([1, 2, 3, 4])).encode().toLowerCase();
+    final code = UR(type: 'bytes', payload: Uint8List.fromList([1, 2, 3, 4]))
+        .encode()
+        .toLowerCase();
     final corrupt = '${code.substring(0, code.length - 2)}aa';
     final ur = UR();
 
@@ -76,7 +82,8 @@ void main() {
   });
 
   test('Read rejects corrupt multipart reassembly and can recover', () {
-    final payload = Uint8List.fromList(List.generate(128, (i) => (i * 17 + 3) & 0xff));
+    final payload =
+        Uint8List.fromList(List.generate(128, (i) => (i * 17 + 3) & 0xff));
     final encoder = UR(type: 'bytes', payload: payload, maxLength: 30);
     final parts = List.generate(20, (_) => encoder.next().toLowerCase());
     final seqLength = FragmentUR.fromUR(ur: UR.decode(parts.first)).seq.length;
@@ -143,7 +150,8 @@ void main() {
   });
 
   test('Large payload round-trips through fragmentation', () {
-    final payload = Uint8List.fromList(List.generate(4096, (i) => (i * 31 + 7) & 0xff));
+    final payload =
+        Uint8List.fromList(List.generate(4096, (i) => (i * 31 + 7) & 0xff));
     final encoder = UR(type: 'bytes', payload: payload, maxLength: 100);
 
     final decoder = UR();
@@ -155,5 +163,90 @@ void main() {
 
     expect(decoder.isComplete, isTrue);
     expect(hex.encode(decoder.payload), hex.encode(payload));
+  });
+
+  test('read() rejects a fragment whose seqLength exceeds the safety cap', () {
+    // A bytewords-valid, field-consistent frame whose seqLength is just above the
+    // 0x10000 cap. Without the cap it is accepted into decode state and _check runs
+    // List.generate(seqLength) — an unbounded allocation on the streaming path.
+    const overCap = 0x10000 + 1;
+    final crafted = Uint8List.fromList(cbor.encode(CborList([
+      CborSmallInt(1),
+      CborInt(BigInt.from(overCap)),
+      CborInt(BigInt.from(overCap)),
+      CborSmallInt(0),
+      CborBytes([0]),
+    ])));
+    final frame =
+        'ur:bytes/1-$overCap/${ByteWords.encode(crafted)}'.toLowerCase();
+
+    final decoder = UR();
+    expect(decoder.read(frame), isFalse);
+    // Must be rejected before any decode state is locked in.
+    expect(decoder.type, isEmpty);
+    expect(decoder.expectedPartIndexes, isEmpty);
+    expect(decoder.isComplete, isFalse);
+  });
+
+  test('read() does not let a single-part frame hijack a multipart decode', () {
+    final multi = Uint8List.fromList(List.generate(120, (i) => (i * 3) & 0xff));
+    final encoder = UR(type: 'bytes', payload: multi, maxLength: 40);
+
+    final decoder = UR();
+    decoder.read(encoder.next()); // start a multipart accumulation
+    expect(decoder.isComplete, isFalse);
+
+    // A valid, unrelated single-part UR must be skipped, not accepted.
+    final stray = UR(type: 'bytes', payload: Uint8List.fromList([9, 9, 9, 9]));
+    expect(decoder.read(stray.encode()), isFalse);
+    expect(decoder.isComplete, isFalse);
+
+    var guard = 0;
+    while (!decoder.isComplete && guard < 5000) {
+      decoder.read(encoder.next());
+      guard++;
+    }
+    expect(decoder.isComplete, isTrue);
+    expect(hex.encode(decoder.payload), hex.encode(multi));
+  });
+
+  test('reset() lets a reused decoder switch to a different message', () {
+    final a = Uint8List.fromList(List.generate(120, (i) => (i * 3) & 0xff));
+    final b = Uint8List.fromList(List.generate(120, (i) => (i * 7 + 1) & 0xff));
+    final encA = UR(type: 'bytes', payload: a, maxLength: 40);
+    final encB = UR(type: 'bytes', payload: b, maxLength: 40);
+
+    final decoder = UR();
+    decoder.read(encA.next()); // lock onto message A
+    expect(decoder.isComplete, isFalse);
+
+    // Without reset, B's fragments are rejected forever (different checksum).
+    decoder.reset();
+
+    var guard = 0;
+    while (!decoder.isComplete && guard < 5000) {
+      decoder.read(encB.next());
+      guard++;
+    }
+    expect(decoder.isComplete, isTrue);
+    expect(hex.encode(decoder.payload), hex.encode(b));
+  });
+
+  test('read() tolerates out-of-range fragment fields without crashing', () {
+    // checksum = 2^32 (> uint32) would drive intToByte(checksum, 4) -> RangeError
+    // (a Dart Error, not a URException) unless fromUR rejects it first.
+    final hugeChecksum = Uint8List.fromList(cbor.encode(CborList([
+      CborSmallInt(1),
+      CborSmallInt(2),
+      CborSmallInt(4),
+      CborInt(BigInt.from(0x100000000)),
+      CborBytes([0, 0, 0, 0]),
+    ])));
+    final frame =
+        'ur:bytes/1-2/${ByteWords.encode(hugeChecksum)}'.toLowerCase();
+
+    final decoder = UR();
+    expect(decoder.read(frame), isFalse);
+    expect(decoder.isComplete, isFalse);
   });
 }

--- a/packages/bc_ur_dart/test/ur_test.dart
+++ b/packages/bc_ur_dart/test/ur_test.dart
@@ -1,3 +1,6 @@
+import 'dart:typed_data';
+
+import 'package:bc_ur_dart/src/models/common/fragment.dart';
 import 'package:bc_ur_dart/src/ur.dart';
 import 'package:convert/convert.dart';
 import 'package:test/test.dart';
@@ -15,7 +18,8 @@ void main() {
   });
 
   test('Encode/Decode multi part UR', () {
-    final payload = '590100916ec65cf77cadf55cd7f9cda1a1030026ddd42e905b77adc36e4f2d3ccba44f7f04f2de44f42d84c374a0e149136f25b01852545961d55f7f7a8cde6d0e2ec43f3b2dcb644a2209e8c9e34af5c4747984a5e873c9cf5f965e25ee29039fdf8ca74f1c769fc07eb7ebaec46e0695aea6cbd60b3ec4bbff1b9ffe8a9e7240129377b9d3711ed38d412fbb4442256f1e6f595e0fc57fed451fb0a0101fb76b1fb1e1b88cfdfdaa946294a47de8fff173f021c0e6f65b05c0a494e50791270a0050a73ae69b6725505a2ec8a5791457c9876dd34aadd192a53aa0dc66b556c0c215c7ceb8248b717c22951e65305b56a3706e3e86eb01c803bbf915d80edcd64d4d';
+    final payload =
+        '590100916ec65cf77cadf55cd7f9cda1a1030026ddd42e905b77adc36e4f2d3ccba44f7f04f2de44f42d84c374a0e149136f25b01852545961d55f7f7a8cde6d0e2ec43f3b2dcb644a2209e8c9e34af5c4747984a5e873c9cf5f965e25ee29039fdf8ca74f1c769fc07eb7ebaec46e0695aea6cbd60b3ec4bbff1b9ffe8a9e7240129377b9d3711ed38d412fbb4442256f1e6f595e0fc57fed451fb0a0101fb76b1fb1e1b88cfdfdaa946294a47de8fff173f021c0e6f65b05c0a494e50791270a0050a73ae69b6725505a2ec8a5791457c9876dd34aadd192a53aa0dc66b556c0c215c7ceb8248b717c22951e65305b56a3706e3e86eb01c803bbf915d80edcd64d4d';
     final parts = [
       'ur:bytes/1-9/lpadascfadaxcywenbpljkhdcahkadaemejtswhhylkepmykhhtsytsnoyoyaxaedsuttydmmhhpktpmsrjtdkgslpgh',
       'ur:bytes/2-9/lpaoascfadaxcywenbpljkhdcagwdpfnsboxgwlbaawzuefywkdplrsrjynbvygabwjldapfcsgmghhkhstlrdcxaefz',
@@ -50,5 +54,106 @@ void main() {
       final item = ur.next();
       expect(item.toLowerCase(), part);
     }
+  });
+
+  test('UR type accepts digits per BCR syntax', () {
+    final payload = Uint8List.fromList([1, 2, 3, 4]);
+    final code = UR(type: 'crypto-psbt2', payload: payload).encode();
+    final decoded = UR.decode(code);
+
+    expect(decoded.type, 'crypto-psbt2');
+    expect(hex.encode(decoded.payload), hex.encode(payload));
+  });
+
+  test('Read rejects corrupt single-part UR without throwing', () {
+    final code = UR(type: 'bytes', payload: Uint8List.fromList([1, 2, 3, 4])).encode().toLowerCase();
+    final corrupt = '${code.substring(0, code.length - 2)}aa';
+    final ur = UR();
+
+    expect(ur.read(corrupt), isFalse);
+    expect(ur.isComplete, isFalse);
+    expect(() => UR.decode(corrupt), throwsException);
+  });
+
+  test('Read rejects corrupt multipart reassembly and can recover', () {
+    final payload = Uint8List.fromList(List.generate(128, (i) => (i * 17 + 3) & 0xff));
+    final encoder = UR(type: 'bytes', payload: payload, maxLength: 30);
+    final parts = List.generate(20, (_) => encoder.next().toLowerCase());
+    final seqLength = FragmentUR.fromUR(ur: UR.decode(parts.first)).seq.length;
+    final corruptParts = parts.map((part) {
+      final fragment = FragmentUR.fromUR(ur: UR.decode(part));
+      return FragmentUR(
+        type: fragment.type,
+        seq: fragment.seq,
+        messageLength: fragment.messageLength,
+        checksum: fragment.checksum ^ 1,
+        part: fragment.part,
+      ).encode();
+    }).toList();
+
+    final decoder = UR(maxLength: 30);
+    for (final part in corruptParts.take(seqLength)) {
+      decoder.read(part);
+      if (decoder.isComplete) break;
+    }
+    expect(decoder.isComplete, isFalse);
+
+    for (final part in parts) {
+      decoder.read(part);
+      if (decoder.isComplete) break;
+    }
+    expect(decoder.isComplete, isTrue);
+    expect(hex.encode(decoder.payload), hex.encode(payload));
+  });
+
+  test('Out-of-order fragments recover the payload', () {
+    final payload =
+        '590100916ec65cf77cadf55cd7f9cda1a1030026ddd42e905b77adc36e4f2d3ccba44f7f04f2de44f42d84c374a0e149136f25b01852545961d55f7f7a8cde6d0e2ec43f3b2dcb644a2209e8c9e34af5c4747984a5e873c9cf5f965e25ee29039fdf8ca74f1c769fc07eb7ebaec46e0695aea6cbd60b3ec4bbff1b9ffe8a9e7240129377b9d3711ed38d412fbb4442256f1e6f595e0fc57fed451fb0a0101fb76b1fb1e1b88cfdfdaa946294a47de8fff173f021c0e6f65b05c0a494e50791270a0050a73ae69b6725505a2ec8a5791457c9876dd34aadd192a53aa0dc66b556c0c215c7ceb8248b717c22951e65305b56a3706e3e86eb01c803bbf915d80edcd64d4d';
+    final parts = [
+      'ur:bytes/1-9/lpadascfadaxcywenbpljkhdcahkadaemejtswhhylkepmykhhtsytsnoyoyaxaedsuttydmmhhpktpmsrjtdkgslpgh',
+      'ur:bytes/2-9/lpaoascfadaxcywenbpljkhdcagwdpfnsboxgwlbaawzuefywkdplrsrjynbvygabwjldapfcsgmghhkhstlrdcxaefz',
+      'ur:bytes/3-9/lpaxascfadaxcywenbpljkhdcahelbknlkuejnbadmssfhfrdpsbiegecpasvssovlgeykssjykklronvsjksopdzmol',
+      'ur:bytes/4-9/lpaaascfadaxcywenbpljkhdcasotkhemthydawydtaxneurlkosgwcekonertkbrlwmplssjtammdplolsbrdzcrtas',
+      'ur:bytes/5-9/lpahascfadaxcywenbpljkhdcatbbdfmssrkzmcwnezelennjpfzbgmuktrhtejscktelgfpdlrkfyfwdajldejokbwf',
+      'ur:bytes/6-9/lpamascfadaxcywenbpljkhdcackjlhkhybssklbwefectpfnbbectrljectpavyrolkzczcpkmwidmwoxkilghdsowp',
+      'ur:bytes/7-9/lpatascfadaxcywenbpljkhdcavszmwnjkwtclrtvaynhpahrtoxmwvwatmedibkaegdosftvandiodagdhthtrlnnhy',
+      'ur:bytes/8-9/lpayascfadaxcywenbpljkhdcadmsponkkbbhgsoltjntegepmttmoonftnbuoiyrehfrtsabzsttorodklubbuyaetk',
+      'ur:bytes/9-9/lpasascfadaxcywenbpljkhdcajskecpmdckihdyhphfotjojtfmlnwmadspaxrkytbztpbauotbgtgtaeaevtgavtny',
+      'ur:bytes/10-9/lpbkascfadaxcywenbpljkhdcahkadaemejtswhhylkepmykhhtsytsnoyoyaxaedsuttydmmhhpktpmsrjtwdkiplzs',
+      'ur:bytes/11-9/lpbdascfadaxcywenbpljkhdcahelbknlkuejnbadmssfhfrdpsbiegecpasvssovlgeykssjykklronvsjkvetiiapk',
+      'ur:bytes/12-9/lpbnascfadaxcywenbpljkhdcarllaluzmdmgstospeyiefmwejlwtpedamktksrvlcygmzemovovllarodtmtbnptrs',
+      'ur:bytes/13-9/lpbtascfadaxcywenbpljkhdcamtkgtpknghchchyketwsvwgwfdhpgmgtylctotzopdrpayoschcmhplffziachrfgd',
+      'ur:bytes/14-9/lpbaascfadaxcywenbpljkhdcapazewnvonnvdnsbyleynwtnsjkjndeoldydkbkdslgjkbbkortbelomueekgvstegt',
+      'ur:bytes/15-9/lpbsascfadaxcywenbpljkhdcaynmhpddpzmversbdqdfyrehnqzlugmjzmnmtwmrouohtstgsbsahpawkditkckynwt',
+      'ur:bytes/16-9/lpbeascfadaxcywenbpljkhdcawygekobamwtlihsnpalnsghenskkiynthdzotsimtojetprsttmukirlrsbtamjtpd',
+      'ur:bytes/17-9/lpbyascfadaxcywenbpljkhdcamklgftaxykpewyrtqzhydntpnytyisincxmhtbceaykolduortotiaiaiafhiaoyce',
+      'ur:bytes/18-9/lpbgascfadaxcywenbpljkhdcahkadaemejtswhhylkepmykhhtsytsnoyoyaxaedsuttydmmhhpktpmsrjtntwkbkwy',
+      'ur:bytes/19-9/lpbwascfadaxcywenbpljkhdcadekicpaajootjzpsdrbalpeywllbdsnbinaerkurspbncxgslgftvtsrjtksplcpeo',
+      'ur:bytes/20-9/lpbbascfadaxcywenbpljkhdcayapmrleeleaxpasfrtrdkncffwjyjzgyetdmlewtkpktgllepfrltataztksmhkbot'
+    ];
+
+    final ur = UR(maxLength: 30);
+    for (final part in parts.reversed) {
+      ur.read(part);
+      if (ur.isComplete) break;
+    }
+
+    expect(ur.isComplete, isTrue);
+    expect(hex.encode(ur.payload), payload);
+  });
+
+  test('Large payload round-trips through fragmentation', () {
+    final payload = Uint8List.fromList(List.generate(4096, (i) => (i * 31 + 7) & 0xff));
+    final encoder = UR(type: 'bytes', payload: payload, maxLength: 100);
+
+    final decoder = UR();
+    var guard = 0;
+    while (!decoder.isComplete) {
+      decoder.read(encoder.next());
+      if (++guard > 10000) fail('Did not complete within fountain budget');
+    }
+
+    expect(decoder.isComplete, isTrue);
+    expect(hex.encode(decoder.payload), hex.encode(payload));
   });
 }

--- a/packages/bc_ur_dart/test/utils/byte_words_test.dart
+++ b/packages/bc_ur_dart/test/utils/byte_words_test.dart
@@ -5,8 +5,10 @@ import 'package:convert/convert.dart';
 import 'package:test/test.dart';
 
 void main() {
-  final words = 'yktsbbswwnwmfefrttsnonbgmtnnjyltvwtybwnebydawswtzcbdjnrsdawzdsksurdtnsrywzzemusffwottppersfdptencxfnmhvatdldroskcljshdbantctpadmadjksnfevymtfpwmftmhfpwtlpfejsylfhecwzonnbmhcybtgwwelpflgmfezeonledtgocsfzhycypf';
-  final input = 'f5d714c6f1eb453bd1cda512969e7487e5d4139f1125eff0fd0b6dbf25f22678df299cbdf2fe93cc42a3d8afbf48a936203c90e6d289b8c52171580e9d1fb12e0173cd45e19641eb3a9041f0854571f73f35f2a5a0901a0d4fed85475245fea58a295518';
+  final words =
+      'yktsbbswwnwmfefrttsnonbgmtnnjyltvwtybwnebydawswtzcbdjnrsdawzdsksurdtnsrywzzemusffwottppersfdptencxfnmhvatdldroskcljshdbantctpadmadjksnfevymtfpwmftmhfpwtlpfejsylfhecwzonnbmhcybtgwwelpflgmfezeonledtgocsfzhycypf';
+  final input =
+      'f5d714c6f1eb453bd1cda512969e7487e5d4139f1125eff0fd0b6dbf25f22678df299cbdf2fe93cc42a3d8afbf48a936203c90e6d289b8c52171580e9d1fb12e0173cd45e19641eb3a9041f0854571f73f35f2a5a0901a0d4fed85475245fea58a295518';
 
   test('Byte words encode', () {
     final result = ByteWords.encode(Uint8List.fromList(hex.decode(input)));
@@ -16,5 +18,13 @@ void main() {
   test('Byte words decode', () {
     final result = ByteWords.decode(words);
     expect(hex.encode(result), input);
+  });
+
+  test('Byte words decode rejects malformed and corrupt input', () {
+    expect(() => ByteWords.decode('wolf'), throwsException);
+    expect(() => ByteWords.decode('${words.substring(0, words.length - 2)}aa'),
+        throwsException);
+    expect(() => ByteWords.decode('${words}a'), throwsException);
+    expect(() => ByteWords.decode('${words}12'), throwsException);
   });
 }


### PR DESCRIPTION
## Summary

Makes `bc_ur_dart` **reject corrupt UR strings and corrupt fragments instead of silently accepting them**, fixes the mixed (fountain) fragment reduction logic, and removes O(n²) hot paths in ByteWords encoding — all proven by new corruption / out-of-order / mixed / large-payload / BCR-golden-vector tests.

Because this is a **cold-signing library**, silently accepting corrupt data can mean signing the wrong transaction. Verification is therefore strict on single-shot decode, while the streaming `read()` path stays tolerant (skips bad frames, never throws) so animated-QR scanning is not broken.


## Changes 

| Task | Change | File(s) |
|------|--------|---------|
| 1 | Add `invalidChecksum` enum + `InvalidChecksumURException` | `lib/src/utils/error.dart` |
| 2 | Align UR type syntax with BCR (`[a-z0-9-]`, allow digits) | `lib/src/utils/type.dart` |
| 3 | Strict full-consumption parsing + CRC32 verification in `ByteWords.decode` | `lib/src/utils/byte_words.dart` |
| 4 | Replace O(n²) string building with `StringBuffer` in `ByteWords.encode` (byte-identical output) | `lib/src/utils/byte_words.dart` |
| 5 | Fix mixed-fragment reduction: queue the **reduced** part, carry source message-level `checksum`/`messageLength` | `lib/src/ur.dart` |
| 6 | Verify reassembled payload checksum; streaming-tolerant `read()` + single-part hijack guard + public `reset()`; parsers on the read path throw only `URException` | `lib/src/ur.dart`, `lib/src/models/common/seq.dart`, `lib/src/models/common/fragment.dart` |
| Tests | Corruption / out-of-order / mixed / large-payload + BCR golden vectors | `test/ur_test.dart`, `test/utils/byte_words_test.dart`, `test/golden_vectors_test.dart` |

## Sources & provenance

All standards constraints and golden values trace to Blockchain Commons specs and the bc-ur reference implementation (verified live over HTTPS on 2026-06-30, per the plan's *Sources & Provenance* section):

- **BCR-2020-005 (Uniform Resources)** — UR type charset: *"Types MUST consist only of characters from the English letters (ignoring case), Arabic numerals, and the hyphen `-`."* → Task 2.
  `raw.githubusercontent.com/BlockchainCommons/Research/master/papers/bcr-2020-005-ur.md`
- **BCR-2020-012 (Bytewords)** — *"…followed by a four-word (four byte, 32 bit) CRC32 checksum in network order (big-endian)."* → Task 3.
  `raw.githubusercontent.com/BlockchainCommons/Research/master/papers/bcr-2020-012-bytewords.md`
- **BCR-2024-001 (Multipart UR / MUR)** — fixed-rate + rateless fountain reduction; reduce mixed parts with known simple parts until convergence. → Tasks 5/6.
  `raw.githubusercontent.com/BlockchainCommons/Research/master/papers/bcr-2024-001-multipart-ur.md`
- **bc-ur (C++ reference)** — authoritative "Wolf" test vectors + fail-closed decode behavior (`Bytewords::decode` throws on malformed/invalid-checksum input; `FountainDecoder::reduce_mixed_by` enqueues the **reduced** part at `fountain-decoder.cpp:100-105`). → Task 5 + Task 10 golden vectors.
  `raw.githubusercontent.com/BlockchainCommons/bc-ur/master/test/test.cpp`

The "Wolf" golden vectors (`payload50Hex`, `payload256Hex`, single-part bytewords, the 20 `expectedParts`) were confirmed **verbatim in `BlockchainCommons/bc-ur/test/test.cpp`** — upstream values, not self-round-trips.

## Compatibility notes

- **Strict about integrity, conformant about spec-permitted syntax.** CRC/checksum/field-range checks never reject conformant input (CRC-32 is deterministic). The type charset was widened to match the spec, not narrowed as a filter.
- **`read()` tolerant, `decode()` strict.** `read()` returns `false` on any un-usable frame (malformed, failed CRC, bad CBOR, metadata mismatch, failed reassembly checksum) and never throws for data-quality problems; single-shot `UR.decode` / `ByteWords.decode` still throw `InvalidChecksumURException`. All read-path parsers were hardened to throw only `URException` (no raw `FormatException`/`TypeError`/`RangeError`/OOM escaping the scan loop).
- **Decoder lifecycle:** a decoder locks onto the first message's metadata; stray single-part frames mid-scan are rejected; call public `reset()` to switch messages.

## Testing

New tests cover: ByteWords corruption / too-short / malformed rejection, UR digit-type acceptance, mixed-fragment recovery of a missing simple part, tampered-reassembly rejection without throwing, garbage-frame skipping, out-of-range fragment fields, single-part hijack guard, `reset()`, and BCR golden vectors (single-part / fixed-rate multipart / rateless / decode).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
