### PR TITLE
fix(crypto_wallet_util): BTC testnet address generation respects networkType

### DIFF
--- a/packages/crypto_wallet_util/CHANGELOG.md
+++ b/packages/crypto_wallet_util/CHANGELOG.md
@@ -20,6 +20,9 @@
   (`0x043587cf`) parses and builds instead of being rejected by the mainnet
   config and crashing on a null wallet. BTC/BCH testnet BIP32 public version
   bytes were corrected to `0x043587cf`.
+- BTC PSBT construction remains backward-compatible with the non-standard
+  testnet extended public-key version (`0x04358a68`, `tpw...`) emitted by 2.0.2,
+  while malformed keys and genuinely unknown versions now fail closed.
 - Taproot wallets keep the caller's `WalletSetting` by reference and derive the
   BIP86 path at sign time, so switching the setting's network stays consistent
   across existing and freshly derived wallets.

--- a/packages/crypto_wallet_util/CHANGELOG.md
+++ b/packages/crypto_wallet_util/CHANGELOG.md
@@ -15,6 +15,11 @@
 - PSBT change detection infers the CashAddr network prefix from the input
   address instead of hard-coding `bitcoincash`, so BCH testnet CashAddr change
   outputs no longer abort transaction construction.
+- `PSBT.fromTransferPsbt` selects the mainnet or testnet chain config from the
+  extended key's BIP32 version bytes, so a standard testnet `tpub`
+  (`0x043587cf`) parses and builds instead of being rejected by the mainnet
+  config and crashing on a null wallet. BTC/BCH testnet BIP32 public version
+  bytes were corrected to `0x043587cf`.
 - Taproot wallets keep the caller's `WalletSetting` by reference and derive the
   BIP86 path at sign time, so switching the setting's network stays consistent
   across existing and freshly derived wallets.

--- a/packages/crypto_wallet_util/CHANGELOG.md
+++ b/packages/crypto_wallet_util/CHANGELOG.md
@@ -3,78 +3,15 @@
 ## [2.0.3] - 2026-07-17
 ### Fixed
 
-- BTC testnet address generation now respects the network type from `WalletSetting`.
-  Previously, `BtcCoin.publicKeyToAddress` hardcoded mainnet version bytes (0x00)
-  and HRP ('bc'), causing testnet wallets to generate mainnet-format addresses that
-  were misidentified as BCH testnet addresses during validation.
-- Added regression tests to verify BTC testnet addresses are correctly generated
-  (using version byte 0x6f for legacy, 'tb' HRP for segwit) and properly detected
-  as BTC rather than BCH.
-
-## [2.0.2] - 2026-07-02
-### Fixed
-
-- PSBT: parse LTC P2SH / Nested SegWit addresses correctly by plumbing chain-aware
-  version bytes and bech32 HRP through address encoding instead of hard-coding BTC
-  mainnet values.
-- GSPL: support LTC P2SH payment address parsing by detecting the script type
-  (P2PKH vs P2SH) and resolving the correct network version bytes from the bip44
-  path coin-type segment.
-- BTC / LTC chain configs: fill in distinct testnet NetworkType values (previously
-  shared mainnet settings).
-
-## [2.0.1] - 2026-06-12
-### Added
-
-- SC (Sia): native Go FFI transaction bridge (`ScGoFfiBridge`) as a faster,
-  opt-in alternative to the WASM bridge. The default `create()` is unchanged
-  and still uses the WASM bridge (`ScWasmRunBridge`), so existing callers are
-  unaffected. The native library is **not** bundled: the caller builds it for
-  their platform (see `lib/src/forked_lib/sia-wasi/build.sh`), loads it, and
-  passes it via `ScTransactionBuilder.createWithFfi(DynamicLibrary)`.
-
-### Changed
-
-- Minimum Dart SDK raised to `>=3.11.0` (required by the `wasd` WASM
-  interpreter that backs the default SC bridge). Consumers on Dart 3.7–3.10
-  must upgrade.
-
-### Removed
-
-- Pruned dead code from the vendored `bitcoin_base_hd` fork that is never
-  reached by this package (BTC/LTC/BCH only use `ECPrivate`):
-  - the entire `provider/` subtree (Electrum/HTTP API providers and the
-    `BitcoinTransactionBuilder` / BCH builder) and `utils/btc_utils.dart`
-    (~2.2k lines).
-  - `ECPublic.verifyTransactionSignature` and
-    `ECPublic.verifySchnorrTransactionSignature` (unused; their post-upgrade
-    bodies had latent argument-shape issues).
-## [2.0.0] - 2026-06-09
-### BREAKING
-
-- Upgrade `blockchain_utils` from `^1.4.1` to `^6.0.0`. Resolves the dependency
-  conflict reported in #20 (consumers using `bitcoin_base 7.x` / `xrpl_dart 7.x`,
-  which require `blockchain_utils ^6.0.0`).
-- Minimum Dart SDK raised to `>=3.7.0` (required by `blockchain_utils 6.0.0`).
-
-### Changed
-
-- Migrated the vendored `bitcoin_base_hd` and `xrpl_dart` forks to the
-  `blockchain_utils` 6.x API: relocated utility imports to the package barrel,
-  `Tuple`/`item1,item2` → Dart records (`$1`,`$2`), `mask*`/`writeUintXLE` →
-  `BinaryOps.*`, `bytesEqual`/`iterableIsEqual` → `BytesUtils`/`CompareUtils`,
-  `Secp256k1*KeyEcdsa` → `Secp256k1*Key`, `BitcoinSigner`/`BitcoinVerifier` →
-  `BitcoinKeySigner`/`BitcoinSignatureVerifier`, `BigintUtils.orderLen` →
-  `BigintUtils.bitlengthInBytes`.
-- ECDSA / Taproot / message signing outputs verified byte-for-byte identical to
-  the pre-upgrade implementation; XRP secp256k1 family-seed derivation and
-  classic/X-address conversion pinned with characterization tests.
-- `Bech32Validations` / `SegwitValidations` declared as `mixin` (Dart 3 language
-  level no longer permits using a plain class as a mixin).
-
-### Notes
-
-- No public API changes beyond the SDK floor; all 782 unit tests pass.
+- BTC address generation and validation now consistently honor the selected
+  network, including legacy, SegWit v0, BIP86 Taproot, custom HRPs, and
+  fail-closed handling for explicitly configured networks without a valid HRP.
+- Taproot key tweaking now follows BIP341 `lift_x` semantics and is pinned to the
+  official BIP86 address and scriptPubKey vector.
+- Bech32, Bech32m, and CashAddr decoding now verifies checksum, network prefix,
+  witness version and length, and canonical bit padding.
+- BCH testnet uses `bchtest` plus testnet version bytes, and BCH validation
+  requires a full network-matching CashAddr to avoid BTC/BCH legacy ambiguity.
 
 ## [1.0.0] - 2024-06-19
 
@@ -334,3 +271,70 @@
 - SC transaction signer (Ed25519) and builder.
 - SC send example.
 
+
+## [2.0.0] - 2026-06-09
+### BREAKING
+
+- Upgrade `blockchain_utils` from `^1.4.1` to `^6.0.0`. Resolves the dependency
+  conflict reported in #20 (consumers using `bitcoin_base 7.x` / `xrpl_dart 7.x`,
+  which require `blockchain_utils ^6.0.0`).
+- Minimum Dart SDK raised to `>=3.7.0` (required by `blockchain_utils 6.0.0`).
+
+### Changed
+
+- Migrated the vendored `bitcoin_base_hd` and `xrpl_dart` forks to the
+  `blockchain_utils` 6.x API: relocated utility imports to the package barrel,
+  `Tuple`/`item1,item2` → Dart records (`$1`,`$2`), `mask*`/`writeUintXLE` →
+  `BinaryOps.*`, `bytesEqual`/`iterableIsEqual` → `BytesUtils`/`CompareUtils`,
+  `Secp256k1*KeyEcdsa` → `Secp256k1*Key`, `BitcoinSigner`/`BitcoinVerifier` →
+  `BitcoinKeySigner`/`BitcoinSignatureVerifier`, `BigintUtils.orderLen` →
+  `BigintUtils.bitlengthInBytes`.
+- ECDSA / Taproot / message signing outputs verified byte-for-byte identical to
+  the pre-upgrade implementation; XRP secp256k1 family-seed derivation and
+  classic/X-address conversion pinned with characterization tests.
+- `Bech32Validations` / `SegwitValidations` declared as `mixin` (Dart 3 language
+  level no longer permits using a plain class as a mixin).
+
+### Notes
+
+- No public API changes beyond the SDK floor; all 782 unit tests pass.
+
+
+## [2.0.2] - 2026-07-02
+### Fixed
+
+- PSBT: parse LTC P2SH / Nested SegWit addresses correctly by plumbing chain-aware
+  version bytes and bech32 HRP through address encoding instead of hard-coding BTC
+  mainnet values.
+- GSPL: support LTC P2SH payment address parsing by detecting the script type
+  (P2PKH vs P2SH) and resolving the correct network version bytes from the bip44
+  path coin-type segment.
+- BTC / LTC chain configs: fill in distinct testnet NetworkType values (previously
+  shared mainnet settings).
+
+## [2.0.1] - 2026-06-12
+### Added
+
+- SC (Sia): native Go FFI transaction bridge (`ScGoFfiBridge`) as a faster,
+  opt-in alternative to the WASM bridge. The default `create()` is unchanged
+  and still uses the WASM bridge (`ScWasmRunBridge`), so existing callers are
+  unaffected. The native library is **not** bundled: the caller builds it for
+  their platform (see `lib/src/forked_lib/sia-wasi/build.sh`), loads it, and
+  passes it via `ScTransactionBuilder.createWithFfi(DynamicLibrary)`.
+
+### Changed
+
+- Minimum Dart SDK raised to `>=3.11.0` (required by the `wasd` WASM
+  interpreter that backs the default SC bridge). Consumers on Dart 3.7–3.10
+  must upgrade.
+
+### Removed
+
+- Pruned dead code from the vendored `bitcoin_base_hd` fork that is never
+  reached by this package (BTC/LTC/BCH only use `ECPrivate`):
+  - the entire `provider/` subtree (Electrum/HTTP API providers and the
+    `BitcoinTransactionBuilder` / BCH builder) and `utils/btc_utils.dart`
+    (~2.2k lines).
+  - `ECPublic.verifyTransactionSignature` and
+    `ECPublic.verifySchnorrTransactionSignature` (unused; their post-upgrade
+    bodies had latent argument-shape issues).

--- a/packages/crypto_wallet_util/CHANGELOG.md
+++ b/packages/crypto_wallet_util/CHANGELOG.md
@@ -12,6 +12,78 @@
   witness version and length, and canonical bit padding.
 - BCH testnet uses `bchtest` plus testnet version bytes, and BCH validation
   requires a full network-matching CashAddr to avoid BTC/BCH legacy ambiguity.
+- PSBT change detection infers the CashAddr network prefix from the input
+  address instead of hard-coding `bitcoincash`, so BCH testnet CashAddr change
+  outputs no longer abort transaction construction.
+- Taproot wallets keep the caller's `WalletSetting` by reference and derive the
+  BIP86 path at sign time, so switching the setting's network stays consistent
+  across existing and freshly derived wallets.
+
+## [2.0.2] - 2026-07-02
+### Fixed
+
+- PSBT: parse LTC P2SH / Nested SegWit addresses correctly by plumbing chain-aware
+  version bytes and bech32 HRP through address encoding instead of hard-coding BTC
+  mainnet values.
+- GSPL: support LTC P2SH payment address parsing by detecting the script type
+  (P2PKH vs P2SH) and resolving the correct network version bytes from the bip44
+  path coin-type segment.
+- BTC / LTC chain configs: fill in distinct testnet NetworkType values (previously
+  shared mainnet settings).
+
+## [2.0.1] - 2026-06-12
+### Added
+
+- SC (Sia): native Go FFI transaction bridge (`ScGoFfiBridge`) as a faster,
+  opt-in alternative to the WASM bridge. The default `create()` is unchanged
+  and still uses the WASM bridge (`ScWasmRunBridge`), so existing callers are
+  unaffected. The native library is **not** bundled: the caller builds it for
+  their platform (see `lib/src/forked_lib/sia-wasi/build.sh`), loads it, and
+  passes it via `ScTransactionBuilder.createWithFfi(DynamicLibrary)`.
+
+### Changed
+
+- Minimum Dart SDK raised to `>=3.11.0` (required by the `wasd` WASM
+  interpreter that backs the default SC bridge). Consumers on Dart 3.7–3.10
+  must upgrade.
+
+### Removed
+
+- Pruned dead code from the vendored `bitcoin_base_hd` fork that is never
+  reached by this package (BTC/LTC/BCH only use `ECPrivate`):
+  - the entire `provider/` subtree (Electrum/HTTP API providers and the
+    `BitcoinTransactionBuilder` / BCH builder) and `utils/btc_utils.dart`
+    (~2.2k lines).
+  - `ECPublic.verifyTransactionSignature` and
+    `ECPublic.verifySchnorrTransactionSignature` (unused; their post-upgrade
+    bodies had latent argument-shape issues).
+
+## [2.0.0] - 2026-06-09
+### BREAKING
+
+- Upgrade `blockchain_utils` from `^1.4.1` to `^6.0.0`. Resolves the dependency
+  conflict reported in #20 (consumers using `bitcoin_base 7.x` / `xrpl_dart 7.x`,
+  which require `blockchain_utils ^6.0.0`).
+- Minimum Dart SDK raised to `>=3.7.0` (required by `blockchain_utils 6.0.0`).
+
+### Changed
+
+- Migrated the vendored `bitcoin_base_hd` and `xrpl_dart` forks to the
+  `blockchain_utils` 6.x API: relocated utility imports to the package barrel,
+  `Tuple`/`item1,item2` → Dart records (`$1`,`$2`), `mask*`/`writeUintXLE` →
+  `BinaryOps.*`, `bytesEqual`/`iterableIsEqual` → `BytesUtils`/`CompareUtils`,
+  `Secp256k1*KeyEcdsa` → `Secp256k1*Key`, `BitcoinSigner`/`BitcoinVerifier` →
+  `BitcoinKeySigner`/`BitcoinSignatureVerifier`, `BigintUtils.orderLen` →
+  `BigintUtils.bitlengthInBytes`.
+- ECDSA / Taproot / message signing outputs verified byte-for-byte identical to
+  the pre-upgrade implementation; XRP secp256k1 family-seed derivation and
+  classic/X-address conversion pinned with characterization tests.
+- `Bech32Validations` / `SegwitValidations` declared as `mixin` (Dart 3 language
+  level no longer permits using a plain class as a mixin).
+
+### Notes
+
+- No public API changes beyond the SDK floor; all 782 unit tests pass.
 
 ## [1.0.0] - 2024-06-19
 
@@ -270,71 +342,3 @@
 - SC transaction assembly with WASM integration (`package:wasm_run`).
 - SC transaction signer (Ed25519) and builder.
 - SC send example.
-
-
-## [2.0.0] - 2026-06-09
-### BREAKING
-
-- Upgrade `blockchain_utils` from `^1.4.1` to `^6.0.0`. Resolves the dependency
-  conflict reported in #20 (consumers using `bitcoin_base 7.x` / `xrpl_dart 7.x`,
-  which require `blockchain_utils ^6.0.0`).
-- Minimum Dart SDK raised to `>=3.7.0` (required by `blockchain_utils 6.0.0`).
-
-### Changed
-
-- Migrated the vendored `bitcoin_base_hd` and `xrpl_dart` forks to the
-  `blockchain_utils` 6.x API: relocated utility imports to the package barrel,
-  `Tuple`/`item1,item2` → Dart records (`$1`,`$2`), `mask*`/`writeUintXLE` →
-  `BinaryOps.*`, `bytesEqual`/`iterableIsEqual` → `BytesUtils`/`CompareUtils`,
-  `Secp256k1*KeyEcdsa` → `Secp256k1*Key`, `BitcoinSigner`/`BitcoinVerifier` →
-  `BitcoinKeySigner`/`BitcoinSignatureVerifier`, `BigintUtils.orderLen` →
-  `BigintUtils.bitlengthInBytes`.
-- ECDSA / Taproot / message signing outputs verified byte-for-byte identical to
-  the pre-upgrade implementation; XRP secp256k1 family-seed derivation and
-  classic/X-address conversion pinned with characterization tests.
-- `Bech32Validations` / `SegwitValidations` declared as `mixin` (Dart 3 language
-  level no longer permits using a plain class as a mixin).
-
-### Notes
-
-- No public API changes beyond the SDK floor; all 782 unit tests pass.
-
-
-## [2.0.2] - 2026-07-02
-### Fixed
-
-- PSBT: parse LTC P2SH / Nested SegWit addresses correctly by plumbing chain-aware
-  version bytes and bech32 HRP through address encoding instead of hard-coding BTC
-  mainnet values.
-- GSPL: support LTC P2SH payment address parsing by detecting the script type
-  (P2PKH vs P2SH) and resolving the correct network version bytes from the bip44
-  path coin-type segment.
-- BTC / LTC chain configs: fill in distinct testnet NetworkType values (previously
-  shared mainnet settings).
-
-## [2.0.1] - 2026-06-12
-### Added
-
-- SC (Sia): native Go FFI transaction bridge (`ScGoFfiBridge`) as a faster,
-  opt-in alternative to the WASM bridge. The default `create()` is unchanged
-  and still uses the WASM bridge (`ScWasmRunBridge`), so existing callers are
-  unaffected. The native library is **not** bundled: the caller builds it for
-  their platform (see `lib/src/forked_lib/sia-wasi/build.sh`), loads it, and
-  passes it via `ScTransactionBuilder.createWithFfi(DynamicLibrary)`.
-
-### Changed
-
-- Minimum Dart SDK raised to `>=3.11.0` (required by the `wasd` WASM
-  interpreter that backs the default SC bridge). Consumers on Dart 3.7–3.10
-  must upgrade.
-
-### Removed
-
-- Pruned dead code from the vendored `bitcoin_base_hd` fork that is never
-  reached by this package (BTC/LTC/BCH only use `ECPrivate`):
-  - the entire `provider/` subtree (Electrum/HTTP API providers and the
-    `BitcoinTransactionBuilder` / BCH builder) and `utils/btc_utils.dart`
-    (~2.2k lines).
-  - `ECPublic.verifyTransactionSignature` and
-    `ECPublic.verifySchnorrTransactionSignature` (unused; their post-upgrade
-    bodies had latent argument-shape issues).

