### PR TITLE
fix: LTC P2SH 地址解析 & chain-aware 地址编码

### DIFF
--- a/packages/crypto_wallet_util/CHANGELOG.md
+++ b/packages/crypto_wallet_util/CHANGELOG.md
@@ -287,6 +287,18 @@
 - No public API changes beyond the SDK floor; all 782 unit tests pass.
 
 
+## [2.0.2] - 2026-07-02
+### Fixed
+
+- PSBT: parse LTC P2SH / Nested SegWit addresses correctly by plumbing chain-aware
+  version bytes and bech32 HRP through address encoding instead of hard-coding BTC
+  mainnet values.
+- GSPL: support LTC P2SH payment address parsing by detecting the script type
+  (P2PKH vs P2SH) and resolving the correct network version bytes from the bip44
+  path coin-type segment.
+- BTC / LTC chain configs: fill in distinct testnet NetworkType values (previously
+  shared mainnet settings).
+
 ## [2.0.1] - 2026-06-12
 ### Added
 

--- a/packages/crypto_wallet_util/lib/src/config/chain/btc/btc.dart
+++ b/packages/crypto_wallet_util/lib/src/config/chain/btc/btc.dart
@@ -1,8 +1,8 @@
 import 'package:crypto_wallet_util/crypto_utils.dart';
 import 'package:crypto_wallet_util/src/forked_lib/bitcoin_flutter/bitcoin_flutter.dart';
 
-/// Provide default config for **btc**, address type is [AddressType.BTC], bip44 path is [BTC_PATH].  
-/// Testnet and mainnet share the same setting. Use [HDWallet] to to instantiate wallet.
+/// Provide default config for **btc**, address type is [AddressType.BTC], bip44 path is [BTC_PATH].
+/// Testnet uses distinct version bytes, WIF, and bech32 HRP from mainnet. Use [HDWallet] to instantiate wallet.
 class BTCChain extends ConfChain {
   BTCChain()
       : super(
@@ -23,10 +23,10 @@ class BTCChain extends ConfChain {
               addressType: AddressType.BTC,
               networkType: NetworkType(
                   messagePrefix: '\u0018Bitcoin Signed Message:\n',
-                  bech32: 'bc',
-                  wif: 128,
-                  pubKeyHash: 0,
-                  scriptHash: 5,
-                  bip32: Bip32Type(public: 76067358, private: 76066276)),
+                  bech32: 'tb',
+                  wif: 239,
+                  pubKeyHash: 0x6f,
+                  scriptHash: 0xc4,
+                  bip32: Bip32Type(public: 70617704, private: 70615956)),
             ));
 }

--- a/packages/crypto_wallet_util/lib/src/config/chain/btc/ltc.dart
+++ b/packages/crypto_wallet_util/lib/src/config/chain/btc/ltc.dart
@@ -1,8 +1,8 @@
 import 'package:crypto_wallet_util/crypto_utils.dart';
 import 'package:crypto_wallet_util/src/forked_lib/bitcoin_flutter/bitcoin_flutter.dart';
 
-/// Provide default config for **ltc**, address type is [AddressType.BTC], bip44 path is [LTC_PATH].  
-/// Testnet and mainnet share the same setting. Use [HDWallet] to to instantiate wallet.
+/// Provide default config for **ltc**, address type is [AddressType.BTC], bip44 path is [LTC_PATH].
+/// Testnet uses distinct version bytes, WIF, and bech32 HRP from mainnet. Use [HDWallet] to instantiate wallet.
 class LTCChain extends ConfChain {
   LTCChain()
       : super(
@@ -23,10 +23,10 @@ class LTCChain extends ConfChain {
               addressType: AddressType.BTC,
               networkType: NetworkType(
                   messagePrefix: '\x19Litecoin Signed Message:\n',
-                  bech32: 'ltc',
-                  wif: 0xb0,
-                  pubKeyHash: 0x30,
-                  scriptHash: 0x32,
-                  bip32: Bip32Type(public: 0x019da462, private: 0x019d9cfe)),
+                  bech32: 'tltc',
+                  wif: 0xef,
+                  pubKeyHash: 0x6f,
+                  scriptHash: 0x3a,
+                  bip32: Bip32Type(public: 0x0436ef9d, private: 0x0436f6e1)),
             ));
 }

--- a/packages/crypto_wallet_util/lib/src/forked_lib/psbt/transaction/partially_signed_bitcoin_transaction.dart
+++ b/packages/crypto_wallet_util/lib/src/forked_lib/psbt/transaction/partially_signed_bitcoin_transaction.dart
@@ -78,20 +78,22 @@ class PSBT {
         return fee;
       }();
 