--- a/packages/crypto_wallet_util/CHANGELOG.md
+++ b/packages/crypto_wallet_util/CHANGELOG.md
@@ -1,5 +1,81 @@
 # Changelog
 
+## [2.0.3] - 2026-07-17
+### Fixed
+
+- BTC testnet address generation now respects the network type from `WalletSetting`.
+  Previously, `BtcCoin.publicKeyToAddress` hardcoded mainnet version bytes (0x00)
+  and HRP ('bc'), causing testnet wallets to generate mainnet-format addresses that
+  were misidentified as BCH testnet addresses during validation.
+- Added regression tests to verify BTC testnet addresses are correctly generated
+  (using version byte 0x6f for legacy, 'tb' HRP for segwit) and properly detected
+  as BTC rather than BCH.
+
+## [2.0.2] - 2026-07-02
+### Fixed
+
+- PSBT: parse LTC P2SH / Nested SegWit addresses correctly by plumbing chain-aware
+  version bytes and bech32 HRP through address encoding instead of hard-coding BTC
+  mainnet values.
+- GSPL: support LTC P2SH payment address parsing by detecting the script type
+  (P2PKH vs P2SH) and resolving the correct network version bytes from the bip44
+  path coin-type segment.
+- BTC / LTC chain configs: fill in distinct testnet NetworkType values (previously
+  shared mainnet settings).
+
+## [2.0.1] - 2026-06-12
+### Added
+
+- SC (Sia): native Go FFI transaction bridge (`ScGoFfiBridge`) as a faster,
+  opt-in alternative to the WASM bridge. The default `create()` is unchanged
+  and still uses the WASM bridge (`ScWasmRunBridge`), so existing callers are
+  unaffected. The native library is **not** bundled: the caller builds it for
+  their platform (see `lib/src/forked_lib/sia-wasi/build.sh`), loads it, and
+  passes it via `ScTransactionBuilder.createWithFfi(DynamicLibrary)`.
+
+### Changed
+
+- Minimum Dart SDK raised to `>=3.11.0` (required by the `wasd` WASM
+  interpreter that backs the default SC bridge). Consumers on Dart 3.7–3.10
+  must upgrade.
+
+### Removed
+
+- Pruned dead code from the vendored `bitcoin_base_hd` fork that is never
+  reached by this package (BTC/LTC/BCH only use `ECPrivate`):
+  - the entire `provider/` subtree (Electrum/HTTP API providers and the
+    `BitcoinTransactionBuilder` / BCH builder) and `utils/btc_utils.dart`
+    (~2.2k lines).
+  - `ECPublic.verifyTransactionSignature` and
+    `ECPublic.verifySchnorrTransactionSignature` (unused; their post-upgrade
+    bodies had latent argument-shape issues).
+## [2.0.0] - 2026-06-09
+### BREAKING
+
+- Upgrade `blockchain_utils` from `^1.4.1` to `^6.0.0`. Resolves the dependency
+  conflict reported in #20 (consumers using `bitcoin_base 7.x` / `xrpl_dart 7.x`,
+  which require `blockchain_utils ^6.0.0`).
+- Minimum Dart SDK raised to `>=3.7.0` (required by `blockchain_utils 6.0.0`).
+
+### Changed
+
+- Migrated the vendored `bitcoin_base_hd` and `xrpl_dart` forks to the
+  `blockchain_utils` 6.x API: relocated utility imports to the package barrel,
+  `Tuple`/`item1,item2` → Dart records (`$1`,`$2`), `mask*`/`writeUintXLE` →
+  `BinaryOps.*`, `bytesEqual`/`iterableIsEqual` → `BytesUtils`/`CompareUtils`,
+  `Secp256k1*KeyEcdsa` → `Secp256k1*Key`, `BitcoinSigner`/`BitcoinVerifier` →
+  `BitcoinKeySigner`/`BitcoinSignatureVerifier`, `BigintUtils.orderLen` →
+  `BigintUtils.bitlengthInBytes`.
+- ECDSA / Taproot / message signing outputs verified byte-for-byte identical to
+  the pre-upgrade implementation; XRP secp256k1 family-seed derivation and
+  classic/X-address conversion pinned with characterization tests.
+- `Bech32Validations` / `SegwitValidations` declared as `mixin` (Dart 3 language
+  level no longer permits using a plain class as a mixin).
+
+### Notes
+
+- No public API changes beyond the SDK floor; all 782 unit tests pass.
+
 ## [1.0.0] - 2024-06-19
 
 ### Added
@@ -258,70 +334,3 @@
 - SC transaction signer (Ed25519) and builder.
 - SC send example.
 
-
-## [2.0.0] - 2026-06-09
-### BREAKING
-
-- Upgrade `blockchain_utils` from `^1.4.1` to `^6.0.0`. Resolves the dependency
-  conflict reported in #20 (consumers using `bitcoin_base 7.x` / `xrpl_dart 7.x`,
-  which require `blockchain_utils ^6.0.0`).
-- Minimum Dart SDK raised to `>=3.7.0` (required by `blockchain_utils 6.0.0`).
-
-### Changed
-
-- Migrated the vendored `bitcoin_base_hd` and `xrpl_dart` forks to the
-  `blockchain_utils` 6.x API: relocated utility imports to the package barrel,
-  `Tuple`/`item1,item2` → Dart records (`$1`,`$2`), `mask*`/`writeUintXLE` →
-  `BinaryOps.*`, `bytesEqual`/`iterableIsEqual` → `BytesUtils`/`CompareUtils`,
-  `Secp256k1*KeyEcdsa` → `Secp256k1*Key`, `BitcoinSigner`/`BitcoinVerifier` →
-  `BitcoinKeySigner`/`BitcoinSignatureVerifier`, `BigintUtils.orderLen` →
-  `BigintUtils.bitlengthInBytes`.
-- ECDSA / Taproot / message signing outputs verified byte-for-byte identical to
-  the pre-upgrade implementation; XRP secp256k1 family-seed derivation and
-  classic/X-address conversion pinned with characterization tests.
-- `Bech32Validations` / `SegwitValidations` declared as `mixin` (Dart 3 language
-  level no longer permits using a plain class as a mixin).
-
-### Notes
-
-- No public API changes beyond the SDK floor; all 782 unit tests pass.
-
-
-## [2.0.2] - 2026-07-02
-### Fixed
-
-- PSBT: parse LTC P2SH / Nested SegWit addresses correctly by plumbing chain-aware
-  version bytes and bech32 HRP through address encoding instead of hard-coding BTC
-  mainnet values.
-- GSPL: support LTC P2SH payment address parsing by detecting the script type
-  (P2PKH vs P2SH) and resolving the correct network version bytes from the bip44
-  path coin-type segment.
-- BTC / LTC chain configs: fill in distinct testnet NetworkType values (previously
-  shared mainnet settings).
-
-## [2.0.1] - 2026-06-12
-### Added
-
-- SC (Sia): native Go FFI transaction bridge (`ScGoFfiBridge`) as a faster,
-  opt-in alternative to the WASM bridge. The default `create()` is unchanged
-  and still uses the WASM bridge (`ScWasmRunBridge`), so existing callers are
-  unaffected. The native library is **not** bundled: the caller builds it for
-  their platform (see `lib/src/forked_lib/sia-wasi/build.sh`), loads it, and
-  passes it via `ScTransactionBuilder.createWithFfi(DynamicLibrary)`.
-
-### Changed
-
-- Minimum Dart SDK raised to `>=3.11.0` (required by the `wasd` WASM
-  interpreter that backs the default SC bridge). Consumers on Dart 3.7–3.10
-  must upgrade.
-
-### Removed
-
-- Pruned dead code from the vendored `bitcoin_base_hd` fork that is never
-  reached by this package (BTC/LTC/BCH only use `ECPrivate`):
-  - the entire `provider/` subtree (Electrum/HTTP API providers and the
-    `BitcoinTransactionBuilder` / BCH builder) and `utils/btc_utils.dart`
-    (~2.2k lines).
-  - `ECPublic.verifyTransactionSignature` and
-    `ECPublic.verifySchnorrTransactionSignature` (unused; their post-upgrade
-    bodies had latent argument-shape issues).

--- a/packages/crypto_wallet_util/lib/src/config/chain/btc/bch.dart
+++ b/packages/crypto_wallet_util/lib/src/config/chain/btc/bch.dart
@@ -1,34 +1,36 @@
 import 'package:crypto_wallet_util/crypto_utils.dart';
-import 'package:crypto_wallet_util/src/forked_lib/bitcoin_flutter/bitcoin_flutter.dart';
 
-/// Provide default config for **bch**, address type is [AddressType.BTC], bip44 path is [BCH_PATH].  
-/// Testnet and mainnet share the same setting. Use [HDWallet] to to instantiate wallet.
+/// Provide default config for **bch**, address type is [AddressType.BTC], bip44 path is [BCH_PATH].
+/// Testnet uses the bchtest CashAddr prefix and Bitcoin testnet version bytes.
 class BCHChain extends ConfChain {
   BCHChain()
-      : super(
-            name: 'bch',
-            mainnet: WalletSetting(
-              bip44Path: BCH_PATH,
-              addressType: AddressType.BTC,
-              prefix: BITCOINCASH_PREFIX,
-              networkType: NetworkType(
-                  messagePrefix: '\u0019BitcoinCash Signed Message:\n',
-                  wif: 128,
-                  pubKeyHash: 0,
-                  scriptHash: 5,
-                  prefix: BITCOINCASH_PREFIX,
-                  bip32: Bip32Type(public: 76067358, private: 76066276)),
-            ),
-            testnet: WalletSetting(
-              bip44Path: BCH_PATH,
-              addressType: AddressType.BTC,
-              prefix: BITCOINCASH_PREFIX,
-              networkType: NetworkType(
-                  messagePrefix: '\u0019BitcoinCash Signed Message:\n',
-                  wif: 128,
-                  pubKeyHash: 0,
-                  scriptHash: 5,
-                  prefix: BITCOINCASH_PREFIX,
-                  bip32: Bip32Type(public: 76067358, private: 76066276)),
-            ));
+    : super(
+        name: 'bch',
+        mainnet: WalletSetting(
+          bip44Path: BCH_PATH,
+          addressType: AddressType.BTC,
+          prefix: BITCOINCASH_PREFIX,
+          networkType: NetworkType(
+            messagePrefix: '\u0019BitcoinCash Signed Message:\n',
+            wif: 128,
+            pubKeyHash: 0,
+            scriptHash: 5,
+            prefix: BITCOINCASH_PREFIX,
+            bip32: Bip32Type(public: 76067358, private: 76066276),
+          ),
+        ),
+        testnet: WalletSetting(
+          bip44Path: BCH_PATH,
+          addressType: AddressType.BTC,
+          prefix: BITCOINCASH_TESTNET_PREFIX,
+          networkType: NetworkType(
+            messagePrefix: '\u0019BitcoinCash Signed Message:\n',
+            wif: 239,
+            pubKeyHash: 0x6f,
+            scriptHash: 0xc4,
+            prefix: BITCOINCASH_TESTNET_PREFIX,
+            bip32: Bip32Type(public: 70617704, private: 70615956),
+          ),
+        ),
+      );
 }

--- a/packages/crypto_wallet_util/lib/src/config/chain/btc/bch.dart
+++ b/packages/crypto_wallet_util/lib/src/config/chain/btc/bch.dart
@@ -29,7 +29,8 @@ class BCHChain extends ConfChain {
             pubKeyHash: 0x6f,
             scriptHash: 0xc4,
             prefix: BITCOINCASH_TESTNET_PREFIX,
-            bip32: Bip32Type(public: 70617704, private: 70615956),
+            // tpub/tprv: 0x043587cf / 0x04358394.
+            bip32: Bip32Type(public: 70617039, private: 70615956),
           ),
         ),
       );

--- a/packages/crypto_wallet_util/lib/src/config/chain/btc/btc.dart
+++ b/packages/crypto_wallet_util/lib/src/config/chain/btc/btc.dart
@@ -27,6 +27,7 @@ class BTCChain extends ConfChain {
                   wif: 239,
                   pubKeyHash: 0x6f,
                   scriptHash: 0xc4,
-                  bip32: Bip32Type(public: 70617704, private: 70615956)),
+                  // tpub/tprv: 0x043587cf / 0x04358394.
+                  bip32: Bip32Type(public: 70617039, private: 70615956)),
             ));
 }

--- a/packages/crypto_wallet_util/lib/src/config/constants/constants.dart
+++ b/packages/crypto_wallet_util/lib/src/config/constants/constants.dart
@@ -91,6 +91,9 @@ const KLS_PREFIX = "karlsen";
 /// BITCOINCASH_PREFIX: bitcoincash;
 const BITCOINCASH_PREFIX = 'bitcoincash';
 
+/// BITCOINCASH_TESTNET_PREFIX: bchtest;
+const BITCOINCASH_TESTNET_PREFIX = 'bchtest';
+
 /// BTC_ADDRESS_REG: ```^([a-km-zA-HJ-NP-Z1-9]{27,34})|(bitcoincash:[a-z0-9]{42})|(bc[a-zA-Z0-9]{25,87})$```
 const String BTC_ADDRESS_REG =
     r'^([a-km-zA-HJ-NP-Z1-9]{27,34})|(bitcoincash:[a-z0-9]{42})|(bc[a-zA-Z0-9]{25,87})$';