-  List<String> get inputAddresses => () {
+  List<String> get inputAddresses => getInputAddresses();
+
+  List<String> getInputAddresses({bool isTestnet = false, String chain = 'btc'}) {
         List<String> inputAddresses = [];
         for (int i = 0; i < inputs.length; i++) {
           PsbtInput input = inputs[i];
 
           if (input.witnessUtxo != null) {
             //  witnessUtxo (PSBT key type 01)
-            inputAddresses.add(input.witnessUtxo!.getAddress());
+            inputAddresses.add(input.witnessUtxo!.getAddress(isTestnet: isTestnet, chain: chain));
           } else if (input.previousTransaction != null) {
             // nonWitnessUtxo (PSBT key type 00)
             Transaction prevTx = input.previousTransaction!;
             int outputIndex = unsignedTransaction!.inputs[i].index;
             if (outputIndex < prevTx.outputs.length) {
-              inputAddresses.add(prevTx.outputs[outputIndex].getAddress());
+              inputAddresses.add(prevTx.outputs[outputIndex].getAddress(isTestnet: isTestnet, chain: chain));
             } else {
               throw Exception(
                   'Invalid output index $outputIndex in previous transaction');
@@ -101,15 +103,18 @@ class PSBT {
           }
         }
         return inputAddresses;
-      }();
+      }
+
+  int get transferAmount => getTransferAmount();
 
   /// Get the transfer amount of the transaction.
-  int get transferAmount => () {
+  int getTransferAmount({bool isTestnet = false, String chain = 'btc'}) {
         int totalAmount = 0;
         int sameCount = 0;
+        final currentInputAddresses = getInputAddresses(isTestnet: isTestnet, chain: chain);
         for (int i = 0; i < unsignedTransaction!.outputs.length; i++) {
-          String outputAddress = unsignedTransaction!.outputs[i].getAddress();
-          if (!inputAddresses.contains(outputAddress)) {
+          String outputAddress = unsignedTransaction!.outputs[i].getAddress(isTestnet: isTestnet, chain: chain);
+          if (!currentInputAddresses.contains(outputAddress)) {
             totalAmount += unsignedTransaction!.outputs[i].amount;
           } else {
             sameCount++;
@@ -120,7 +125,7 @@ class PSBT {
         }
 
         return totalAmount;
-      }();
+      }
 
   /// Get the sending amount of the transaction.
   int get sendingAmount => () {
@@ -781,9 +786,17 @@ class PsbtOutput {
   int? get amount => _amount;
   String? get script => _script;
 
-  String getAddress() {
+  String getAddress({bool isTestnet = false, String chain = 'btc'}) {
     ScriptPublicKey script = ScriptPublicKey.parse(_script!);
-    return script.getAddress();
+    final chainConf = getChainConfig(chain);
+    final networkType = isTestnet
+        ? chainConf.testnet.networkType
+        : chainConf.mainnet.networkType;
+    return script.getAddress(
+        isTestnet: isTestnet,
+        pubKeyHashVersion: networkType?.pubKeyHash ?? 0x00,
+        scriptHashVersion: networkType?.scriptHash ?? 0x05,
+        bech32Hrp: networkType?.bech32 ?? 'bc');
   }
 
   /// @nodoc

--- a/packages/crypto_wallet_util/lib/src/forked_lib/psbt/transaction/script_public_key.dart
+++ b/packages/crypto_wallet_util/lib/src/forked_lib/psbt/transaction/script_public_key.dart
@@ -2,7 +2,6 @@ import 'dart:typed_data';
 
 import 'package:bech32m_i/bech32m_i.dart' as bech32m;
 import 'package:bs58check/bs58check.dart';
-import 'package:crypto_wallet_util/src/forked_lib/psbt/network/bitcoin_network.dart';
 import 'package:crypto_wallet_util/src/utils/bech32/bech32.dart';
 
 import 'package:crypto_wallet_util/src/utils/utils.dart';
@@ -59,54 +58,41 @@ class ScriptPublicKey extends Script {
     ]);
   }
 
-  String _getSegwitHrp({bool isTestnet = false}) {
-    String hrp;
-    if (!isTestnet) {
-      hrp = 'bc';
-    } else if (BitcoinNetwork.currentNetwork == BitcoinNetwork.testnet) {
-      hrp = 'tb';
-    } else {
-      hrp = 'bcrt';
-    }
-
-    return hrp;
-  }
-
   /// Get the address from the script.
-  String getAddress({bool isTestnet = false}) {
-    //todo: other address type
+  /// [pubKeyHashVersion], [scriptHashVersion], [bech32Hrp] default to Bitcoin mainnet values.
+  /// Pass chain-specific values for other chains (e.g. LTC: 0x30, 0x32, 'ltc').
+  /// [isTestnet] is deprecated — prefer passing explicit version bytes via [TransactionOutput.getAddress].
+  String getAddress(
+      {bool isTestnet = false,
+      int pubKeyHashVersion = 0x00,
+      int scriptHashVersion = 0x05,
+      String bech32Hrp = 'bc'}) {
     if (isP2WPKH()) {
-      String hrp = _getSegwitHrp(isTestnet: isTestnet);
-
       Uint8List h160 = commands[1];
       var data5Bits =
           Converter.convertBits(Uint8List.fromList(h160), 8, 5, pad: true);
-      return bech32.encode(Bech32(hrp, [0x00] + data5Bits));
+      return bech32.encode(Bech32(bech32Hrp, [0x00] + data5Bits));
     } else if (isP2PKH()) {
-      Uint8List prefix =
-          isTestnet ? Uint8List.fromList([0x6f]) : Uint8List.fromList([0x00]);
+      Uint8List prefix = Uint8List.fromList([pubKeyHashVersion]);
       Uint8List h160 = commands[2];
       Uint8List prefixedHash = Uint8List.fromList(prefix + h160);
       return getBase58Address(prefixedHash);
     } else if (isP2SH()) {
-      Uint8List prefix =
-          isTestnet ? Uint8List.fromList([0xc4]) : Uint8List.fromList([0x05]);
+      Uint8List prefix = Uint8List.fromList([scriptHashVersion]);
       Uint8List h160 = commands[1];
       Uint8List prefixedHash = Uint8List.fromList(prefix + h160);
       return getBase58Address(prefixedHash);
     } else if (isP2TR()) {
-      String hrp = _getSegwitHrp(isTestnet: isTestnet);
       Uint8List h256 = commands[1];
       var data5Bits =
           Converter.convertBits(Uint8List.fromList(h256), 8, 5, pad: true);
       bech32m.Bech32mCodec codec = const bech32m.Bech32mCodec();
-      return codec.encode(bech32m.Bech32m(hrp, [0x01] + data5Bits));
+      return codec.encode(bech32m.Bech32m(bech32Hrp, [0x01] + data5Bits));
     } else if (isP2WSH()) {
-      String hrp = _getSegwitHrp(isTestnet: isTestnet);
       Uint8List h256 = commands[1];
       var data5Bits =
           Converter.convertBits(Uint8List.fromList(h256), 8, 5, pad: true);
-      return bech32.encode(Bech32(hrp, [0x00] + data5Bits));
+      return bech32.encode(Bech32(bech32Hrp, [0x00] + data5Bits));
     } else {
       return 'Script : Non-standard script.';
     }

--- a/packages/crypto_wallet_util/lib/src/forked_lib/psbt/transaction/script_public_key.dart
+++ b/packages/crypto_wallet_util/lib/src/forked_lib/psbt/transaction/script_public_key.dart
@@ -59,26 +59,28 @@ class ScriptPublicKey extends Script {
   }
 
   /// Get the address from the script.
-  /// [pubKeyHashVersion], [scriptHashVersion], [bech32Hrp] default to Bitcoin mainnet values.
-  /// Pass chain-specific values for other chains (e.g. LTC: 0x30, 0x32, 'ltc').
-  /// [isTestnet] is deprecated — prefer passing explicit version bytes via [TransactionOutput.getAddress].
+  /// [pubKeyHashVersion], [scriptHashVersion], [bech32Hrp] default to null —
+  /// when omitted, fall back to BTC mainnet/testnet values based on [isTestnet].
   String getAddress(
       {bool isTestnet = false,
-      int pubKeyHashVersion = 0x00,
-      int scriptHashVersion = 0x05,
-      String bech32Hrp = 'bc'}) {
+      int? pubKeyHashVersion,
+      int? scriptHashVersion,
+      String? bech32Hrp}) {
+    final pkhVersion = pubKeyHashVersion ?? (isTestnet ? 0x6f : 0x00);
+    final shVersion = scriptHashVersion ?? (isTestnet ? 0xc4 : 0x05);
+    final hrp = bech32Hrp ?? (isTestnet ? 'tb' : 'bc');
     if (isP2WPKH()) {
       Uint8List h160 = commands[1];
       var data5Bits =
           Converter.convertBits(Uint8List.fromList(h160), 8, 5, pad: true);
-      return bech32.encode(Bech32(bech32Hrp, [0x00] + data5Bits));
+      return bech32.encode(Bech32(hrp, [0x00] + data5Bits));
     } else if (isP2PKH()) {
-      Uint8List prefix = Uint8List.fromList([pubKeyHashVersion]);
+      Uint8List prefix = Uint8List.fromList([pkhVersion]);
       Uint8List h160 = commands[2];
       Uint8List prefixedHash = Uint8List.fromList(prefix + h160);
       return getBase58Address(prefixedHash);
     } else if (isP2SH()) {
-      Uint8List prefix = Uint8List.fromList([scriptHashVersion]);
+      Uint8List prefix = Uint8List.fromList([shVersion]);
       Uint8List h160 = commands[1];
       Uint8List prefixedHash = Uint8List.fromList(prefix + h160);
       return getBase58Address(prefixedHash);
@@ -87,12 +89,12 @@ class ScriptPublicKey extends Script {
       var data5Bits =
           Converter.convertBits(Uint8List.fromList(h256), 8, 5, pad: true);
       bech32m.Bech32mCodec codec = const bech32m.Bech32mCodec();
-      return codec.encode(bech32m.Bech32m(bech32Hrp, [0x01] + data5Bits));
+      return codec.encode(bech32m.Bech32m(hrp, [0x01] + data5Bits));
     } else if (isP2WSH()) {
       Uint8List h256 = commands[1];
       var data5Bits =
           Converter.convertBits(Uint8List.fromList(h256), 8, 5, pad: true);
-      return bech32.encode(Bech32(bech32Hrp, [0x00] + data5Bits));
+      return bech32.encode(Bech32(hrp, [0x00] + data5Bits));
     } else {
       return 'Script : Non-standard script.';
     }

--- a/packages/crypto_wallet_util/lib/src/forked_lib/psbt/transaction/transaction_output.dart
+++ b/packages/crypto_wallet_util/lib/src/forked_lib/psbt/transaction/transaction_output.dart
@@ -1,5 +1,6 @@
 import 'dart:typed_data';
 
+import 'package:crypto_wallet_util/src/config/config.dart';
 import '../transaction/script_public_key.dart';
 import '../utils/converter.dart';
 
@@ -58,7 +59,16 @@ class TransactionOutput {
   }
 
   /// Get the address of the transaction output.
-  String getAddress({bool isTestnet = false}) {
-    return _scriptPubKey.getAddress(isTestnet: isTestnet);
+  /// [chain] is used to look up the correct version bytes for address encoding.
+  String getAddress({bool isTestnet = false, String chain = 'btc'}) {
+    final chainConf = getChainConfig(chain);
+    final networkType = isTestnet
+        ? chainConf.testnet.networkType
+        : chainConf.mainnet.networkType;
+    return _scriptPubKey.getAddress(
+        isTestnet: isTestnet,
+        pubKeyHashVersion: networkType?.pubKeyHash ?? 0x00,
+        scriptHashVersion: networkType?.scriptHash ?? 0x05,
+        bech32Hrp: networkType?.bech32 ?? 'bc');
   }
 }

--- a/packages/crypto_wallet_util/lib/src/transaction/btc/gspl_tx_data.dart
+++ b/packages/crypto_wallet_util/lib/src/transaction/btc/gspl_tx_data.dart
@@ -1,11 +1,12 @@
 import 'dart:typed_data';
 
 import 'package:bs58check/bs58check.dart';
-import 'package:crypto_wallet_util/config.dart' show getChainConfigByBip44Path;
+import 'package:crypto_wallet_util/config.dart' show chainConfigs;
 import 'package:crypto_wallet_util/src/forked_lib/bitcoin_flutter/bitcoin_flutter.dart' as btc;
 import 'package:crypto_wallet_util/src/forked_lib/bitcoin_flutter/src/utils/constants/op.dart';
 import 'package:crypto_wallet_util/src/transaction/btc/sign_data.dart';
 import 'package:crypto_wallet_util/src/type/type.dart';
+import 'package:crypto_wallet_util/src/utils/bip32/bip32.dart' show NetworkType;
 import 'package:crypto_wallet_util/src/utils/utils.dart';
 
 class GsplTxData extends TxData {
@@ -16,26 +17,44 @@ class GsplTxData extends TxData {
 
   GsplTxData({required this.inputs, required this.hex, this.change, required this.dataType});
 
-  // Parse address
-  String _generateAddress(Uint8List pubKeyHashHex) {
-    final paths = inputs.map((input) => input.path).toList();
-    if (paths.isEmpty) {
+  NetworkType get _networkType {
+    final path = inputs.map((input) => input.path).whereType<String>().firstWhere(
+          (value) => value.isNotEmpty,
+          orElse: () => change?.path ?? '',
+        );
+    if (path.isEmpty) {
       throw Exception('No path found');
     }
-    final path = paths.first;
-    if (path == null) {
-      throw Exception('Path not found');
+
+    final segments = path.split('/');
+    if (segments.length < 3) {
+      throw Exception('Invalid bip44 path: $path');
     }
-    final networkType = getChainConfigByBip44Path(path).mainnet.networkType;
-    if (networkType == null) {
-      throw Exception('Network type not found');
+
+    final coinType = segments[2].replaceAll("'", '');
+    for (final chainConfig in chainConfigs) {
+      final chainPath = chainConfig.mainnet.bip44Path;
+      final chainSegments = chainPath.split('/');
+      if (chainSegments.length < 3) {
+        continue;
+      }
+      if (chainSegments[2].replaceAll("'", '') == coinType) {
+        final networkType = chainConfig.mainnet.networkType;
+        if (networkType != null) {
+          return networkType;
+        }
+      }
     }
-    final prefixHex = networkType.pubKeyHash;
+
+    throw Exception('Network type not found for path: $path');
+  }
+
+  String _generateAddress(Uint8List hash160, int versionByte) {
 
     // Concatenate version + pubkeyHash
-    final Uint8List payload = Uint8List(pubKeyHashHex.length + 1);
-    payload[0] = prefixHex;
-    payload.setRange(1, payload.length, pubKeyHashHex);
+    final Uint8List payload = Uint8List(hash160.length + 1);
+    payload[0] = versionByte;
+    payload.setRange(1, payload.length, hash160);
 
     // Double SHA256
     final sha256Hash = getSHA256Digest(getSHA256Digest(payload));
@@ -50,16 +69,27 @@ class GsplTxData extends TxData {
     return base58.encode(fullData);
   }
 
-  String? _extractP2PKHAddress(Uint8List? script) {
+  String? _extractAddress(Uint8List? script) {
     if (script == null) return null;
-    if (script.length != 25) return null;
-    final op_dup = script[0];
-    final op_hash160 = script[1];
-    final push_20 = script[2];
-    final op_equalverify = script[23];
-    final op_checksig = script[24];
-    if (op_dup != OPS['OP_DUP'] || op_hash160 != OPS['OP_HASH160'] || push_20 != 0x14 || op_equalverify != OPS['OP_EQUALVERIFY'] || op_checksig != OPS['OP_CHECKSIG']) return null;
-    return _generateAddress(script.sublist(3, 23));
+    final net = _networkType;
+
+    if (script.length == 25 &&
+        script[0] == OPS['OP_DUP'] &&
+        script[1] == OPS['OP_HASH160'] &&
+        script[2] == 0x14 &&
+        script[23] == OPS['OP_EQUALVERIFY'] &&
+        script[24] == OPS['OP_CHECKSIG']) {
+      return _generateAddress(script.sublist(3, 23), net.pubKeyHash);
+    }
+
+    if (script.length == 23 &&
+        script[0] == OPS['OP_HASH160'] &&
+        script[1] == 0x14 &&
+        script[22] == OPS['OP_EQUAL']) {
+      return _generateAddress(script.sublist(2, 22), net.scriptHash);
+    }
+
+    return null;
   }
 
   int _getFee(int? amount) {
@@ -80,7 +110,7 @@ class GsplTxData extends TxData {
 
     final outputs = transaction.outs;
     final changeAmount = change?.amount;
-    final allPayments = outputs.map((output) => { 'address': _extractP2PKHAddress(output.script), 'amount': output.value }).toList();
+    final allPayments = outputs.map((output) => {'address': _extractAddress(output.script), 'amount': output.value}).toList();
     final payments = changeAmount != null && allPayments.isNotEmpty && allPayments.last['amount'] == changeAmount ? allPayments.sublist(0, allPayments.length - 1) : allPayments;
     final payAmount = payments.map((payment) => payment['amount']).toList().whereType<int>().fold<int>(0, (sum, amount) => sum + amount);
     final amount = outputs.map((output) => output.value).toList().whereType<int>().fold<int>(0, (sum, amount) => sum + amount);

--- a/packages/crypto_wallet_util/lib/src/transaction/btc/psbt_tx_data.dart
+++ b/packages/crypto_wallet_util/lib/src/transaction/btc/psbt_tx_data.dart
@@ -12,38 +12,57 @@ import 'package:crypto_wallet_util/src/forked_lib/bitcoin_flutter/bitcoin_flutte
 class PsbtTxData extends TxData {
   final PSBT psbt;
   final bool isTaproot;
+  final String chain;
+  final bool isTestnet;
   String unsignedPsbt = '';
 
-  PsbtTxData(this.psbt, this.unsignedPsbt, this.isTaproot);
+  PsbtTxData(this.psbt, this.unsignedPsbt, this.isTaproot,
+      {this.chain = 'btc', this.isTestnet = false});
 
   /// gas fee
   int get fee => psbt.fee;
 
   /// get transfer amount (all outputs, not excluding change)
-  int get transferAmount => psbt.transferAmount;
+  int get transferAmount =>
+      psbt.getTransferAmount(isTestnet: isTestnet, chain: chain);
 
   /// get receive address (first non-change output)
   String get transferAddress {
-    return psbt.unsignedTransaction!.outputs[0].getAddress();
+    return psbt.unsignedTransaction!.outputs[0]
+        .getAddress(isTestnet: isTestnet, chain: chain);
   }
 
   List<Map<String, dynamic>> get payments {
     final payments = psbt.unsignedTransaction!.outputs.map((e) => {
-      'address': e.getAddress(),
+      'address': e.getAddress(isTestnet: isTestnet, chain: chain),
       'amount': e.amount
     }).toList();
-    return payments.where((output) => !psbt.inputAddresses.contains(output['address'])).toList();
+    return payments
+        .where((output) => !psbt
+            .getInputAddresses(isTestnet: isTestnet, chain: chain)
+            .contains(output['address']))
+        .toList();
   }
 
-  Origin get origin => getOrigin(unsignedPsbt);
+  Origin get origin =>
+      getOrigin(unsignedPsbt, chain: chain, isTestnet: isTestnet);
 
-  static PsbtTxData fromHash(String hash, {bool isTaproot = false}) {
-    return PsbtTxData(PSBT.parse(hash), hash, isTaproot);
+  static PsbtTxData fromHash(String hash,
+      {bool isTaproot = false, String chain = 'btc', bool isTestnet = false}) {
+    return PsbtTxData(PSBT.parse(hash), hash, isTaproot,
+        chain: chain, isTestnet: isTestnet);
   }
 
-  static Origin getOrigin(String psbtHex) {
+  static Origin getOrigin(String psbtHex,
+      {String chain = 'btc', bool isTestnet = false}) {
     final psbt = PSBT.parse(psbtHex);
     final unsignedTx = psbt.unsignedTransaction!;
+    final chainConf = getChainConfig(chain);
+    final networkType =
+        (isTestnet ? chainConf.testnet.networkType : chainConf.mainnet.networkType);
+    final pkhVersion = networkType?.pubKeyHash ?? 0x00;
+    final shVersion = networkType?.scriptHash ?? 0x05;
+    final hrp = networkType?.bech32 ?? 'bc';
 
     // Extract inputs from PSBT
     final inputs = <OriginInput>[];
@@ -57,7 +76,10 @@ class PsbtTxData extends TxData {
 
       if (psbtInput.witnessUtxo != null) {
         value = psbtInput.witnessUtxo!.amount / 100000000;
-        address = psbtInput.witnessUtxo!.scriptPubKey.getAddress();
+        address = psbtInput.witnessUtxo!.scriptPubKey.getAddress(
+            pubKeyHashVersion: pkhVersion,
+            scriptHashVersion: shVersion,
+            bech32Hrp: hrp);
       } else if (psbtInput.previousTransaction != null) {
         // Fallback to previous transaction if available
         final prevTx = psbtInput.previousTransaction!;
@@ -65,7 +87,7 @@ class PsbtTxData extends TxData {
         if (outputIndex < prevTx.outputs.length) {
           final output = prevTx.outputs[outputIndex];
           value = output.amount / 100000000;
-          address = output.scriptPubKey.getAddress();
+          address = output.getAddress(isTestnet: isTestnet, chain: chain);
         } else {
           // ignore: avoid_print
           print('Warning: PSBT input $i has invalid output index');
@@ -106,7 +128,7 @@ class PsbtTxData extends TxData {
     final outputs = <OriginOutput>[];
     for (final output in unsignedTx.outputs) {
       outputs.add(OriginOutput(
-        address: output.scriptPubKey.getAddress(),
+        address: output.getAddress(isTestnet: isTestnet, chain: chain),
         amount: (output.amount / 100000000), // Convert satoshis to BTC
         path: null, // May be available in PSBT output data
         value: output.amount.toString(),
@@ -131,10 +153,12 @@ class PsbtTxData extends TxData {
     if (!isSigned) {
       throw Exception('Transaction is not signed');
     }
-    final chainConf = getChainConfig('btc').mainnet;
+    final chainConf = isTestnet
+        ? getChainConfig(chain).testnet
+        : getChainConfig(chain).mainnet;
     if (isTaproot) {
       final btcTx = bitcoin.Transaction();
-      final originTx = getOrigin(unsignedPsbt);
+      final originTx = getOrigin(unsignedPsbt, chain: chain, isTestnet: isTestnet);
 
       btcTx.setVersion(originTx.version);
       btcTx.setLocktime(originTx.locktime);

--- a/packages/crypto_wallet_util/pubspec.yaml
+++ b/packages/crypto_wallet_util/pubspec.yaml
@@ -1,6 +1,6 @@
 name: crypto_wallet_util
 description: A collection of utility functions for cryptocurrencies.
-version: 2.0.1
+version: 2.0.2
 homepage: https://github.com/fxwalletOfficial/fx-wallet-packages/tree/main/packages/wallet_crypto_util
 
 environment:

--- a/packages/crypto_wallet_util/test/gspl/gspl_test.dart
+++ b/packages/crypto_wallet_util/test/gspl/gspl_test.dart
@@ -258,6 +258,56 @@ void main() async {
         expect(lastPayment['amount'], isNot(equals(99990000)));
       }
     });
+
+    test('should parse LTC P2SH payment address', () async {
+      final txData = GsplTxData(
+        inputs: [
+          GsplItem(
+            path: "m/44'/2'/0'/0/3",
+            amount: 50000000,
+            signHashType: 1,
+          )
+        ],
+        hex: '020000000100000000000000000000000000000000000000000000000000000000000000000000000000ffffffff02102700000000000017a914f1a0e4682c80c932a225b448644366e106712a228794310000000000001976a914e8df6b4293962bcde0c39e59bd3371981897392b88ac00000000',
+        change: GsplItem(
+          path: "m/44'/2'/0'/1/7",
+          amount: 12692,
+          signHashType: 1,
+        ),
+        dataType: BtcSignDataType.TRANSACTION,
+      );
+
+      final jsonData = txData.toJson();
+      final payments = jsonData['payments'] as List;
+      expect(payments, hasLength(1));
+
+      final payment = payments.first as Map<String, dynamic>;
+      expect(payment['address'], 'MVvmpeZN3U8RwNrHxEovpb5KWxdkMmqfjC');
+      expect(payment['amount'], 10000);
+    });
+
+    test('should resolve network type from non-0/0 input path', () async {
+      final txData = GsplTxData(
+        inputs: [
+          GsplItem(
+            path: "m/44'/2'/0'/0/3",
+            amount: 50000000,
+            signHashType: 1,
+          )
+        ],
+        hex: '020000000100000000000000000000000000000000000000000000000000000000000000000000000000ffffffff0110270000000000001976a914e8df6b4293962bcde0c39e59bd3371981897392b88ac00000000',
+        change: null,
+        dataType: BtcSignDataType.TRANSACTION,
+      );
+
+      final jsonData = txData.toJson();
+      final payments = jsonData['payments'] as List;
+      expect(payments, hasLength(1));
+
+      final payment = payments.first as Map<String, dynamic>;
+      expect(payment['address'], 'LgTGg988MpnG3N3FbLufCPjiKZjrqYque7');
+      expect(payment['amount'], 10000);
+    });
   });
 
   group('GSPL Signature Hash Type Tests', () {

--- a/packages/crypto_wallet_util/test/psbt/psbt_test.dart
+++ b/packages/crypto_wallet_util/test/psbt/psbt_test.dart
@@ -3,7 +3,11 @@ import 'dart:io';
 
 import 'package:test/test.dart';
 
+import 'package:bs58check/bs58check.dart';
 import 'package:crypto_wallet_util/crypto_utils.dart';
+import 'package:crypto_wallet_util/src/forked_lib/psbt/transaction/script_public_key.dart'
+    as psbt;
+import 'package:crypto_wallet_util/src/forked_lib/psbt/utils/converter.dart';
 
 void main() async {
   final transactions = json
@@ -53,5 +57,82 @@ void main() async {
         assert(jsonData.isNotEmpty);
       });
     }
+  });
+
+  group('LTC address parsing', () {
+    // LTC version bytes: pubKeyHash=0x30, scriptHash=0x32, bech32Hrp='ltc'
+    const ltcPubKeyHash = 0x30;
+    const ltcScriptHash = 0x32;
+    const ltcBech32Hrp = 'ltc';
+
+    test('P2PKH script produces LTC L-address', () {
+      final hash160 = Converter.hexToBytes('e8df6b4293962bcde0c39e59bd3371981897392b');
+      final script = psbt.ScriptPublicKey([0x76, 0xa9, hash160, 0x88, 0xac]);
+      final address = script.getAddress(
+          pubKeyHashVersion: ltcPubKeyHash, bech32Hrp: ltcBech32Hrp);
+      expect(address.startsWith('L'), isTrue);
+    });
+
+    test('P2SH script produces LTC M-address', () {
+      final hash160 = Converter.hexToBytes('f1a0e4682c80c932a225b448644366e106712a22');
+      final script = psbt.ScriptPublicKey([0xa9, hash160, 0x87]);
+      final address = script.getAddress(
+          scriptHashVersion: ltcScriptHash, bech32Hrp: ltcBech32Hrp);
+      expect(address.startsWith('M'), isTrue);
+    });
+
+    test('P2WPKH script produces LTC ltc1-address', () {
+      final hash160 = Converter.hexToBytes('751e76e8199196d454941c45d1b3a323f1433bd6');
+      final script = psbt.ScriptPublicKey([0x00, hash160]);
+      final address = script.getAddress(bech32Hrp: ltcBech32Hrp);
+      expect(address.startsWith('ltc1'), isTrue);
+    });
+
+    test('PsbtTxData.fromHash with chain ltc returns LTC addresses', () {
+      final transactions = json.decode(
+          File('./test/psbt/data.json').readAsStringSync(encoding: utf8));
+      final psbtHex = transactions[0]['psbt'];
+      final psbtTxData = PsbtTxData.fromHash(psbtHex, chain: 'ltc');
+      // Access raw output addresses (unfiltered) via the unsigned transaction
+      final outputs = psbtTxData.psbt.unsignedTransaction!.outputs;
+      expect(outputs, isNotEmpty);
+      for (final output in outputs) {
+        final addr = output.getAddress(chain: 'ltc');
+        // BTC P2PKH addresses start with '1', LTC P2PKH with 'L'
+        expect(addr.startsWith('L'), isTrue,
+            reason: 'LTC address should start with L, got $addr');
+      }
+    });
+
+    test('LTC testnet P2WPKH script produces tltc1-address', () {
+      final hash160 = Converter.hexToBytes('751e76e8199196d454941c45d1b3a323f1433bd6');
+      final script = psbt.ScriptPublicKey([0x00, hash160]);
+      final mainnetAddr = script.getAddress(
+          pubKeyHashVersion: 0x30, scriptHashVersion: 0x32, bech32Hrp: 'ltc');
+      final testnetAddr = script.getAddress(
+          pubKeyHashVersion: 0x6f, scriptHashVersion: 0x3a, bech32Hrp: 'tltc');
+      expect(mainnetAddr.startsWith('ltc1'), isTrue);
+      expect(testnetAddr.startsWith('tltc1'), isTrue);
+      expect(mainnetAddr, isNot(equals(testnetAddr)));
+    });
+
+    test('LTC testnet P2SH uses 0x3a version byte (not BTC 0xc4)', () {
+      // Per blockchain_utils CoinConf.litecoinTestNet: p2shStdNetVer = [0x3a]
+      final hash160 = Converter.hexToBytes('f1a0e4682c80c932a225b448644366e106712a22');
+      final script = psbt.ScriptPublicKey([0xa9, hash160, 0x87]);
+      final ltcTestnetAddr = script.getAddress(
+          pubKeyHashVersion: 0x6f, scriptHashVersion: 0x3a, bech32Hrp: 'tltc');
+      final btcTestnetAddr = script.getAddress(
+          pubKeyHashVersion: 0x6f, scriptHashVersion: 0xc4, bech32Hrp: 'tb');
+      // The two addresses must differ — if they're the same, version byte is
+      // being collapsed somewhere upstream.
+      expect(ltcTestnetAddr, isNot(equals(btcTestnetAddr)),
+          reason: 'LTC testnet P2SH (0x3a) and BTC testnet P2SH (0xc4) must '
+              'produce different addresses. Got: $ltcTestnetAddr');
+      // Decode base58 to confirm version byte is 0x3a.
+      final decoded = base58.decode(ltcTestnetAddr);
+      expect(decoded.first, 0x3a,
+          reason: 'LTC testnet P2SH address must encode with version byte 0x3a');
+    });
   });
 }

--- a/packages/crypto_wallet_util/test/psbt/psbt_test.dart
+++ b/packages/crypto_wallet_util/test/psbt/psbt_test.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 import 'dart:io';
+import 'dart:typed_data';
 
 import 'package:test/test.dart';
 
@@ -133,6 +134,54 @@ void main() async {
       final decoded = base58.decode(ltcTestnetAddr);
       expect(decoded.first, 0x3a,
           reason: 'LTC testnet P2SH address must encode with version byte 0x3a');
+    });
+
+    test('isTestnet fallback: P2PKH → 0x6f, P2SH → 0xc4, P2WPKH → tb', () {
+      final pkhHash160 = Uint8List.fromList(
+          Converter.hexToBytes('e8df6b4293962bcde0c39e59bd3371981897392b'));
+      final shHash160 = Uint8List.fromList(
+          Converter.hexToBytes('f1a0e4682c80c932a225b448644366e106712a22'));
+      final wpkhHash160 = Uint8List.fromList(
+          Converter.hexToBytes('751e76e8199196d454941c45d1b3a323f1433bd6'));
+
+      final pkhScript =
+          psbt.ScriptPublicKey([0x76, 0xa9, pkhHash160, 0x88, 0xac]);
+      final shScript = psbt.ScriptPublicKey([0xa9, shHash160, 0x87]);
+      final wpkhScript = psbt.ScriptPublicKey([0x00, wpkhHash160]);
+
+      // isTestnet: false → BTC mainnet versions
+      final mainnetPkh = pkhScript.getAddress();
+      expect(base58.decode(mainnetPkh).first, 0x00,
+          reason: 'mainnet P2PKH → version byte 0x00');
+
+      final mainnetSh = shScript.getAddress();
+      expect(base58.decode(mainnetSh).first, 0x05,
+          reason: 'mainnet P2SH → version byte 0x05');
+
+      final mainnetWpkh = wpkhScript.getAddress();
+      expect(mainnetWpkh.startsWith('bc1'), isTrue,
+          reason: 'mainnet P2WPKH → bech32 hrp bc');
+
+      // isTestnet: true → BTC testnet versions
+      final testnetPkh = pkhScript.getAddress(isTestnet: true);
+      expect(base58.decode(testnetPkh).first, 0x6f,
+          reason: 'isTestnet: true → P2PKH version byte 0x6f');
+
+      final testnetSh = shScript.getAddress(isTestnet: true);
+      expect(base58.decode(testnetSh).first, 0xc4,
+          reason: 'isTestnet: true → P2SH version byte 0xc4');
+
+      final testnetWpkh = wpkhScript.getAddress(isTestnet: true);
+      expect(testnetWpkh.startsWith('tb1'), isTrue,
+          reason: 'isTestnet: true → bech32 hrp tb');
+
+      // Explicit params still override isTestnet.
+      final override = wpkhScript.getAddress(
+          isTestnet: true,
+          pubKeyHashVersion: 0x30,
+          bech32Hrp: 'ltc');
+      expect(override.startsWith('ltc1'), isTrue,
+          reason: 'explicit params override isTestnet fallback');
     });
   });
 }


### PR DESCRIPTION
## 概要

- PSBT 和 GSPL 交易解析中，LTC 地址不再硬编码 BTC 主网的 version bytes / bech32 HRP，改为通过链配置参数化传入
- 补齐 BTC / LTC testnet 的 NetworkType 配置（此前与 mainnet 共用）

## 变更详情

### PSBT 地址编码参数化
- `script_public_key.dart`: `getAddress()` 接受显式 `pubKeyHashVersion` / `scriptHashVersion` / `bech32Hrp` 参数，删除全局 `BitcoinNetwork` 依赖
- `transaction_output.dart` / `partially_signed_bitcoin_transaction.dart`: 通过 `chain` 名称查找 `ConfChain` 配置，传入对应 version bytes
- `psbt_tx_data.dart`: 新增可选 `chain` / `isTestnet` 参数，贯穿 `getOrigin()` / `sign()` 等链路

### GSPL P2SH 支持
- `gspl_tx_data.dart`: `_extractAddress()` 同时支持 P2PKH（25 字节）和 P2SH（23 字节）脚本解析
- `_networkType`: 从 bip44 path 的 coin_type 段匹配对应链的 NetworkType

### 链配置补齐
- `btc.dart` / `ltc.dart`: testnet 填入正确的独立 version bytes（bech32、wif、pubKeyHash、scriptHash）

## 测试
- 全部 802 个测试通过
- 新增 LTC P2PKH / P2SH / P2WPKH / testnet 地址解析测试
- 新增 GSPL LTC P2SH payment address 端到端测试