--- a/packages/crypto_wallet_util/lib/src/forked_lib/bitcoin_flutter/src/address.dart
+++ b/packages/crypto_wallet_util/lib/src/forked_lib/bitcoin_flutter/src/address.dart
@@ -174,32 +174,47 @@ class Address {
 
   static String bchToLegacy(String addr, {String? prefix}) {
     final parts = addr.split(':');
-    if (parts.length != 2 ||
-        (prefix != null && !validateCashAddress(addr, prefix))) {
+    final cashAddressPrefix = (prefix ?? parts.first).toLowerCase();
+    if (parts.length != 2 || !validateCashAddress(addr, cashAddressPrefix)) {
       throw ArgumentError('Invalid CashAddr');
     }
-    final payload = base32Decode(addr.split(':')[1]);
-    final hash = convertBits(
+    final payload = base32Decode(parts[1]);
+    final decoded = convertBits(
       payload.sublist(0, payload.length - 8),
       5,
       8,
       strictMode: true,
     );
-    return bs58check.encode(Uint8List.fromList(hash));
+    final isScriptHash = decoded.first & 0x78 == 8;
+    final isMainnet = cashAddressPrefix == 'bitcoincash';
+    final legacyVersion = isMainnet
+        ? (isScriptHash ? 0x05 : 0x00)
+        : (isScriptHash ? 0xc4 : 0x6f);
+    return bs58check.encode(
+      Uint8List.fromList([legacyVersion, ...decoded.sublist(1)]),
+    );
   }
 
   static String legacyToBch({required String address, required String prefix}) {
     final decode = bs58check.decode(address);
     final hash = decode.sublist(1);
-    final type = 'P2PKH';
+    final normalizedPrefix = prefix.toLowerCase();
+    final isMainnet = normalizedPrefix == 'bitcoincash';
+    final pubKeyHashVersion = isMainnet ? 0x00 : 0x6f;
+    final scriptHashVersion = isMainnet ? 0x05 : 0xc4;
+    final type = decode.first == pubKeyHashVersion
+        ? 'P2PKH'
+        : decode.first == scriptHashVersion
+        ? 'P2SH'
+        : throw ArgumentError('Legacy address does not match CashAddr network');
 
-    final prefixData = prefixToUint5Array(prefix) + [0];
+    final prefixData = prefixToUint5Array(normalizedPrefix) + [0];
     final versionByte = getTypeBits(type) + getHashSizeBits(hash);
     final payloadData = convertBits([versionByte] + hash, 8, 5);
     final checksumData =
         prefixData + payloadData + List.generate(8, (index) => 0);
     final payload = payloadData + checksumToUint5Array(polymod(checksumData));
 
-    return '$prefix:${base32Encode(payload)}';
+    return '$normalizedPrefix:${base32Encode(payload)}';
   }
 }

--- a/packages/crypto_wallet_util/lib/src/forked_lib/bitcoin_flutter/src/address.dart
+++ b/packages/crypto_wallet_util/lib/src/forked_lib/bitcoin_flutter/src/address.dart
@@ -12,7 +12,6 @@ import '../src/models/networks.dart';
 import '../src/payments/index.dart' show PaymentData;
 import '../src/payments/p2pkh.dart';
 import '../src/payments/p2sh.dart';
-import '../src/payments/p2wpkh.dart';
 import '../src/utils/constants/op.dart';
 import '../src/utils/script.dart';
 
@@ -30,15 +29,27 @@ class Address {
     final network = nw ?? bitcoin;
     bool flag = false;
     final parts = address.split(':');
-    if(parts.length == 2 && parts[0] == 'bitcoincash'){
-      final reAddress = bchToLegacy(address);
-      address = reAddress;
+    if (parts.length == 2) {
+      final cashAddressPrefix = network.prefix;
+      if (cashAddressPrefix == null ||
+          !validateCashAddress(address, cashAddressPrefix)) {
+        throw ArgumentError('Invalid CashAddr prefix or checksum');
+      }
+      address = bchToLegacy(address, prefix: cashAddressPrefix);
     }
 
     try {
       final decodeBase58 = bs58check.decode(address);
-      if (decodeBase58[0] == network.pubKeyHash) return P2PKH(data: PaymentData(address: address), network: network).data.output;
-      if (decodeBase58[0] == network.scriptHash) return P2SH(data: PaymentData(address: address), network: network).data.output;
+      if (decodeBase58[0] == network.pubKeyHash)
+        return P2PKH(
+          data: PaymentData(address: address),
+          network: network,
+        ).data.output;
+      if (decodeBase58[0] == network.scriptHash)
+        return P2SH(
+          data: PaymentData(address: address),
+          network: network,
+        ).data.output;
 
       throw ArgumentError('Invalid version or Network mismatch');
     } catch (e) {
@@ -47,28 +58,49 @@ class Address {
 
     try {
       final decodeBech32 = bech32.decode(address);
-      if (network.bech32 != decodeBech32.hrp) throw ArgumentError('Invalid prefix or Network mismatch');
-
-      final p2wpkh = P2WPKH(data: PaymentData(address: address), network: network);
-      return p2wpkh.data.output;
+      if (network.bech32 != decodeBech32.hrp)
+        throw ArgumentError('Invalid prefix or Network mismatch');
+      if (decodeBech32.data.isEmpty || decodeBech32.data.first != 0) {
+        throw ArgumentError('Unsupported witness version');
+      }
+      final program = Uint8List.fromList(
+        convertBits(decodeBech32.data.sublist(1), 5, 8, strictMode: true),
+      );
+      if (program.length != 20 && program.length != 32) {
+        throw ArgumentError('Invalid SegWit v0 witness program');
+      }
+      return compile([OPS['OP_0'], program]);
     } catch (e) {
       flag = true;
     }
 
     try {
       final decodeBech32m = bech32.decode(address, encoding: 'bech32m');
-      if (network.bech32 != decodeBech32m.hrp) throw ArgumentError('Invalid prefix or Network mismatch');
+      if (network.bech32 != decodeBech32m.hrp)
+        throw ArgumentError('Invalid prefix or Network mismatch');
+      if (decodeBech32m.data.isEmpty || decodeBech32m.data.first != 1) {
+        throw ArgumentError('Unsupported witness version');
+      }
 
-      final hash = Uint8List.fromList(convertBits(decodeBech32m.data.sublist(1), 5, 8, strictMode: true));
+      final hash = Uint8List.fromList(
+        convertBits(decodeBech32m.data.sublist(1), 5, 8, strictMode: true),
+      );
+      if (hash.length != 32) {
+        throw ArgumentError('Invalid Taproot witness program');
+      }
       return compile([OPS['OP_1'], hash]);
     } catch (e) {
       flag = true;
     }
 
-    if(flag) throw ArgumentError('$address has no matching Script');
+    if (flag) throw ArgumentError('$address has no matching Script');
   }
 
-  static String createExtendedAddress(Uint8List seed, {String? path, List<int>? prefix}) {
+  static String createExtendedAddress(
+    Uint8List seed, {
+    String? path,
+    List<int>? prefix,
+  }) {
     path ??= "m/44'/195'/0'/0/0";
     prefix ??= xprv;
 
@@ -94,10 +126,65 @@ class Address {
     return Base58CheckCodec.bitcoin().encode(Base58CheckPayload(0x41, addr));
   }
 
-  static String bchToLegacy(String addr) {
-    if(addr.split(':').length == 1) return '';
+  static bool validateCashAddress(String address, String prefix) {
+    try {
+      if (address.toLowerCase() != address &&
+          address.toUpperCase() != address) {
+        return false;
+      }
+
+      final normalizedAddress = address.toLowerCase();
+      final normalizedPrefix = prefix.toLowerCase();
+      final parts = normalizedAddress.split(':');
+      if (parts.length != 2 ||
+          parts[0] != normalizedPrefix ||
+          parts[1].isEmpty) {
+        return false;
+      }
+
+      final payload = base32Decode(parts[1]);
+      if (payload.length <= 8 || payload.any((value) => value < 0)) {
+        return false;
+      }
+
+      final checksumData = prefixToUint5Array(normalizedPrefix) + [0] + payload;
+      if (polymod(checksumData) != BigInt.zero) {
+        return false;
+      }
+
+      final payloadData = payload.sublist(0, payload.length - 8);
+      final decoded = convertBits(payloadData, 5, 8, strictMode: true);
+      if (decoded.isEmpty ||
+          convertBits(decoded, 8, 5).join(',') != payloadData.join(',')) {
+        return false;
+      }
+
+      final version = decoded.first;
+      if ((version & 0x80) != 0 ||
+          (version & 0x78) != 0 && (version & 0x78) != 8) {
+        return false;
+      }
+
+      const hashSizes = [20, 24, 28, 32, 40, 48, 56, 64];
+      return decoded.length - 1 == hashSizes[version & 0x07];
+    } catch (_) {
+      return false;
+    }
+  }
+
+  static String bchToLegacy(String addr, {String? prefix}) {
+    final parts = addr.split(':');
+    if (parts.length != 2 ||
+        (prefix != null && !validateCashAddress(addr, prefix))) {
+      throw ArgumentError('Invalid CashAddr');
+    }
     final payload = base32Decode(addr.split(':')[1]);
-    final hash = convertBits(payload.sublist(0, 34), 5, 8, strictMode: true);
+    final hash = convertBits(
+      payload.sublist(0, payload.length - 8),
+      5,
+      8,
+      strictMode: true,
+    );
     return bs58check.encode(Uint8List.fromList(hash));
   }
 
@@ -109,7 +196,8 @@ class Address {
     final prefixData = prefixToUint5Array(prefix) + [0];
     final versionByte = getTypeBits(type) + getHashSizeBits(hash);
     final payloadData = convertBits([versionByte] + hash, 8, 5);
-    final checksumData = prefixData + payloadData + List.generate(8, (index) => 0);
+    final checksumData =
+        prefixData + payloadData + List.generate(8, (index) => 0);
     final payload = payloadData + checksumToUint5Array(polymod(checksumData));
 
     return '$prefix:${base32Encode(payload)}';

--- a/packages/crypto_wallet_util/lib/src/forked_lib/bitcoin_flutter/src/utils/script.dart
+++ b/packages/crypto_wallet_util/lib/src/forked_lib/bitcoin_flutter/src/utils/script.dart
@@ -1,7 +1,8 @@
 import 'dart:convert';
 import 'dart:typed_data';
 
-import 'package:crypto_wallet_util/src/utils/bip32/src/utils/ecurve.dart' show isPoint;
+import 'package:crypto_wallet_util/src/utils/bip32/src/utils/ecurve.dart'
+    show isPoint;
 import 'package:hex/hex.dart';
 import 'package:crypto/crypto.dart';
 import 'package:pointycastle/export.dart';
@@ -13,14 +14,22 @@ import '../utils/push_data.dart' as pushdata;
 import '../utils/check_types.dart';
 
 final secp256k1 = ECCurve_secp256k1();
-final secp256k1P = BigInt.parse('fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f', radix: 16);
+final secp256k1P = BigInt.parse(
+  'fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f',
+  radix: 16,
+);
 
-Map<int, String> REVERSE_OPS = OPS.map((String string, int number) => MapEntry(number, string));
+Map<int, String> REVERSE_OPS = OPS.map(
+  (String string, int number) => MapEntry(number, string),
+);
 final OP_INT_BASE = OPS['OP_RESERVED'];
 final ZERO = Uint8List.fromList([0]);
 
 bool isOPInt(dynamic value) {
-  return (value is num && (value == OPS['OP_0'] || (value >= OPS['OP_1']! && value <= OPS['OP_16']!) || value == OPS['OP_1NEGATE']));
+  return (value is num &&
+      (value == OPS['OP_0'] ||
+          (value >= OPS['OP_1']! && value <= OPS['OP_16']!) ||
+          value == OPS['OP_1NEGATE']));
 }
 
 bool isPushOnlyChunk(dynamic value) {
@@ -106,10 +115,12 @@ List<dynamic>? decompile(dynamic buffer) {
 
 Uint8List? fromASM(String? asm) {
   if (asm == '') return Uint8List.fromList([]);
-  return compile(asm!.split(' ').map((chunkStr) {
-    if (OPS[chunkStr] != null) return OPS[chunkStr];
-    return HEX.decode(chunkStr);
-  }).toList());
+  return compile(
+    asm!.split(' ').map((chunkStr) {
+      if (OPS[chunkStr] != null) return OPS[chunkStr];
+      return HEX.decode(chunkStr);
+    }).toList(),
+  );
 }
 
 String toASM(List<dynamic>? c) {
@@ -119,16 +130,18 @@ String toASM(List<dynamic>? c) {
   } else {
     chunks = c;
   }
-  return chunks!.map((chunk) {
-    // data?
-    if (chunk is Uint8List) {
-      final op = asMinimalOP(chunk);
-      if (op == null) return HEX.encode(chunk);
-      chunk = op;
-    }
-    // opcode!
-    return REVERSE_OPS[chunk];
-  }).join(' ');
+  return chunks!
+      .map((chunk) {
+        // data?
+        if (chunk is Uint8List) {
+          final op = asMinimalOP(chunk);
+          if (op == null) return HEX.encode(chunk);
+          chunk = op;
+        }
+        // opcode!
+        return REVERSE_OPS[chunk];
+      })
+      .join(' ');
 }
 
 int? asMinimalOP(Uint8List buffer) {
@@ -189,8 +202,10 @@ Uint8List bip66encode(r, s) {
   if (lenS > 33) throw ArgumentError('S length is too long');
   if (r[0] & 0x80 != 0) throw ArgumentError('R value is negative');
   if (s[0] & 0x80 != 0) throw ArgumentError('S value is negative');
-  if (lenR > 1 && (r[0] == 0x00) && r[1] & 0x80 == 0) throw ArgumentError('R value excessively padded');
-  if (lenS > 1 && (s[0] == 0x00) && s[1] & 0x80 == 0) throw ArgumentError('S value excessively padded');
+  if (lenR > 1 && (r[0] == 0x00) && r[1] & 0x80 == 0)
+    throw ArgumentError('R value excessively padded');
+  if (lenS > 1 && (s[0] == 0x00) && s[1] & 0x80 == 0)
+    throw ArgumentError('S value excessively padded');
 
   var signature = Uint8List(6 + lenR + lenS as int);
 
@@ -210,8 +225,10 @@ Uint8List encodeSignature(Uint8List signature, int hashType) {
   if (!isUint(hashType, 8)) throw ArgumentError('Invalid hasType $hashType');
   if (signature.length != 64) throw ArgumentError('Invalid signature');
 
-  final hashTypeMod = hashType & ~((hashType & SIGHASH_BITCOINCASHBIP143) > 0 ? 0xc0 : 0x80);
-  if (hashTypeMod <= 0 || hashTypeMod >= 4) throw ArgumentError('Invalid hashType $hashType');
+  final hashTypeMod =
+      hashType & ~((hashType & SIGHASH_BITCOINCASHBIP143) > 0 ? 0xc0 : 0x80);
+  if (hashTypeMod <= 0 || hashTypeMod >= 4)
+    throw ArgumentError('Invalid hashType $hashType');
 
   final hashTypeBuffer = Uint8List(1);
   hashTypeBuffer.buffer.asByteData().setUint8(0, hashType);
@@ -302,12 +319,19 @@ List base32Decode(String data) {
 }
 
 polymod(data) {
-  var GENERATOR = [0x98f2bc8e61, 0x79b76d99e2, 0xf33e5fb3c4, 0xae2eabe2a8, 0x1e4f43e470];
+  var GENERATOR = [
+    0x98f2bc8e61,
+    0x79b76d99e2,
+    0xf33e5fb3c4,
+    0xae2eabe2a8,
+    0x1e4f43e470,
+  ];
   var checksum = BigInt.from(1);
   for (var i = 0; i < data.length; i++) {
     var value = data[i];
     var topBits = checksum >> 35;
-    checksum = ((checksum & BigInt.from(0x07ffffffff)) << 5) ^ BigInt.from(value);
+    checksum =
+        ((checksum & BigInt.from(0x07ffffffff)) << 5) ^ BigInt.from(value);
     for (var j = 0; j < GENERATOR.length; j++) {
       if (((topBits >> j) & BigInt.from(1)).compareTo(BigInt.from(1)) == 0) {
         checksum = checksum ^ BigInt.from(GENERATOR[j]);
@@ -339,12 +363,26 @@ List<int> bigToBytes(BigInt integer) {
   return HEX.decode(hexNum);
 }
 
+List<int> bigTo32Bytes(BigInt integer) {
+  final bytes = bigToBytes(integer);
+  if (bytes.length > 32) {
+    throw ArgumentError('Integer does not fit in 32 bytes');
+  }
+  return List<int>.filled(32 - bytes.length, 0) + bytes;
+}
+
 BigInt bigFromBytes(List<int> bytes) {
   return BigInt.parse(HEX.encode(bytes), radix: 16);
 }
 
 BigInt getE(ECPoint P, List<int> rX, List<int> m) {
-  return bigFromBytes(taggedHash('BIP0340/challenge', rX + bigToBytes(P.x!.toBigInteger()!) + m)) % secp256k1.n;
+  return bigFromBytes(
+        taggedHash(
+          'BIP0340/challenge',
+          rX + bigToBytes(P.x!.toBigInteger()!) + m,
+        ),
+      ) %
+      secp256k1.n;
 }
 
 /// If the spending conditions do not require a script path, the output key should commit to an unSpendable script path
@@ -354,10 +392,25 @@ BigInt getE(ECPoint P, List<int> rX, List<int> m) {
 List<int> taprootConstruct({required ECPoint pubKey, List<int>? merkleRoot}) {
   merkleRoot ??= [];
 
-  final tweak = taggedHash('TapTweak', bigToBytes(pubKey.x!.toBigInteger()!));
-  final mul = secp256k1.G * BigInt.parse(HEX.encode(tweak), radix: 16);
-  final result = mul! + pubKey;
-  return bigToBytes(result!.x!.toBigInteger()!);
+  final internalKey = bigTo32Bytes(pubKey.x!.toBigInteger()!);
+  // BIP340 x-only public keys use lift_x, which always chooses the curve
+  // point with an even Y coordinate. A compressed key with odd Y must not be
+  // tweaked directly.
+  final evenPublicKey =
+      secp256k1.curve.decodePoint(Uint8List.fromList([0x02, ...internalKey]))!;
+  final tweak = BigInt.parse(
+    HEX.encode(taggedHash('TapTweak', internalKey + merkleRoot)),
+    radix: 16,
+  );
+  if (tweak >= secp256k1.n) {
+    throw ArgumentError('Invalid Taproot tweak');
+  }
+
+  final result = (secp256k1.G * tweak)! + evenPublicKey;
+  if (result == null || result.isInfinity) {
+    throw ArgumentError('Invalid Taproot output key');
+  }
+  return bigTo32Bytes(result.x!.toBigInteger()!);
 }
 
 Uint8List toXOnly(Uint8List pubkey) {

--- a/packages/crypto_wallet_util/lib/src/forked_lib/psbt/transaction/partially_signed_bitcoin_transaction.dart
+++ b/packages/crypto_wallet_util/lib/src/forked_lib/psbt/transaction/partially_signed_bitcoin_transaction.dart
@@ -3,8 +3,11 @@ import 'dart:typed_data';
 import 'package:crypto_wallet_util/src/forked_lib/psbt/model/origin.dart';
 import 'package:convert/convert.dart';
 
+import 'package:bs58check/bs58check.dart' as bs58check;
+
 import '../../bitcoin_flutter/bitcoin_flutter.dart' as bitcoin;
 import 'package:crypto_wallet_util/config.dart';
+import 'package:crypto_wallet_util/src/type/wallet_type.dart';
 import 'package:crypto_wallet_util/src/utils/number.dart';
 import '../model/transfer_info.dart' as fx;
 import '../model/transfer_info.dart';
@@ -36,6 +39,24 @@ String _bchToLegacy(String address) {
   } catch (_) {
     return address;
   }
+}
+
+/// Pick the mainnet or testnet [WalletSetting] for [chain] based on the BIP32
+/// version bytes of [xpubkey]. The extended key itself is the authoritative
+/// source of its network (mainnet `xpub`/`ypub`/... vs testnet `tpub`/...), so
+/// deriving from it keeps [bitcoin.HDWallet.fromBase58] parsing consistent —
+/// passing the wrong network silently yields a null wallet and later NPEs.
+/// Falls back to mainnet when the version cannot be read or does not match.
+WalletSetting _selectNetworkForXpub(ConfChain chain, String xpubkey) {
+  try {
+    final decoded = bs58check.decode(xpubkey);
+    final version =
+        (decoded[0] << 24) | (decoded[1] << 16) | (decoded[2] << 8) | decoded[3];
+    if (version == chain.testnet.networkType?.bip32.public) {
+      return chain.testnet;
+    }
+  } catch (_) {}
+  return chain.mainnet;
 }
 
 /// Represents a PSBT(BIP-0174).
@@ -344,7 +365,8 @@ class PSBT {
   factory PSBT.fromTransferPsbt(BtcTransferInfo btcInfo,
       {WalletType walletType = WalletType.SingleSignatureWallet}) {
     String xpubkey = btcInfo.xpubkey;
-    final chainConf = getChainConfig(btcInfo.chain).mainnet;
+    final chainConf =
+        _selectNetworkForXpub(getChainConfig(btcInfo.chain), xpubkey);
     final hdWallet =
         bitcoin.HDWallet.fromBase58(xpubkey, network: chainConf.networkType);
     final Origin btcTxData = btcInfo.origin;

--- a/packages/crypto_wallet_util/lib/src/forked_lib/psbt/transaction/partially_signed_bitcoin_transaction.dart
+++ b/packages/crypto_wallet_util/lib/src/forked_lib/psbt/transaction/partially_signed_bitcoin_transaction.dart
@@ -7,7 +7,8 @@ import 'package:bs58check/bs58check.dart' as bs58check;
 
 import '../../bitcoin_flutter/bitcoin_flutter.dart' as bitcoin;
 import 'package:crypto_wallet_util/config.dart';
-import 'package:crypto_wallet_util/src/type/wallet_type.dart';
+import 'package:crypto_wallet_util/src/utils/bip32/bip32.dart'
+    show Bip32Type, NetworkType;
 import 'package:crypto_wallet_util/src/utils/number.dart';
 import '../model/transfer_info.dart' as fx;
 import '../model/transfer_info.dart';
@@ -27,6 +28,11 @@ const PSBT_IN_TAP_INTERNAL_KEY = "17";
 
 enum WalletType { SingleSignatureWallet, MultisignatureWallet }
 
+// crypto_wallet_util 2.0.2 accidentally shipped this BTC testnet BIP32 public
+// version. Existing persisted watch-only keys must remain readable after the
+// corrected standard tpub version was introduced in 2.0.3.
+const int _legacyBtcTestnetBip32Public = 0x04358a68;
+
 /// Normalise a BCH address to its legacy (base58) form so CashAddr and legacy
 /// representations can be compared. The CashAddr network prefix (`bitcoincash`
 /// or `bchtest`) is inferred from the address itself; a legacy address is
@@ -41,22 +47,58 @@ String _bchToLegacy(String address) {
   }
 }
 
-/// Pick the mainnet or testnet [WalletSetting] for [chain] based on the BIP32
-/// version bytes of [xpubkey]. The extended key itself is the authoritative
-/// source of its network (mainnet `xpub`/`ypub`/... vs testnet `tpub`/...), so
-/// deriving from it keeps [bitcoin.HDWallet.fromBase58] parsing consistent —
-/// passing the wrong network silently yields a null wallet and later NPEs.
-/// Falls back to mainnet when the version cannot be read or does not match.
-WalletSetting _selectNetworkForXpub(ConfChain chain, String xpubkey) {
+NetworkType _networkWithBip32Public(NetworkType network, int publicVersion) {
+  return NetworkType(
+    messagePrefix: network.messagePrefix,
+    bech32: network.bech32,
+    prefix: network.prefix,
+    bip32: Bip32Type(
+      public: publicVersion,
+      private: network.bip32.private,
+    ),
+    pubKeyHash: network.pubKeyHash,
+    scriptHash: network.scriptHash,
+    wif: network.wif,
+  );
+}
+
+/// Select the network used to parse [xpubkey] from its BIP32 version bytes.
+///
+/// Besides the configured mainnet and testnet public versions, BTC accepts the
+/// non-standard testnet public version shipped by crypto_wallet_util 2.0.2.
+/// No other fallback is allowed: malformed keys and unknown versions fail
+/// closed instead of being passed to the mainnet parser and failing later.
+NetworkType _selectNetworkForXpub(ConfChain chain, String xpubkey) {
+  late final Uint8List decoded;
   try {
-    final decoded = bs58check.decode(xpubkey);
-    final version =
-        (decoded[0] << 24) | (decoded[1] << 16) | (decoded[2] << 8) | decoded[3];
-    if (version == chain.testnet.networkType?.bip32.public) {
-      return chain.testnet;
-    }
-  } catch (_) {}
-  return chain.mainnet;
+    decoded = bs58check.decode(xpubkey);
+  } catch (_) {
+    throw ArgumentError.value(xpubkey, 'xpubkey', 'Invalid extended public key');
+  }
+  if (decoded.length != 78) {
+    throw ArgumentError.value(xpubkey, 'xpubkey', 'Invalid extended public key');
+  }
+
+  final mainnet = chain.mainnet.networkType;
+  final testnet = chain.testnet.networkType;
+  if (mainnet == null || testnet == null) {
+    throw ArgumentError('Missing BIP32 network configuration for ${chain.name}');
+  }
+
+  final version =
+      (decoded[0] << 24) | (decoded[1] << 16) | (decoded[2] << 8) | decoded[3];
+  if (version == mainnet.bip32.public) return mainnet;
+  if (version == testnet.bip32.public) return testnet;
+  if (chain.name.toLowerCase() == 'btc' &&
+      version == _legacyBtcTestnetBip32Public) {
+    return _networkWithBip32Public(testnet, version);
+  }
+
+  throw ArgumentError.value(
+    version,
+    'xpubkey',
+    'Unsupported extended public key version',
+  );
 }
 
 /// Represents a PSBT(BIP-0174).
@@ -365,10 +407,9 @@ class PSBT {
   factory PSBT.fromTransferPsbt(BtcTransferInfo btcInfo,
       {WalletType walletType = WalletType.SingleSignatureWallet}) {
     String xpubkey = btcInfo.xpubkey;
-    final chainConf =
+    final network =
         _selectNetworkForXpub(getChainConfig(btcInfo.chain), xpubkey);
-    final hdWallet =
-        bitcoin.HDWallet.fromBase58(xpubkey, network: chainConf.networkType);
+    final hdWallet = bitcoin.HDWallet.fromBase58(xpubkey, network: network);
     final Origin btcTxData = btcInfo.origin;
 
     int offset = 0;

--- a/packages/crypto_wallet_util/lib/src/forked_lib/psbt/transaction/partially_signed_bitcoin_transaction.dart
+++ b/packages/crypto_wallet_util/lib/src/forked_lib/psbt/transaction/partially_signed_bitcoin_transaction.dart
@@ -24,6 +24,20 @@ const PSBT_IN_TAP_INTERNAL_KEY = "17";
 
 enum WalletType { SingleSignatureWallet, MultisignatureWallet }
 
+/// Normalise a BCH address to its legacy (base58) form so CashAddr and legacy
+/// representations can be compared. The CashAddr network prefix (`bitcoincash`
+/// or `bchtest`) is inferred from the address itself; a legacy address is
+/// returned unchanged. On any conversion failure the input is returned as-is so
+/// callers fall back to a plain string comparison instead of throwing.
+String _bchToLegacy(String address) {
+  if (!address.contains(':')) return address;
+  try {
+    return bitcoin.Address.bchToLegacy(address);
+  } catch (_) {
+    return address;
+  }
+}
+
 /// Represents a PSBT(BIP-0174).
 class PSBT {
   /// @nodoc
@@ -426,16 +440,18 @@ class PSBT {
       }
     }
     int changeIndex = -1; // total - payoff;
-    if (outputsIndex.isNotEmpty &&
-        (outputs[outputsIndex[0]].address == inputAddress ||
-            (btcInfo.chain.toLowerCase() == 'bch' &&
-                (outputs[outputsIndex[0]].address ==
-                        bitcoin.Address.bchToLegacy(
-                            inputAddress, prefix: 'bitcoincash') ||
-                    outputs[outputsIndex[0]].address ==
-                        bitcoin.Address.legacyToBch(
-                            address: inputAddress, prefix: 'bitcoincash'))))) {
-      changeIndex = outputsIndex[0];
+    if (outputsIndex.isNotEmpty) {
+      final candidate = outputs[outputsIndex[0]].address;
+      bool isChange = candidate == inputAddress;
+      if (!isChange && btcInfo.chain.toLowerCase() == 'bch') {
+        // BCH addresses come in CashAddr and legacy forms, on either mainnet
+        // (`bitcoincash`) or testnet (`bchtest`). Normalise both sides to their
+        // legacy form — inferring the network prefix from each address instead
+        // of hard-coding mainnet — so a testnet CashAddr input matches its
+        // legacy change output.
+        isChange = _bchToLegacy(candidate) == _bchToLegacy(inputAddress);
+      }
+      if (isChange) changeIndex = outputsIndex[0];
     }
 
     // Outputs

--- a/packages/crypto_wallet_util/lib/src/forked_lib/psbt/transaction/partially_signed_bitcoin_transaction.dart
+++ b/packages/crypto_wallet_util/lib/src/forked_lib/psbt/transaction/partially_signed_bitcoin_transaction.dart
@@ -430,7 +430,8 @@ class PSBT {
         (outputs[outputsIndex[0]].address == inputAddress ||
             (btcInfo.chain.toLowerCase() == 'bch' &&
                 (outputs[outputsIndex[0]].address ==
-                        bitcoin.Address.bchToLegacy(inputAddress) ||
+                        bitcoin.Address.bchToLegacy(
+                            inputAddress, prefix: 'bitcoincash') ||
                     outputs[outputsIndex[0]].address ==
                         bitcoin.Address.legacyToBch(
                             address: inputAddress, prefix: 'bitcoincash'))))) {

--- a/packages/crypto_wallet_util/lib/src/utils/address.dart
+++ b/packages/crypto_wallet_util/lib/src/utils/address.dart
@@ -55,16 +55,14 @@ class AddressUtils {
     return RegExp(ETH_ADDRESS_REG).hasMatch(address);
   }
 
-  static bool checkBtcAddress(String address,
-      [NetworkType? networkType]) {
+  static bool checkBtcAddress(String address, [NetworkType? networkType]) {
     try {
-      if (networkType?.prefix == 'bitcoincash' &&
-          !address.startsWith('1') &&
-          !address.startsWith('3')) {
-        return checkStandardBase32(address);
-      }
-      if (address.startsWith('bc')) {
-        return checkBech32Address(address, 'bc', address.length - 3);
+      final cashAddressPrefix = networkType?.prefix;
+      if (cashAddressPrefix != null) {
+        // BTC and BCH testnet legacy P2PKH addresses share version 0x6f, so
+        // they cannot be classified by address bytes alone. Require the
+        // network-qualified CashAddr form for BCH.
+        return bitcoin.Address.validateCashAddress(address, cashAddressPrefix);
       }
       bitcoin.Address.addressToOutputScript(address, networkType);
       return true;
@@ -85,8 +83,11 @@ class AddressUtils {
     }
   }
 
-  static bool checkBase58Address(String address, String regExp,
-      [int length = 32]) {
+  static bool checkBase58Address(
+    String address,
+    String regExp, [
+    int length = 32,
+  ]) {
     try {
       if (!RegExp(regExp).hasMatch(address)) {
         return false;
@@ -194,8 +195,10 @@ class AddressUtils {
   static bool checkAlgoAddress(String address, conf) {
     if (!RegExp(conf.regExp).hasMatch(address.toLowerCase())) return false;
 
-    final base32Data =
-        Base32.decode(address.toLowerCase(), type: Base32Type.RFC4648);
+    final base32Data = Base32.decode(
+      address.toLowerCase(),
+      type: Base32Type.RFC4648,
+    );
     final data = base32Data.sublist(0, base32Data.length - 4);
     final checkSum = base32Data.sublist(base32Data.length - 4);
     final sha512data = getSHA512256(data.toUint8List());
@@ -253,8 +256,9 @@ bool checkStandardBase32(String address) {
 
 bool checkRFC4648Base32(String address, String prefix) {
   try {
-    String addressData =
-        address.substring(address.indexOf(prefix) + prefix.length);
+    String addressData = address.substring(
+      address.indexOf(prefix) + prefix.length,
+    );
     final decoded =
         Base32.decode(addressData, type: Base32Type.RFC4648).toUint8List();
     final addressEncode = Base32.encode(decoded, type: Base32Type.RFC4648);
@@ -273,8 +277,9 @@ bool checkBase58(String address, {int length = 25}) {
   Uint8List data = decoded.sublist(0, decoded.length - 4);
   Uint8List checksum = decoded.sublist(decoded.length - 4);
   Uint8List midData = Uint8List.fromList(sha256.convert(data).bytes);
-  Uint8List calculatedChecksum =
-      Uint8List.fromList(sha256.convert(midData).bytes.sublist(0, 4));
+  Uint8List calculatedChecksum = Uint8List.fromList(
+    sha256.convert(midData).bytes.sublist(0, 4),
+  );
   for (int i = 0; i < 4; i++) {
     if (checksum[i] != calculatedChecksum[i]) {
       return false;
@@ -319,8 +324,9 @@ String toEthChecksumAddress(String address) {
 /// A method to get [AddressType] by network name([String]).
 AddressType getAddressType(network) {
   return AddressType.values.firstWhere(
-      (e) => (e.toString().split(".").last) == network.toUpperCase(),
-      orElse: () => AddressType.NONE);
+    (e) => (e.toString().split(".").last) == network.toUpperCase(),
+    orElse: () => AddressType.NONE,
+  );
 }
 
 /// [AddressType] enum to [String]

--- a/packages/crypto_wallet_util/lib/src/utils/bech32/bech32.dart
+++ b/packages/crypto_wallet_util/lib/src/utils/bech32/bech32.dart
@@ -108,8 +108,10 @@ class Bech32Decoder extends Converter<String, Bech32> with Bech32Validations {
     }
 
     final encodedData = input.substring(separatorPosition + 1);
-    final dataIncludingChecksum =
-        encodedData.split('').map((c) => charset.indexOf(c)).toList();
+    final dataIncludingChecksum = encodedData
+        .split('')
+        .map((c) => charset.indexOf(c))
+        .toList();
     if (hasOutOfBoundsChars(dataIncludingChecksum)) {
       throw OutOfBoundChars(encodedData);
     }
@@ -280,7 +282,10 @@ List<int> convertBits(data, int from, int to, {bool strictMode = false}) {
   var bits = 0;
 
   for (var i = 0; i < data.length; i++) {
-    var value = data[i];
+    final value = data[i] as int;
+    if (value < 0 || value >> from != 0) {
+      throw ArgumentError('Input value $value exceeds $from bits');
+    }
     accumulator = (accumulator << from) | value;
     bits += from;
     while (bits >= to) {
@@ -293,9 +298,10 @@ List<int> convertBits(data, int from, int to, {bool strictMode = false}) {
   if (!strictMode) {
     if (bits > 0) {
       result[index] = (accumulator << (to - bits)) & mask;
-      index++;
     }
-  } else {}
+  } else if (bits >= from || ((accumulator << (to - bits)) & mask) != 0) {
+    throw ArgumentError('Invalid padding');
+  }
 
   return result;
 }
@@ -334,10 +340,9 @@ Uint8List convertBit(Uint8List buff) {
   String str = '';
   for (var i = 0; i < buff.length; i++) {
     String res = buff[i].toRadixString(2);
-    res =
-        res.length < 8
-            ? '00000000'.substring(0, 8 - res.length) + res
-            : buff[i].toRadixString(2);
+    res = res.length < 8
+        ? '00000000'.substring(0, 8 - res.length) + res
+        : buff[i].toRadixString(2);
 
     str = str + res;
   }

--- a/packages/crypto_wallet_util/lib/src/utils/bech32/bech32.dart
+++ b/packages/crypto_wallet_util/lib/src/utils/bech32/bech32.dart
@@ -17,24 +17,51 @@ class Bech32Codec extends Codec<Bech32, String> {
   Bech32Encoder get encoder => Bech32Encoder();
 
   @override
-  String encode(Bech32 input, {maxLength = Bech32Validations.maxInputLength, String encoding = 'bech32'}) {
-    return Bech32Encoder().convert(input, maxLength: maxLength, encoding: encoding);
+  String encode(
+    Bech32 input, {
+    maxLength = Bech32Validations.maxInputLength,
+    String encoding = 'bech32',
+  }) {
+    return Bech32Encoder().convert(
+      input,
+      maxLength: maxLength,
+      encoding: encoding,
+    );
   }
 
   @override
-  Bech32 decode(String encoded, {maxLength = Bech32Validations.maxInputLength, String encoding = 'bech32'}) {
-    return Bech32Decoder().convert(encoded, maxLength: maxLength, encoding: encoding);
+  Bech32 decode(
+    String encoded, {
+    maxLength = Bech32Validations.maxInputLength,
+    String encoding = 'bech32',
+  }) {
+    return Bech32Decoder().convert(
+      encoded,
+      maxLength: maxLength,
+      encoding: encoding,
+    );
   }
 }
 
 // This class converts a Bech32 class instance to a String.
 class Bech32Encoder extends Converter<Bech32, String> with Bech32Validations {
   @override
-  String convert(Bech32 input, {int maxLength = Bech32Validations.maxInputLength, String encoding = 'bech32'}) {
+  String convert(
+    Bech32 input, {
+    int maxLength = Bech32Validations.maxInputLength,
+    String encoding = 'bech32',
+  }) {
     var hrp = input.hrp;
     var data = input.data;
 
-    if (hrp.length + data.length + separator.length + Bech32Validations.checksumLength > maxLength) throw TooLong(hrp.length + data.length + 1 + Bech32Validations.checksumLength);
+    if (hrp.length +
+            data.length +
+            separator.length +
+            Bech32Validations.checksumLength >
+        maxLength)
+      throw TooLong(
+        hrp.length + data.length + 1 + Bech32Validations.checksumLength,
+      );
     if (hrp.isEmpty) throw TooShortHrp();
     if (hasOutOfRangeHrpCharacters(hrp)) throw OutOfRangeHrpCharacters(hrp);
     if (isMixedCase(hrp)) throw MixedCase(hrp);
@@ -58,14 +85,44 @@ class Bech32Encoder extends Converter<Bech32, String> with Bech32Validations {
 /// This class converts a String to a Bech32 class instance.
 class Bech32Decoder extends Converter<String, Bech32> with Bech32Validations {
   @override
-  Bech32 convert(String input, {int maxLength = Bech32Validations.maxInputLength, String encoding = 'bech32'}) {
-    var separatorPosition = input.lastIndexOf(separator);
+  Bech32 convert(
+    String input, {
+    int maxLength = Bech32Validations.maxInputLength,
+    String encoding = 'bech32',
+  }) {
+    if (input.length > maxLength) throw TooLong(input.length);
+    if (isMixedCase(input)) throw MixedCase(input);
+
+    final separatorPosition = input.lastIndexOf(separator);
+    if (hasInvalidSeparator(input) || isHrpTooShort(separatorPosition)) {
+      throw InvalidSeparator(separatorPosition);
+    }
+    if (isChecksumTooShort(separatorPosition, input)) {
+      throw TooShortChecksum();
+    }
+
     input = input.toLowerCase();
-    var hrp = input.substring(0, separatorPosition);
-    var data = input.substring(
-        separatorPosition + 1, input.length - Bech32Validations.checksumLength);
-    var dataBytes = data.split('').map((c) => charset.indexOf(c)).toList();
-    return Bech32(hrp, dataBytes);
+    final hrp = input.substring(0, separatorPosition);
+    if (hasOutOfRangeHrpCharacters(hrp)) {
+      throw OutOfRangeHrpCharacters(hrp);
+    }
+
+    final encodedData = input.substring(separatorPosition + 1);
+    final dataIncludingChecksum =
+        encodedData.split('').map((c) => charset.indexOf(c)).toList();
+    if (hasOutOfBoundsChars(dataIncludingChecksum)) {
+      throw OutOfBoundChars(encodedData);
+    }
+
+    final checksumStart =
+        dataIncludingChecksum.length - Bech32Validations.checksumLength;
+    final data = dataIncludingChecksum.sublist(0, checksumStart);
+    final checksum = dataIncludingChecksum.sublist(checksumStart);
+    if (isInvalidChecksum(hrp, data, checksum, encoding: encoding)) {
+      throw InvalidChecksum();
+    }
+
+    return Bech32(hrp, data);
   }
 }
 
@@ -87,7 +144,12 @@ mixin Bech32Validations {
     return separatorPosition == 0;
   }
 
-  bool isInvalidChecksum(String hrp, List<int> data, List<int> checksum, {String encoding = 'bech32'}) {
+  bool isInvalidChecksum(
+    String hrp,
+    List<int> data,
+    List<int> checksum, {
+    String encoding = 'bech32',
+  }) {
     return !_verifyChecksum(hrp, data + checksum, encoding: encoding);
   }
 
@@ -116,11 +178,47 @@ class Bech32 {
 const String separator = '1';
 
 const List<String> charset = [
-  'q', 'p', 'z', 'r', 'y', '9', 'x', '8', 'g', 'f', '2', 't', 'v', 'd', 'w', '0',
-  's', '3', 'j', 'n', '5', '4', 'k', 'h', 'c', 'e', '6', 'm', 'u', 'a', '7', 'l'
+  'q',
+  'p',
+  'z',
+  'r',
+  'y',
+  '9',
+  'x',
+  '8',
+  'g',
+  'f',
+  '2',
+  't',
+  'v',
+  'd',
+  'w',
+  '0',
+  's',
+  '3',
+  'j',
+  'n',
+  '5',
+  '4',
+  'k',
+  'h',
+  'c',
+  'e',
+  '6',
+  'm',
+  'u',
+  'a',
+  '7',
+  'l',
 ];
 
-const List<int> generator = [0x3b6a57b2, 0x26508e6d, 0x1ea119fa, 0x3d4233dd, 0x2a1462b3];
+const List<int> generator = [
+  0x3b6a57b2,
+  0x26508e6d,
+  0x1ea119fa,
+  0x3d4233dd,
+  0x2a1462b3,
+];
 
 int _polymod(List<int> values) {
   var chk = 1;
@@ -144,11 +242,20 @@ List<int> _hrpExpand(String hrp) {
   return result;
 }
 
-bool _verifyChecksum(String hrp, List<int> dataIncludingChecksum, {String encoding = 'bech32'}) {
-  return _polymod(_hrpExpand(hrp) + dataIncludingChecksum) == (encoding == 'bech32' ? 1 : 0x2bc830a3);
+bool _verifyChecksum(
+  String hrp,
+  List<int> dataIncludingChecksum, {
+  String encoding = 'bech32',
+}) {
+  return _polymod(_hrpExpand(hrp) + dataIncludingChecksum) ==
+      (encoding == 'bech32' ? 1 : 0x2bc830a3);
 }
 
-List<int> _createChecksum(String hrp, List<int> data, {String encoding = 'bech32'}) {
+List<int> _createChecksum(
+  String hrp,
+  List<int> data, {
+  String encoding = 'bech32',
+}) {
   final ENCODING_CONST = encoding == 'bech32' ? 1 : 0x2bc830a3;
   var values = _hrpExpand(hrp) + data + [0, 0, 0, 0, 0, 0];
   var polymod = _polymod(values) ^ ENCODING_CONST;
@@ -193,8 +300,11 @@ List<int> convertBits(data, int from, int to, {bool strictMode = false}) {
   return result;
 }
 
-List<int> createChecksum(String hrp, List<int> data,
-    {String encoding = 'bech32'}) {
+List<int> createChecksum(
+  String hrp,
+  List<int> data, {
+  String encoding = 'bech32',
+}) {
   final ENCODING_CONST = encoding == 'bech32' ? 1 : 0x2bc830a3;
   var values = _hrpExpand(hrp) + data + [0, 0, 0, 0, 0, 0];
   var polymod = _polymod(values) ^ ENCODING_CONST;
@@ -207,8 +317,11 @@ List<int> createChecksum(String hrp, List<int> data,
   return result;
 }
 
-bool verifyChecksum(String hrp, List<int> dataIncludingChecksum,
-    {String encoding = 'bech32'}) {
+bool verifyChecksum(
+  String hrp,
+  List<int> dataIncludingChecksum, {
+  String encoding = 'bech32',
+}) {
   return _polymod(_hrpExpand(hrp) + dataIncludingChecksum) ==
       (encoding == 'bech32' ? 1 : 0x2bc830a3);
 }
@@ -221,9 +334,10 @@ Uint8List convertBit(Uint8List buff) {
   String str = '';
   for (var i = 0; i < buff.length; i++) {
     String res = buff[i].toRadixString(2);
-    res = res.length < 8
-        ? '00000000'.substring(0, 8 - res.length) + res
-        : buff[i].toRadixString(2);
+    res =
+        res.length < 8
+            ? '00000000'.substring(0, 8 - res.length) + res
+            : buff[i].toRadixString(2);
 
     str = str + res;
   }

--- a/packages/crypto_wallet_util/lib/src/wallet.dart
+++ b/packages/crypto_wallet_util/lib/src/wallet.dart
@@ -32,12 +32,16 @@ enum Wallet {
   LTC,
   BCH,
   TAPROOT,
-  NONE
+  NONE,
 }
 
-Future<WalletType> getMnemonicWallet(String coin, String mnemonic) async {
+Future<WalletType> getMnemonicWallet(
+  String coin,
+  String mnemonic, {
+  WalletSetting? walletSetting,
+}) async {
   final wallet = getWallet(coin);
-  final setting = getChainConfig(coin).mainnet;
+  final setting = walletSetting ?? getChainConfig(coin).mainnet;
   switch (wallet) {
     case Wallet.NONE:
       throw Exception('Unsupported chain');
@@ -92,13 +96,17 @@ Future<WalletType> getMnemonicWallet(String coin, String mnemonic) async {
     case Wallet.BCH:
       return BchCoin.fromMnemonic(mnemonic, setting);
     case Wallet.TAPROOT:
-      return BtcCoin.fromMnemonic(mnemonic, null, true);
+      return BtcCoin.fromMnemonic(mnemonic, walletSetting, true);
   }
 }
 
-WalletType getPrivateKeyWallet(String coin, String privateKey) {
+WalletType getPrivateKeyWallet(
+  String coin,
+  String privateKey, {
+  WalletSetting? walletSetting,
+}) {
   final wallet = getWallet(coin);
-  final setting = getChainConfig(coin).mainnet;
+  final setting = walletSetting ?? getChainConfig(coin).mainnet;
   switch (wallet) {
     case Wallet.NONE:
       throw Exception('Unsupported chain');
@@ -153,7 +161,7 @@ WalletType getPrivateKeyWallet(String coin, String privateKey) {
     case Wallet.BCH:
       return BchCoin.fromPrivateKey(privateKey, setting);
     case Wallet.TAPROOT:
-      return BtcCoin.fromPrivateKey(privateKey, null, true);
+      return BtcCoin.fromPrivateKey(privateKey, walletSetting, true);
   }
 }
 
@@ -162,8 +170,9 @@ Wallet getWallet(coin) {
   if (coin == 'karlsen') return Wallet.KLS;
   if (coin == 'scp') return Wallet.SCP;
   return Wallet.values.firstWhere(
-      (element) => (element.toString().split(".").last) == coin.toUpperCase(),
-      orElse: () => Wallet.NONE);
+    (element) => (element.toString().split(".").last) == coin.toUpperCase(),
+    orElse: () => Wallet.NONE,
+  );
 }
 
 List<String> supportCrypto() {

--- a/packages/crypto_wallet_util/lib/src/wallets/btc.dart
+++ b/packages/crypto_wallet_util/lib/src/wallets/btc.dart
@@ -45,11 +45,12 @@ class BtcCoin extends WalletType {
   @override
   String publicKeyToAddress(Uint8List publicKey) {
     if (isTaproot) {
-      return P2PKH.getTaprootAddress(publicKey, 'bc');
+      final hrp = setting?.networkType?.bech32 ?? 'bc';
+      return P2PKH.getTaprootAddress(publicKey, hrp);
     } else {
       final addressBytes = sha160fromByte(publicKey);
       Uint8List versionedHash = Uint8List(21);
-      versionedHash[0] = 0x00;
+      versionedHash[0] = setting?.networkType?.pubKeyHash ?? 0x00;
       versionedHash.setRange(1, 21, addressBytes);
       return getBase58Address(versionedHash);
     }

--- a/packages/crypto_wallet_util/lib/src/wallets/btc.dart
+++ b/packages/crypto_wallet_util/lib/src/wallets/btc.dart
@@ -15,23 +15,12 @@ class BtcCoin extends WalletType {
   final isTaproot;
   WalletSetting? setting;
   BtcCoin({WalletSetting? setting, this.isTaproot = false}) {
-    if (setting == null) {
-      this.setting = isTaproot ? _taproot : _default;
-    } else if (isTaproot) {
-      // The network and derivation scheme are independent choices. A caller
-      // may pass BTCChain().testnet to select testnet, but Taproot keys must
-      // still use the BIP86 path.
-      this.setting = WalletSetting(
-        bip44Path: TAPROOT_PATH,
-        prefix: setting.prefix,
-        networkType: setting.networkType,
-        bech32Length: setting.bech32Length,
-        regExp: setting.regExp,
-        addressType: setting.addressType,
-      );
-    } else {
-      this.setting = setting;
-    }
+    // Keep the caller's setting by reference so any later network state
+    // (`networkType`) stays observable. The network and derivation scheme are
+    // independent choices: a caller may pass BTCChain().testnet to select
+    // testnet, but Taproot keys must still derive on the BIP86 path — that is
+    // handled in [mnemonicToPrivateKey] rather than by copying the setting.
+    this.setting = setting ?? (isTaproot ? _taproot : _default);
   }
 
   static Future<BtcCoin> fromMnemonic(
@@ -56,7 +45,10 @@ class BtcCoin extends WalletType {
 
   @override
   Future<Uint8List> mnemonicToPrivateKey(String mnemonic) async {
-    return HDWallet.bip32DerivePath(mnemonic, setting!.bip44Path);
+    // Taproot always derives on the BIP86 path, independent of the network
+    // carried by [setting]; other script types honour the setting's path.
+    final path = isTaproot ? TAPROOT_PATH : setting!.bip44Path;
+    return HDWallet.bip32DerivePath(mnemonic, path);
   }
 
   @override

--- a/packages/crypto_wallet_util/lib/src/wallets/btc.dart
+++ b/packages/crypto_wallet_util/lib/src/wallets/btc.dart
@@ -14,19 +14,41 @@ class BtcCoin extends WalletType {
   final _taproot = WalletSetting(bip44Path: TAPROOT_PATH);
   final isTaproot;
   WalletSetting? setting;
-  BtcCoin({setting, this.isTaproot = false}) {
-    this.setting = setting ?? (isTaproot ? _taproot : _default);
+  BtcCoin({WalletSetting? setting, this.isTaproot = false}) {
+    if (setting == null) {
+      this.setting = isTaproot ? _taproot : _default;
+    } else if (isTaproot) {
+      // The network and derivation scheme are independent choices. A caller
+      // may pass BTCChain().testnet to select testnet, but Taproot keys must
+      // still use the BIP86 path.
+      this.setting = WalletSetting(
+        bip44Path: TAPROOT_PATH,
+        prefix: setting.prefix,
+        networkType: setting.networkType,
+        bech32Length: setting.bech32Length,
+        regExp: setting.regExp,
+        addressType: setting.addressType,
+      );
+    } else {
+      this.setting = setting;
+    }
   }
 
-  static Future<BtcCoin> fromMnemonic(String mnemonic,
-      [WalletSetting? setting, bool isTaproot = false]) async {
+  static Future<BtcCoin> fromMnemonic(
+    String mnemonic, [
+    WalletSetting? setting,
+    bool isTaproot = false,
+  ]) async {
     final wallet = BtcCoin(setting: setting, isTaproot: isTaproot);
     await wallet.initFromMnemonic(mnemonic);
     return wallet;
   }
 
-  factory BtcCoin.fromPrivateKey(dynamic privateKey,
-      [WalletSetting? setting, bool isTaproot = false]) {
+  factory BtcCoin.fromPrivateKey(
+    dynamic privateKey, [
+    WalletSetting? setting,
+    bool isTaproot = false,
+  ]) {
     final wallet = BtcCoin(setting: setting, isTaproot: isTaproot);
     wallet.initFromPrivateKey(dynamicToUint8List(privateKey));
     return wallet;
@@ -45,7 +67,11 @@ class BtcCoin extends WalletType {
   @override
   String publicKeyToAddress(Uint8List publicKey) {
     if (isTaproot) {
-      final hrp = setting?.networkType?.bech32 ?? 'bc';
+      final networkType = setting?.networkType;
+      final hrp = networkType == null ? 'bc' : networkType.bech32;
+      if (hrp == null) {
+        throw ArgumentError('Taproot networkType must define a bech32 HRP');
+      }
       return P2PKH.getTaprootAddress(publicKey, hrp);
     } else {
       final addressBytes = sha160fromByte(publicKey);

--- a/packages/crypto_wallet_util/pubspec.yaml
+++ b/packages/crypto_wallet_util/pubspec.yaml
@@ -1,6 +1,6 @@
 name: crypto_wallet_util
 description: A collection of utility functions for cryptocurrencies.
-version: 2.0.2
+version: 2.0.3
 homepage: https://github.com/fxwalletOfficial/fx-wallet-packages/tree/main/packages/wallet_crypto_util
 
 environment:

--- a/packages/crypto_wallet_util/test/address/data/address.json
+++ b/packages/crypto_wallet_util/test/address/data/address.json
@@ -18,11 +18,12 @@
     {
       "name": "bch",
       "address": [
-        "1NXGKidXJKnFKXLANwFu4ukBCPSTdPs4bx",
-        "qrkp86fu8492fksahgjka3zcqw220h7l6qp9j3xjxa",
         "bitcoincash:qrkp86fu8492fksahgjka3zcqw220h7l6qp9j3xjxa"
       ],
-      "error": []
+      "error": [
+        "1NXGKidXJKnFKXLANwFu4ukBCPSTdPs4bx",
+        "qrkp86fu8492fksahgjka3zcqw220h7l6qp9j3xjxa"
+      ]
     },
     {
       "name": "bells",

--- a/packages/crypto_wallet_util/test/transaction/bch_test.dart
+++ b/packages/crypto_wallet_util/test/transaction/bch_test.dart
@@ -1,7 +1,31 @@
+import 'dart:convert';
+import 'dart:io';
+
 import 'package:crypto_wallet_util/crypto_utils.dart';
 import 'package:crypto_wallet_util/src/forked_lib/bitcoin_flutter/bitcoin_flutter.dart'
     as bitcoin;
+import 'package:crypto_wallet_util/src/forked_lib/psbt/transaction/partially_signed_bitcoin_transaction.dart';
 import 'package:test/test.dart';
+
+PSBT _buildBchPsbtFixture({
+  required String inputAddress,
+  required String changeAddress,
+}) {
+  final fixtures =
+      json.decode(
+            File('./test/psbt/data.json').readAsStringSync(encoding: utf8),
+          )
+          as List<dynamic>;
+  final transferJson =
+      json.decode(json.encode(fixtures.first['data'])) as Map<String, dynamic>;
+  final origin = transferJson['origin'] as Map<String, dynamic>;
+  final outputs = origin['outputs'] as List<dynamic>;
+  transferJson['chain'] = 'bch';
+  transferJson['inputAddress'] = inputAddress;
+  outputs[1]['address'] = changeAddress;
+  outputs[1]['path'] = "m/44'/145'/0'/1/0";
+  return PSBT.fromTransferPsbt(BtcTransferInfo.fromJson(transferJson));
+}
 
 void main() async {
   const String mnemonic =
@@ -304,6 +328,56 @@ void main() async {
         );
       },
     );
+
+    test('BCH testnet CashAddr identifies legacy PSBT change output', () async {
+      final wallet = await BchCoin.fromMnemonic(mnemonic, BCHChain().testnet);
+      final cashAddress = wallet.address;
+      final legacyAddress = bitcoin.Address.bchToLegacy(cashAddress);
+      expect(cashAddress, startsWith('bchtest:'));
+      expect(legacyAddress, anyOf(startsWith('m'), startsWith('n')));
+
+      // Exercise the real PSBT change-detection call chain with a bchtest input
+      // and its equivalent legacy m/n output. Before the fix this threw because
+      // the conversion was forced through the bitcoincash mainnet prefix.
+      final psbt = _buildBchPsbtFixture(
+        inputAddress: cashAddress,
+        changeAddress: legacyAddress,
+      );
+
+      expect(psbt.outputs[0].derivationPath, isNull);
+      expect(psbt.outputs[1].derivationPath, isNotNull);
+      expect(psbt.outputs[1].isChange, isTrue);
+    });
+
+    test('BCH PSBT does not mark a cross-network address as change', () async {
+      final chain = BCHChain();
+      final testnetWallet = await BchCoin.fromMnemonic(mnemonic, chain.testnet);
+      final mainnetWallet = await BchCoin.fromMnemonic(mnemonic, chain.mainnet);
+      final mainnetLegacy = bitcoin.Address.bchToLegacy(mainnetWallet.address);
+
+      final psbt = _buildBchPsbtFixture(
+        inputAddress: testnetWallet.address,
+        changeAddress: mainnetLegacy,
+      );
+
+      expect(psbt.outputs[1].derivationPath, isNull);
+      expect(psbt.outputs[1].isChange, isFalse);
+    });
+
+    for (final inputAddress in ['', 'bchtest:not-valid']) {
+      test('BCH PSBT fails closed for input "$inputAddress"', () async {
+        final wallet = await BchCoin.fromMnemonic(mnemonic, BCHChain().testnet);
+        final legacyAddress = bitcoin.Address.bchToLegacy(wallet.address);
+
+        final psbt = _buildBchPsbtFixture(
+          inputAddress: inputAddress,
+          changeAddress: legacyAddress,
+        );
+
+        expect(psbt.outputs[1].derivationPath, isNull);
+        expect(psbt.outputs[1].isChange, isFalse);
+      });
+    }
 
     test(
       'BCH validation rejects legacy testnet ambiguity and bad checksum',

--- a/packages/crypto_wallet_util/test/transaction/bch_test.dart
+++ b/packages/crypto_wallet_util/test/transaction/bch_test.dart
@@ -9,13 +9,22 @@ void main() async {
   group('BCH Basic Wallet Tests', () {
     test('bch address generation', () {
       final address = bchWallet.publicKeyToAddress(bchWallet.publicKey);
-      expect(address, equals('bitcoincash:qq0xhc4ndukzq3xsrqt26vpp2ker49h5t5qp85fg5p'));
+      expect(
+        address,
+        equals('bitcoincash:qq0xhc4ndukzq3xsrqt26vpp2ker49h5t5qp85fg5p'),
+      );
     });
 
     test('bch sign/verify', () {
-      const message = '509e115a79d13dbaf43e03f944328453e4d81f443ce35eaa2f5c0432e1903483';
+      const message =
+          '509e115a79d13dbaf43e03f944328453e4d81f443ce35eaa2f5c0432e1903483';
       final signature = bchWallet.sign(message);
-      expect(signature, equals('3043021f1e7def81da639baf2cf3ec58cbbd43bd3c7576bf6064cf5d72759642b818e202205f3e413d1ae0bae0c305c8855c504399c5db680fecc3953b2af1c03b4ad14f9241'));
+      expect(
+        signature,
+        equals(
+          '3043021f1e7def81da639baf2cf3ec58cbbd43bd3c7576bf6064cf5d72759642b818e202205f3e413d1ae0bae0c305c8855c504399c5db680fecc3953b2af1c03b4ad14f9241',
+        ),
+      );
     });
 
     test('bch private key to public key', () {
@@ -25,7 +34,8 @@ void main() async {
     });
 
     test('bch from private key', () {
-      final privateKeyHex = '1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef';
+      final privateKeyHex =
+          '1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef';
       final wallet = BchCoin.fromPrivateKey(privateKeyHex);
       expect(wallet.privateKey, isNotEmpty);
       expect(wallet.publicKey, isNotEmpty);
@@ -47,9 +57,10 @@ void main() async {
             path: "m/44'/145'/0'/0/0",
             amount: 3979484,
             signHashType: 65, // SIGHASH_ALL | SIGHASH_BITCOINCASHBIP143
-          )
+          ),
         ],
-        hex: '02000000013b12abfd3a60fbe75f79f71dceeb07c665704d8ad46ff419a223f80b2565fd900100000000ffffffff020e260000000000001976a9146a624a6ee30c77e5da3d49c53a54b92544e9a57888accc913c00000000001976a914a4c0b3134c06f28a7c00a70518e1bd2bbb4ec05c88ac00000000',
+        hex:
+            '02000000013b12abfd3a60fbe75f79f71dceeb07c665704d8ad46ff419a223f80b2565fd900100000000ffffffff020e260000000000001976a9146a624a6ee30c77e5da3d49c53a54b92544e9a57888accc913c00000000001976a914a4c0b3134c06f28a7c00a70518e1bd2bbb4ec05c88ac00000000',
         change: null,
         dataType: BtcSignDataType.TRANSACTION,
       );
@@ -66,7 +77,6 @@ void main() async {
         expect(input.signature, isNotNull);
         expect(input.signature!.isNotEmpty, true);
       }
-
     });
 
     test('bch gspl transaction with change output', () async {
@@ -76,9 +86,10 @@ void main() async {
             path: "m/44'/145'/0'/0/0",
             amount: 3979484,
             signHashType: 65,
-          )
+          ),
         ],
-        hex: '02000000013b12abfd3a60fbe75f79f71dceeb07c665704d8ad46ff419a223f80b2565fd900100000000ffffffff020e260000000000001976a9146a624a6ee30c77e5da3d49c53a54b92544e9a57888accc913c00000000001976a914a4c0b3134c06f28a7c00a70518e1bd2bbb4ec05c88ac00000000',
+        hex:
+            '02000000013b12abfd3a60fbe75f79f71dceeb07c665704d8ad46ff419a223f80b2565fd900100000000ffffffff020e260000000000001976a9146a624a6ee30c77e5da3d49c53a54b92544e9a57888accc913c00000000001976a914a4c0b3134c06f28a7c00a70518e1bd2bbb4ec05c88ac00000000',
         change: GsplItem(
           path: "m/44'/145'/0'/1/0",
           amount: 1000000,
@@ -105,44 +116,30 @@ void main() async {
 
     test('should throw exception for null input path in GSPL', () async {
       final txData = GsplTxData(
-        inputs: [
-          GsplItem(
-            path: null,
-            amount: 100000000,
-            signHashType: 65,
-          )
-        ],
-        hex: '02000000013b12abfd3a60fbe75f79f71dceeb07c665704d8ad46ff419a223f80b2565fd900100000000ffffffff020e260000000000001976a9146a624a6ee30c77e5da3d49c53a54b92544e9a57888accc913c00000000001976a914a4c0b3134c06f28a7c00a70518e1bd2bbb4ec05c88ac00000000',
+        inputs: [GsplItem(path: null, amount: 100000000, signHashType: 65)],
+        hex:
+            '02000000013b12abfd3a60fbe75f79f71dceeb07c665704d8ad46ff419a223f80b2565fd900100000000ffffffff020e260000000000001976a9146a624a6ee30c77e5da3d49c53a54b92544e9a57888accc913c00000000001976a914a4c0b3134c06f28a7c00a70518e1bd2bbb4ec05c88ac00000000',
         change: null,
         dataType: BtcSignDataType.TRANSACTION,
       );
 
       final signer = GsplTxSigner(bchWallet, txData);
-      expect(
-        () => signer.sign(),
-        throwsA(isA<Exception>()),
-      );
+      expect(() => signer.sign(), throwsA(isA<Exception>()));
     });
 
     test('should throw exception for null input amount in GSPL', () async {
       final txData = GsplTxData(
         inputs: [
-          GsplItem(
-            path: "m/44'/145'/0'/0/0",
-            amount: null,
-            signHashType: 65,
-          )
+          GsplItem(path: "m/44'/145'/0'/0/0", amount: null, signHashType: 65),
         ],
-        hex: '02000000013b12abfd3a60fbe75f79f71dceeb07c665704d8ad46ff419a223f80b2565fd900100000000ffffffff020e260000000000001976a9146a624a6ee30c77e5da3d49c53a54b92544e9a57888accc913c00000000001976a914a4c0b3134c06f28a7c00a70518e1bd2bbb4ec05c88ac00000000',
+        hex:
+            '02000000013b12abfd3a60fbe75f79f71dceeb07c665704d8ad46ff419a223f80b2565fd900100000000ffffffff020e260000000000001976a9146a624a6ee30c77e5da3d49c53a54b92544e9a57888accc913c00000000001976a914a4c0b3134c06f28a7c00a70518e1bd2bbb4ec05c88ac00000000',
         change: null,
         dataType: BtcSignDataType.TRANSACTION,
       );
 
       final signer = GsplTxSigner(bchWallet, txData);
-      expect(
-        () => signer.sign(),
-        throwsA(isA<Exception>()),
-      );
+      expect(() => signer.sign(), throwsA(isA<Exception>()));
     });
   });
 
@@ -154,16 +151,17 @@ void main() async {
             path: "m/44'/145'/0'/0/0",
             amount: 3979484,
             signHashType: 65, // SIGHASH_ALL | SIGHASH_BITCOINCASHBIP143
-          )
+          ),
         ],
-        hex: '02000000013b12abfd3a60fbe75f79f71dceeb07c665704d8ad46ff419a223f80b2565fd900100000000ffffffff020e260000000000001976a9146a624a6ee30c77e5da3d49c53a54b92544e9a57888accc913c00000000001976a914a4c0b3134c06f28a7c00a70518e1bd2bbb4ec05c88ac00000000',
+        hex:
+            '02000000013b12abfd3a60fbe75f79f71dceeb07c665704d8ad46ff419a223f80b2565fd900100000000ffffffff020e260000000000001976a9146a624a6ee30c77e5da3d49c53a54b92544e9a57888accc913c00000000001976a914a4c0b3134c06f28a7c00a70518e1bd2bbb4ec05c88ac00000000',
         change: null,
         dataType: BtcSignDataType.TRANSACTION,
       );
 
       final signer = GsplTxSigner(bchWallet, txData);
       final signedTxData = signer.sign();
-      
+
       expect(signer.verify(), true);
       expect(signedTxData.isSigned, true);
     });
@@ -174,50 +172,141 @@ void main() async {
           GsplItem(
             path: "m/44'/145'/0'/0/0",
             amount: 3979484,
-            signHashType: 67, // SIGHASH_ALL | SIGHASH_BITCOINCASHBIP143 | SIGHASH_ANYONECANPAY
-          )
+            signHashType:
+                67, // SIGHASH_ALL | SIGHASH_BITCOINCASHBIP143 | SIGHASH_ANYONECANPAY
+          ),
         ],
-        hex: '02000000013b12abfd3a60fbe75f79f71dceeb07c665704d8ad46ff419a223f80b2565fd900100000000ffffffff020e260000000000001976a9146a624a6ee30c77e5da3d49c53a54b92544e9a57888accc913c00000000001976a914a4c0b3134c06f28a7c00a70518e1bd2bbb4ec05c88ac00000000',
+        hex:
+            '02000000013b12abfd3a60fbe75f79f71dceeb07c665704d8ad46ff419a223f80b2565fd900100000000ffffffff020e260000000000001976a9146a624a6ee30c77e5da3d49c53a54b92544e9a57888accc913c00000000001976a914a4c0b3134c06f28a7c00a70518e1bd2bbb4ec05c88ac00000000',
         change: null,
         dataType: BtcSignDataType.TRANSACTION,
       );
 
       final signer = GsplTxSigner(bchWallet, txData);
       final signedTxData = signer.sign();
-      
+
       expect(signer.verify(), true);
       expect(signedTxData.isSigned, true);
     });
 
     test('bch should use correct sighash type in wallet', () {
       // BCH wallet should have the correct sighash type set
-      expect(bchWallet.sighashType, equals(65)); // SIGHASH_ALL | SIGHASH_BITCOINCASHBIP143
+      expect(
+        bchWallet.sighashType,
+        equals(65),
+      ); // SIGHASH_ALL | SIGHASH_BITCOINCASHBIP143
     });
   });
 
   group('BCH Address Format Tests', () {
     test('bch should generate correct cashaddr format', () {
       final address = bchWallet.publicKeyToAddress(bchWallet.publicKey);
-      
+
       // Check CashAddr format
       expect(address.startsWith('bitcoincash:'), isTrue);
-      
+
       // Check that it's a valid CashAddr format
       final parts = address.split(':');
       expect(parts.length, equals(2));
       expect(parts[0], equals('bitcoincash'));
-      
+
       // The address part should be a valid bech32 string
       final addressPart = parts[1];
       expect(addressPart.length, greaterThan(0));
     });
 
     test('bch should handle different public keys', () {
-      final privateKeyHex = '1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef';
+      final privateKeyHex =
+          '1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef';
       final wallet = BchCoin.fromPrivateKey(privateKeyHex);
       final address = wallet.publicKeyToAddress(wallet.publicKey);
-      
+
       expect(address.startsWith('bitcoincash:'), isTrue);
     });
+
+    test('BCH testnet generates and validates bchtest CashAddr', () async {
+      final bchChain = BCHChain();
+      final wallet = await BchCoin.fromMnemonic(mnemonic, bchChain.testnet);
+      final address = wallet.address;
+
+      expect(address, startsWith('bchtest:'));
+      expect(AddressUtils.checkAddressValid(address, bchChain.testnet), isTrue);
+      expect(
+        AddressUtils.checkAddressValid(address, bchChain.mainnet),
+        isFalse,
+      );
+    });
+
+    test(
+      'BCH mainnet and testnet CashAddr prefixes do not cross-validate',
+      () async {
+        final bchChain = BCHChain();
+        final mainnetWallet = await BchCoin.fromMnemonic(
+          mnemonic,
+          bchChain.mainnet,
+        );
+        final testnetWallet = await BchCoin.fromMnemonic(
+          mnemonic,
+          bchChain.testnet,
+        );
+
+        expect(
+          AddressUtils.checkAddressValid(
+            mainnetWallet.address,
+            bchChain.mainnet,
+          ),
+          isTrue,
+        );
+        expect(
+          AddressUtils.checkAddressValid(
+            mainnetWallet.address,
+            bchChain.testnet,
+          ),
+          isFalse,
+        );
+        expect(
+          AddressUtils.checkAddressValid(
+            testnetWallet.address,
+            bchChain.mainnet,
+          ),
+          isFalse,
+        );
+      },
+    );
+
+    test(
+      'BCH validation rejects legacy testnet ambiguity and bad checksum',
+      () async {
+        final btcChain = BTCChain();
+        final bchChain = BCHChain();
+        final btcWallet = await BtcCoin.fromMnemonic(
+          mnemonic,
+          btcChain.testnet,
+        );
+        final bchWallet = await BchCoin.fromMnemonic(
+          mnemonic,
+          bchChain.testnet,
+        );
+        final cashAddress = bchWallet.address;
+        final corruptedCashAddress =
+            '${cashAddress.substring(0, cashAddress.length - 1)}q';
+
+        expect(
+          AddressUtils.checkAddressValid(btcWallet.address, btcChain.testnet),
+          isTrue,
+        );
+        expect(
+          AddressUtils.checkAddressValid(btcWallet.address, bchChain.testnet),
+          isFalse,
+        );
+        expect(
+          AddressUtils.checkAddressValid(
+            corruptedCashAddress,
+            bchChain.testnet,
+          ),
+          isFalse,
+        );
+      },
+    );
   });
 }

--- a/packages/crypto_wallet_util/test/transaction/bch_test.dart
+++ b/packages/crypto_wallet_util/test/transaction/bch_test.dart
@@ -1,4 +1,6 @@
 import 'package:crypto_wallet_util/crypto_utils.dart';
+import 'package:crypto_wallet_util/src/forked_lib/bitcoin_flutter/bitcoin_flutter.dart'
+    as bitcoin;
 import 'package:test/test.dart';
 
 void main() async {
@@ -232,8 +234,37 @@ void main() async {
       expect(address, startsWith('bchtest:'));
       expect(AddressUtils.checkAddressValid(address, bchChain.testnet), isTrue);
       expect(
+        bitcoin.Address.addressToOutputScript(
+          address,
+          bchChain.testnet.networkType,
+        ),
+        isNotEmpty,
+      );
+      expect(
         AddressUtils.checkAddressValid(address, bchChain.mainnet),
         isFalse,
+      );
+    });
+
+    test('BCH testnet P2SH conversion preserves type and network', () {
+      const legacyTestnetP2sh = '2NBFNJTktNa7GZusGbDbGKRZTxdK9VVez3n';
+      final bchChain = BCHChain();
+      final cashAddress = bitcoin.Address.legacyToBch(
+        address: legacyTestnetP2sh,
+        prefix: 'bchtest',
+      );
+
+      expect(cashAddress, startsWith('bchtest:p'));
+      expect(
+        bitcoin.Address.bchToLegacy(cashAddress, prefix: 'bchtest'),
+        legacyTestnetP2sh,
+      );
+      expect(
+        bitcoin.Address.addressToOutputScript(
+          cashAddress,
+          bchChain.testnet.networkType,
+        ),
+        isNotEmpty,
       );
     });
 
@@ -305,6 +336,10 @@ void main() async {
             bchChain.testnet,
           ),
           isFalse,
+        );
+        expect(
+          () => bitcoin.Address.bchToLegacy(corruptedCashAddress),
+          throwsArgumentError,
         );
       },
     );

--- a/packages/crypto_wallet_util/test/transaction/bch_test.dart
+++ b/packages/crypto_wallet_util/test/transaction/bch_test.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:crypto_wallet_util/crypto_utils.dart';
+import 'package:crypto_wallet_util/src/utils/utils.dart';
 import 'package:crypto_wallet_util/src/forked_lib/bitcoin_flutter/bitcoin_flutter.dart'
     as bitcoin;
 import 'package:crypto_wallet_util/src/forked_lib/psbt/transaction/partially_signed_bitcoin_transaction.dart';
@@ -10,6 +11,7 @@ import 'package:test/test.dart';
 PSBT _buildBchPsbtFixture({
   required String inputAddress,
   required String changeAddress,
+  String? xpubkey,
 }) {
   final fixtures =
       json.decode(
@@ -22,9 +24,21 @@ PSBT _buildBchPsbtFixture({
   final outputs = origin['outputs'] as List<dynamic>;
   transferJson['chain'] = 'bch';
   transferJson['inputAddress'] = inputAddress;
+  if (xpubkey != null) transferJson['xpubkey'] = xpubkey;
   outputs[1]['address'] = changeAddress;
   outputs[1]['path'] = "m/44'/145'/0'/1/0";
   return PSBT.fromTransferPsbt(BtcTransferInfo.fromJson(transferJson));
+}
+
+/// Account-level (`m/44'/145'/0'`) testnet extended public key (`tpub`) derived
+/// from [mnemonic]. Its version bytes (`0x043587cf`) drive network selection in
+/// `PSBT.fromTransferPsbt`.
+String _bchTestnetAccountTpub(String mnemonic) {
+  final seed = HDWallet.mnemonicToSeed(mnemonic);
+  return bitcoin.HDWallet.fromSeed(
+    seed,
+    network: BCHChain().testnet.networkType,
+  ).derivePath("m/44'/145'/0'").base58!;
 }
 
 void main() async {
@@ -345,6 +359,29 @@ void main() async {
       );
 
       expect(psbt.outputs[0].derivationPath, isNull);
+      expect(psbt.outputs[1].derivationPath, isNotNull);
+      expect(psbt.outputs[1].isChange, isTrue);
+    });
+
+    test('BCH testnet tpub builds a PSBT through the production path', () async {
+      final wallet = await BchCoin.fromMnemonic(mnemonic, BCHChain().testnet);
+      final cashAddress = wallet.address;
+      final legacyAddress = bitcoin.Address.bchToLegacy(cashAddress);
+
+      final tpub = _bchTestnetAccountTpub(mnemonic);
+      expect(tpub, startsWith('tpub'));
+
+      // Regression for the deeper F5 finding: a standard testnet tpub must be
+      // recognised (version 0x043587cf → testnet config) and parse through the
+      // real PSBT construction path, instead of being forced through the
+      // mainnet config and crashing with a null check before change detection.
+      final psbt = _buildBchPsbtFixture(
+        inputAddress: cashAddress,
+        changeAddress: legacyAddress,
+        xpubkey: tpub,
+      );
+
+      expect(psbt.serialize(), isNotEmpty);
       expect(psbt.outputs[1].derivationPath, isNotNull);
       expect(psbt.outputs[1].isChange, isTrue);
     });

--- a/packages/crypto_wallet_util/test/transaction/btc_test.dart
+++ b/packages/crypto_wallet_util/test/transaction/btc_test.dart
@@ -11,8 +11,9 @@ void main() async {
   final legacyWallet = await BtcCoin.fromMnemonic(mnemonic);
   final taprootWallet = await BtcCoin.fromMnemonic(mnemonic, null, true);
 
-  final psbtJson = json
-      .decode(File('./test/psbt/data.json').readAsStringSync(encoding: utf8));
+  final psbtJson = json.decode(
+    File('./test/psbt/data.json').readAsStringSync(encoding: utf8),
+  );
 
   final legacyUnsignedPsbt = psbtJson[0]['psbt'];
   final taprootUnsignedPsbt = psbtJson[1]['psbt'];
@@ -20,8 +21,10 @@ void main() async {
   group('test psbt tx signer', () {
     test('legacy signature generation', () {
       // Create PSBT transaction data and signer
-      final psbtTxData =
-          PsbtTxData.fromHash(legacyUnsignedPsbt, isTaproot: false);
+      final psbtTxData = PsbtTxData.fromHash(
+        legacyUnsignedPsbt,
+        isTaproot: false,
+      );
 
       final signer = PsbtTxSigner(legacyWallet, psbtTxData);
 
@@ -38,8 +41,10 @@ void main() async {
 
     test('taproot signature generation', () {
       // Create PSBT transaction data and signer
-      final psbtTxData =
-          PsbtTxData.fromHash(taprootUnsignedPsbt, isTaproot: true);
+      final psbtTxData = PsbtTxData.fromHash(
+        taprootUnsignedPsbt,
+        isTaproot: true,
+      );
       final signer = PsbtTxSigner(taprootWallet, psbtTxData);
 
       // Sign the transaction
@@ -56,22 +61,32 @@ void main() async {
   });
 
   test('psbt to origin', () {
-    final psbtTxData =
-        PsbtTxData.fromHash(taprootUnsignedPsbt, isTaproot: true);
+    final psbtTxData = PsbtTxData.fromHash(
+      taprootUnsignedPsbt,
+      isTaproot: true,
+    );
     final originTx = psbtTxData.origin;
     final originData = psbtJson[1]['data']['origin'];
     // compare origin data
     // expect(originTx.version, originData['version']);
     expect(originTx.locktime, originData['locktime']);
     for (var i = 0; i < originTx.inputs.length; i++) {
-      expect(originTx.inputs[i].prevout.hash,
-          originData['inputs'][i]['prevout']['hash']);
-      expect(originTx.inputs[i].prevout.index,
-          originData['inputs'][i]['prevout']['index']);
-      expect(originTx.inputs[i].coin.value,
-          originData['inputs'][i]['coin']['value']);
-      expect(originTx.inputs[i].coin.address,
-          originData['inputs'][i]['coin']['address']);
+      expect(
+        originTx.inputs[i].prevout.hash,
+        originData['inputs'][i]['prevout']['hash'],
+      );
+      expect(
+        originTx.inputs[i].prevout.index,
+        originData['inputs'][i]['prevout']['index'],
+      );
+      expect(
+        originTx.inputs[i].coin.value,
+        originData['inputs'][i]['coin']['value'],
+      );
+      expect(
+        originTx.inputs[i].coin.address,
+        originData['inputs'][i]['coin']['address'],
+      );
     }
     for (var i = 0; i < originTx.outputs.length; i++) {
       expect(originTx.outputs[i].amount, originData['outputs'][i]['amount']);
@@ -85,8 +100,10 @@ void main() async {
       final txHash = transactionJson['fl_signature'];
       final txType = transactionJson['data']['txType'];
 
-      final psbtTxData = PsbtTxData.fromHash(signedPsbt,
-          isTaproot: txType == 'TxType.TAPROOT');
+      final psbtTxData = PsbtTxData.fromHash(
+        signedPsbt,
+        isTaproot: txType == 'TxType.TAPROOT',
+      );
       psbtTxData.isSigned = true;
       final signature = psbtTxData.getSignedTxHex();
 
@@ -98,18 +115,25 @@ void main() async {
   // Regression test for #74: BTC testnet address should not be misidentified as BCH
   group('testnet address generation and detection', () {
     test('BTC testnet address should use correct version byte (0x6f)', () async {
-      const mnemonic = 'assault assault assault assault assault assault assault assault assault assault assault about';
+      const mnemonic =
+          'assault assault assault assault assault assault assault assault assault assault assault about';
       final btcChain = BTCChain();
       final wallet = await BtcCoin.fromMnemonic(mnemonic, btcChain.testnet);
       final address = wallet.address;
 
       // Should generate testnet format address (m/n... for legacy, tb1... for segwit)
-      expect(address.startsWith('m') || address.startsWith('n') || address.startsWith('tb1'), isTrue,
-          reason: 'BTC testnet address should start with m/n/tb1, got: $address');
+      expect(
+        address.startsWith('m') ||
+            address.startsWith('n') ||
+            address.startsWith('tb1'),
+        isTrue,
+        reason: 'BTC testnet address should start with m/n/tb1, got: $address',
+      );
     });
 
-    test('BTC testnet address should be detected as BTC, not BCH', () async {
-      const mnemonic = 'assault assault assault assault assault assault assault assault assault assault assault about';
+    test('BTC testnet legacy address is assigned to BTC, not BCH', () async {
+      const mnemonic =
+          'assault assault assault assault assault assault assault assault assault assault assault about';
       final btcChain = BTCChain();
       final bchChain = BCHChain();
 
@@ -117,23 +141,202 @@ void main() async {
       final address = wallet.address;
 
       // Should be valid for BTC testnet
-      final isBtcValid = AddressUtils.checkAddressValid(address, btcChain.testnet);
-      expect(isBtcValid, isTrue, reason: 'BTC testnet address should be valid for BTC testnet');
+      final isBtcValid = AddressUtils.checkAddressValid(
+        address,
+        btcChain.testnet,
+      );
+      expect(
+        isBtcValid,
+        isTrue,
+        reason: 'BTC testnet address should be valid for BTC testnet',
+      );
 
-      // Should NOT be valid for BCH testnet (BCH testnet uses pubKeyHash: 0x00, BTC testnet uses 0x6f)
-      final isBchValid = AddressUtils.checkAddressValid(address, bchChain.testnet);
-      expect(isBchValid, isFalse, reason: 'BTC testnet address should NOT be valid for BCH testnet');
+      // BTC and BCH testnet legacy addresses share version 0x6f. BCH
+      // classification therefore requires a network-qualified CashAddr.
+      final isBchValid = AddressUtils.checkAddressValid(
+        address,
+        bchChain.testnet,
+      );
+      expect(
+        isBchValid,
+        isFalse,
+        reason: 'BTC testnet address should NOT be valid for BCH testnet',
+      );
     });
 
     test('BTC mainnet address format unchanged', () async {
-      const mnemonic = 'assault assault assault assault assault assault assault assault assault assault assault about';
+      const mnemonic =
+          'assault assault assault assault assault assault assault assault assault assault assault about';
       final btcChain = BTCChain();
       final wallet = await BtcCoin.fromMnemonic(mnemonic, btcChain.mainnet);
       final address = wallet.address;
 
       // Mainnet should still generate 1.../bc1... addresses
-      expect(address.startsWith('1') || address.startsWith('3') || address.startsWith('bc1'), isTrue,
-          reason: 'BTC mainnet address should start with 1/3/bc1, got: $address');
+      expect(
+        address.startsWith('1') ||
+            address.startsWith('3') ||
+            address.startsWith('bc1'),
+        isTrue,
+        reason: 'BTC mainnet address should start with 1/3/bc1, got: $address',
+      );
+    });
+  });
+
+  group('BIP86 Taproot network handling', () {
+    const bip86Mnemonic =
+        'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
+
+    test('public factory matches the first BIP86 mainnet vector', () async {
+      final wallet = await getMnemonicWallet('taproot', bip86Mnemonic);
+
+      expect(
+        wallet.address,
+        'bc1p5cyxnuxmeuwuvkwfem96lqzszd02n6xdcjrs20cac6yqjjwudpxqkedrcr',
+      );
+    });
+
+    test(
+      'public factory keeps BIP86 derivation when selecting testnet',
+      () async {
+        final btcChain = BTCChain();
+        final legacyWallet = await BtcCoin.fromMnemonic(
+          bip86Mnemonic,
+          btcChain.testnet,
+        );
+        final taprootWallet = await getMnemonicWallet(
+          'taproot',
+          bip86Mnemonic,
+          walletSetting: btcChain.testnet,
+        );
+
+        expect(taprootWallet.publicKey, isNot(equals(legacyWallet.publicKey)));
+        expect(
+          taprootWallet.address,
+          'tb1p5cyxnuxmeuwuvkwfem96lqzszd02n6xdcjrs20cac6yqjjwudpxqp3mvzv',
+        );
+      },
+    );
+
+    test(
+      'Taproot validation rejects addresses from the other network',
+      () async {
+        final btcChain = BTCChain();
+        final mainnetWallet = await getMnemonicWallet('taproot', bip86Mnemonic);
+        final testnetWallet = await getMnemonicWallet(
+          'taproot',
+          bip86Mnemonic,
+          walletSetting: btcChain.testnet,
+        );
+
+        expect(
+          AddressUtils.checkAddressValid(
+            mainnetWallet.address,
+            btcChain.mainnet,
+          ),
+          isTrue,
+        );
+        expect(
+          AddressUtils.checkAddressValid(
+            mainnetWallet.address,
+            btcChain.testnet,
+          ),
+          isFalse,
+        );
+        expect(
+          AddressUtils.checkAddressValid(
+            testnetWallet.address,
+            btcChain.testnet,
+          ),
+          isTrue,
+        );
+        expect(
+          AddressUtils.checkAddressValid(
+            testnetWallet.address,
+            btcChain.mainnet,
+          ),
+          isFalse,
+        );
+      },
+    );
+
+    test('Taproot validation rejects an invalid bech32m checksum', () async {
+      final btcChain = BTCChain();
+      final wallet = await getMnemonicWallet('taproot', bip86Mnemonic);
+      final address = wallet.address;
+      final corruptedAddress = '${address.substring(0, address.length - 1)}q';
+
+      expect(
+        AddressUtils.checkAddressValid(corruptedAddress, btcChain.mainnet),
+        isFalse,
+      );
+    });
+
+    test('custom regtest and signet-compatible HRPs are supported', () async {
+      WalletSetting settingForHrp(String hrp) => WalletSetting(
+        bip44Path: BTC_PATH,
+        addressType: AddressType.BTC,
+        networkType: NetworkType(
+          messagePrefix: '\u0018Bitcoin Signed Message:\n',
+          bech32: hrp,
+          wif: 239,
+          pubKeyHash: 0x6f,
+          scriptHash: 0xc4,
+          bip32: Bip32Type(public: 70617704, private: 70615956),
+        ),
+      );
+
+      final regtestSetting = settingForHrp('bcrt');
+      final signetSetting = settingForHrp('tb');
+      final regtestWallet = await BtcCoin.fromMnemonic(
+        bip86Mnemonic,
+        regtestSetting,
+        true,
+      );
+      final signetWallet = await BtcCoin.fromMnemonic(
+        bip86Mnemonic,
+        signetSetting,
+        true,
+      );
+
+      expect(regtestWallet.address, startsWith('bcrt1p'));
+      expect(
+        AddressUtils.checkAddressValid(regtestWallet.address, regtestSetting),
+        isTrue,
+      );
+      expect(signetWallet.address, startsWith('tb1p'));
+      expect(
+        AddressUtils.checkAddressValid(signetWallet.address, signetSetting),
+        isTrue,
+      );
+    });
+
+    test('explicit networks without a valid HRP fail closed', () async {
+      WalletSetting settingForHrp(String? hrp) => WalletSetting(
+        bip44Path: BTC_PATH,
+        addressType: AddressType.BTC,
+        networkType: NetworkType(
+          messagePrefix: '\u0018Bitcoin Signed Message:\n',
+          bech32: hrp,
+          wif: 239,
+          pubKeyHash: 0x6f,
+          scriptHash: 0xc4,
+          bip32: Bip32Type(public: 70617704, private: 70615956),
+        ),
+      );
+
+      final missingHrpWallet = await BtcCoin.fromMnemonic(
+        bip86Mnemonic,
+        settingForHrp(null),
+        true,
+      );
+      final invalidHrpWallet = await BtcCoin.fromMnemonic(
+        bip86Mnemonic,
+        settingForHrp(' '),
+        true,
+      );
+
+      expect(() => missingHrpWallet.address, throwsArgumentError);
+      expect(() => invalidHrpWallet.address, throwsA(isA<Exception>()));
     });
   });
 }

--- a/packages/crypto_wallet_util/test/transaction/btc_test.dart
+++ b/packages/crypto_wallet_util/test/transaction/btc_test.dart
@@ -4,6 +4,8 @@ import 'dart:convert';
 import 'package:test/test.dart';
 
 import 'package:crypto_wallet_util/crypto_utils.dart';
+import 'package:crypto_wallet_util/src/forked_lib/bitcoin_flutter/bitcoin_flutter.dart'
+    as bitcoin;
 
 void main() async {
   const String mnemonic =
@@ -188,10 +190,18 @@ void main() async {
 
     test('public factory matches the first BIP86 mainnet vector', () async {
       final wallet = await getMnemonicWallet('taproot', bip86Mnemonic);
+      final script = bitcoin.Address.addressToOutputScript(
+        wallet.address,
+        BTCChain().mainnet.networkType,
+      );
 
       expect(
         wallet.address,
         'bc1p5cyxnuxmeuwuvkwfem96lqzszd02n6xdcjrs20cac6yqjjwudpxqkedrcr',
+      );
+      expect(
+        script!.map((byte) => byte.toRadixString(16).padLeft(2, '0')).join(),
+        '5120a60869f0dbcf1dc659c9cecbaf8050135ea9e8cdc487053f1dc6880949dc684c',
       );
     });
 
@@ -271,6 +281,26 @@ void main() async {
       );
     });
 
+    test('Taproot validation rejects non-canonical witness padding', () async {
+      final btcChain = BTCChain();
+      final wallet = await getMnemonicWallet('taproot', bip86Mnemonic);
+      final decoded = bitcoin.bech32.decode(
+        wallet.address,
+        encoding: 'bech32m',
+      );
+      final dataWithNonZeroPadding = List<int>.from(decoded.data);
+      dataWithNonZeroPadding[dataWithNonZeroPadding.length - 1] |= 1;
+      final nonCanonicalAddress = bitcoin.bech32.encode(
+        bitcoin.Bech32(decoded.hrp, dataWithNonZeroPadding),
+        encoding: 'bech32m',
+      );
+
+      expect(
+        AddressUtils.checkAddressValid(nonCanonicalAddress, btcChain.mainnet),
+        isFalse,
+      );
+    });
+
     test('custom regtest and signet-compatible HRPs are supported', () async {
       WalletSetting settingForHrp(String hrp) => WalletSetting(
         bip44Path: BTC_PATH,
@@ -334,9 +364,15 @@ void main() async {
         settingForHrp(' '),
         true,
       );
+      final emptyHrpWallet = await BtcCoin.fromMnemonic(
+        bip86Mnemonic,
+        settingForHrp(''),
+        true,
+      );
 
       expect(() => missingHrpWallet.address, throwsArgumentError);
       expect(() => invalidHrpWallet.address, throwsA(isA<Exception>()));
+      expect(() => emptyHrpWallet.address, throwsA(isA<Exception>()));
     });
   });
 }

--- a/packages/crypto_wallet_util/test/transaction/btc_test.dart
+++ b/packages/crypto_wallet_util/test/transaction/btc_test.dart
@@ -228,6 +228,34 @@ void main() async {
     );
 
     test(
+      'Taproot address follows later network changes on a shared setting',
+      () async {
+        // The Taproot constructor keeps the caller's setting by reference
+        // instead of snapshotting it, so switching the shared setting's
+        // network propagates to existing and freshly derived wallets alike
+        // (regression for state splitting between mainnet/testnet).
+        final setting = WalletSetting(
+          bip44Path: BTC_PATH,
+          addressType: AddressType.BTC,
+          networkType: BTCChain().mainnet.networkType,
+        );
+        final wallet = await BtcCoin.fromMnemonic(bip86Mnemonic, setting, true);
+        final originalMainnetAddress = wallet.address;
+        expect(originalMainnetAddress, startsWith('bc1p'));
+
+        setting.networkType = BTCChain().testnet.networkType;
+        expect(wallet.address, startsWith('tb1p'));
+
+        final fresh = await BtcCoin.fromMnemonic(bip86Mnemonic, setting, true);
+        expect(fresh.address, equals(wallet.address));
+
+        setting.networkType = BTCChain().mainnet.networkType;
+        expect(wallet.address, originalMainnetAddress);
+        expect(fresh.address, originalMainnetAddress);
+      },
+    );
+
+    test(
       'Taproot validation rejects addresses from the other network',
       () async {
         final btcChain = BTCChain();

--- a/packages/crypto_wallet_util/test/transaction/btc_test.dart
+++ b/packages/crypto_wallet_util/test/transaction/btc_test.dart
@@ -94,4 +94,46 @@ void main() async {
       expect(signature, txHash);
     }
   });
+
+  // Regression test for #74: BTC testnet address should not be misidentified as BCH
+  group('testnet address generation and detection', () {
+    test('BTC testnet address should use correct version byte (0x6f)', () async {
+      const mnemonic = 'assault assault assault assault assault assault assault assault assault assault assault about';
+      final btcChain = BTCChain();
+      final wallet = await BtcCoin.fromMnemonic(mnemonic, btcChain.testnet);
+      final address = wallet.address;
+
+      // Should generate testnet format address (m/n... for legacy, tb1... for segwit)
+      expect(address.startsWith('m') || address.startsWith('n') || address.startsWith('tb1'), isTrue,
+          reason: 'BTC testnet address should start with m/n/tb1, got: $address');
+    });
+
+    test('BTC testnet address should be detected as BTC, not BCH', () async {
+      const mnemonic = 'assault assault assault assault assault assault assault assault assault assault assault about';
+      final btcChain = BTCChain();
+      final bchChain = BCHChain();
+
+      final wallet = await BtcCoin.fromMnemonic(mnemonic, btcChain.testnet);
+      final address = wallet.address;
+
+      // Should be valid for BTC testnet
+      final isBtcValid = AddressUtils.checkAddressValid(address, btcChain.testnet);
+      expect(isBtcValid, isTrue, reason: 'BTC testnet address should be valid for BTC testnet');
+
+      // Should NOT be valid for BCH testnet (BCH testnet uses pubKeyHash: 0x00, BTC testnet uses 0x6f)
+      final isBchValid = AddressUtils.checkAddressValid(address, bchChain.testnet);
+      expect(isBchValid, isFalse, reason: 'BTC testnet address should NOT be valid for BCH testnet');
+    });
+
+    test('BTC mainnet address format unchanged', () async {
+      const mnemonic = 'assault assault assault assault assault assault assault assault assault assault assault about';
+      final btcChain = BTCChain();
+      final wallet = await BtcCoin.fromMnemonic(mnemonic, btcChain.mainnet);
+      final address = wallet.address;
+
+      // Mainnet should still generate 1.../bc1... addresses
+      expect(address.startsWith('1') || address.startsWith('3') || address.startsWith('bc1'), isTrue,
+          reason: 'BTC mainnet address should start with 1/3/bc1, got: $address');
+    });
+  });
 }

--- a/packages/crypto_wallet_util/test/transaction/btc_test.dart
+++ b/packages/crypto_wallet_util/test/transaction/btc_test.dart
@@ -6,6 +6,39 @@ import 'package:test/test.dart';
 import 'package:crypto_wallet_util/crypto_utils.dart';
 import 'package:crypto_wallet_util/src/forked_lib/bitcoin_flutter/bitcoin_flutter.dart'
     as bitcoin;
+import 'package:crypto_wallet_util/src/forked_lib/psbt/transaction/partially_signed_bitcoin_transaction.dart';
+import 'package:crypto_wallet_util/src/utils/utils.dart';
+
+PSBT _buildBtcPsbtFixture(String xpubkey) {
+  final fixtures =
+      json.decode(
+            File('./test/psbt/data.json').readAsStringSync(encoding: utf8),
+          )
+          as List<dynamic>;
+  final transferJson =
+      json.decode(json.encode(fixtures.first['data'])) as Map<String, dynamic>;
+  transferJson['xpubkey'] = xpubkey;
+  return PSBT.fromTransferPsbt(BtcTransferInfo.fromJson(transferJson));
+}
+
+String _btcAccountXpubForVersion(String mnemonic, int publicVersion) {
+  final standardTestnet = BTCChain().testnet.networkType!;
+  final legacyNetwork = NetworkType(
+    messagePrefix: standardTestnet.messagePrefix,
+    bech32: standardTestnet.bech32,
+    bip32: Bip32Type(
+      public: publicVersion,
+      private: standardTestnet.bip32.private,
+    ),
+    pubKeyHash: standardTestnet.pubKeyHash,
+    scriptHash: standardTestnet.scriptHash,
+    wif: standardTestnet.wif,
+  );
+  return bitcoin.HDWallet.fromSeed(
+    HDWallet.mnemonicToSeed(mnemonic),
+    network: legacyNetwork,
+  ).derivePath("m/44'/0'/0'").base58!;
+}
 
 void main() async {
   const String mnemonic =
@@ -19,6 +52,40 @@ void main() async {
 
   final legacyUnsignedPsbt = psbtJson[0]['psbt'];
   final taprootUnsignedPsbt = psbtJson[1]['psbt'];
+
+  group('test extended-key network compatibility', () {
+    test('2.0.2 BTC testnet key builds a PSBT after upgrading', () {
+      const legacyTestnetPublicVersion = 0x04358a68;
+      final legacyTestnetXpub = _btcAccountXpubForVersion(
+        mnemonic,
+        legacyTestnetPublicVersion,
+      );
+
+      expect(legacyTestnetXpub, startsWith('tpw'));
+
+      final psbt = _buildBtcPsbtFixture(legacyTestnetXpub);
+
+      expect(psbt.serialize(), isNotEmpty);
+    });
+
+    test('unknown checksum-valid extended-key version fails closed', () {
+      final unknownVersionXpub = _btcAccountXpubForVersion(
+        mnemonic,
+        0x01020304,
+      );
+
+      expect(
+        () => _buildBtcPsbtFixture(unknownVersionXpub),
+        throwsArgumentError,
+      );
+    });
+
+    for (final invalidXpub in ['', 'not-an-extended-key']) {
+      test('invalid extended key "$invalidXpub" fails closed', () {
+        expect(() => _buildBtcPsbtFixture(invalidXpub), throwsArgumentError);
+      });
+    }
+  });
 
   group('test psbt tx signer', () {
     test('legacy signature generation', () {


### PR DESCRIPTION
## Summary

Fix BTC/BCH address generation and validation so the configured network is
honored consistently across wallet creation, address parsing, PSBT change
detection, and persisted extended-key upgrades.

## Scope

This PR is limited to the BTC/BCH network-address regression and the adjacent
encoding, validation, PSBT, and upgrade-compatibility invariants required to
close review findings F1-F8. It is not a merge/backport PR and does not include
unrelated business behavior; out-of-scope findings belong in separate PRs.

## What changed

- Preserve `WalletSetting` through public wallet factories and keep Taproot on
  the BIP86 derivation path without snapshotting mutable network state.
- Generate and validate legacy, SegWit v0, and Taproot addresses against the
  selected network; explicit networks with a missing, empty, or invalid HRP now
  fail closed.
- Implement BIP341 `lift_x`/even-Y Taproot tweaking and pin the result to the
  official BIP86 address and scriptPubKey vector.
- Fully validate Bech32/Bech32m checksum, case, witness version/program length,
  network HRP, input ranges, and canonical bit padding.
- Configure BCH testnet with `bchtest` and testnet version bytes, require full
  network-matching CashAddr validation, and preserve P2PKH/P2SH type and network
  during CashAddr/legacy conversion.
- Infer BCH CashAddr network from each address during PSBT change detection,
  allowing `bchtest` CashAddr inputs to match equivalent m/n legacy change
  outputs without hard-coding mainnet.
- Select the PSBT mainnet/testnet config from validated BIP32 public version
  bytes, including the standard testnet `tpub` version (`0x043587cf`).
- Preserve upgrade compatibility with the non-standard BTC testnet public
  version (`0x04358a68`, `tpw...`) emitted by 2.0.2, while malformed keys and
  genuinely unknown versions fail closed instead of falling back to mainnet.
- Restore changelog order to 2.0.3, 2.0.2, 2.0.1, 2.0.0, then 1.x; historical
  release text is unchanged.

## Invariants covered

- Success: BTC mainnet/testnet, Taproot mainnet/testnet, custom `tb`/`bcrt`
  HRPs, BCH mainnet/testnet P2PKH, BCH testnet P2SH, standard testnet `tpub`,
  2.0.2 BTC testnet `tpw...`, and real PSBT `bchtest` CashAddr-to-m/n legacy
  change detection.
- Failure: cross-network BTC/Taproot/BCH addresses, cross-network PSBT change
  candidates, bad Bech32m/CashAddr checksums, non-canonical witness padding,
  BTC/BCH legacy ambiguity, mismatched CashAddr/legacy networks, and
  checksum-valid extended keys with unknown versions.
- Empty/fallback: null wallet networks retain the existing mainnet fallback;
  explicitly supplied networks with null, empty, or invalid HRPs fail closed;
  empty/malformed extended keys fail closed; empty and malformed BCH PSBT input
  addresses do not throw or get marked as change.
- Rollback/upgrade: a shared Taproot setting is verified across
  mainnet -> testnet -> mainnet, and a deterministic 2.0.2 `tpw...` key is
  verified through the 2.0.3 production PSBT construction path.
- Concurrency/cache: not applicable. The changed paths are synchronous,
  deterministic address/key encoding and validation plus PSBT map construction,
  with no shared cache, persistence writes, retries, or transaction state.

## Real call-chain verification

Tests exercise production APIs without mocks:

- public `getMnemonicWallet` -> BIP86 derivation -> address generation
- generated BIP86 address -> `Address.addressToOutputScript` -> official
  scriptPubKey
- generated `bchtest` P2PKH/P2SH -> CashAddr conversion ->
  `Address.addressToOutputScript`
- `AddressUtils.checkAddressValid` with real `WalletSetting` mainnet/testnet
  configs
- real fixture -> `BtcTransferInfo.fromJson` -> `PSBT.fromTransferPsbt` ->
  `HDWallet.fromBase58`, covering mainnet `xpub`, standard testnet `tpub`,
  2.0.2 legacy `tpw...`, unknown versions, and empty/malformed keys
- real fixture -> `BtcTransferInfo.fromJson` -> `PSBT.fromTransferPsbt` ->
  change output derivation, including success, cross-network rejection, empty
  input, and malformed CashAddr fallback

## Verification

- `flutter test test/transaction/btc_test.dart test/transaction/bch_test.dart`
  — 43/43 passed
- `flutter test` — 827/827 passed
- `dart analyze` — no errors or warnings (40 pre-existing info lints)
- `git diff --check` — clean
