### PR TITLE
feat(ur): compress SC V2 signing requests

### DIFF
--- a/packages/bc_ur_dart/CHANGELOG.md
+++ b/packages/bc_ur_dart/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.1.28]
+
+- Feature (SC): add the opt-in deterministic `zlib-json-v1` encoding for `ScSignRequest.signingPayloadData`; legacy uncompressed requests remain byte-compatible and continue to decode.
+- Security (SC): reject corrupted, unknown and over-4-MiB decompressed signing payloads at the `ScSignRequest.fromUR` / `fromCBOR` boundary.
+
 ## [0.1.0]
 
 - Initial version.

--- a/packages/bc_ur_dart/lib/src/models/sc/sc_sign_request.dart
+++ b/packages/bc_ur_dart/lib/src/models/sc/sc_sign_request.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:bc_ur_dart/src/registry/registry_item.dart';
@@ -21,9 +23,26 @@ enum ScSignRequestKeys {
   chain,
   // Appended at the end to keep existing CBOR key indices stable / backward compatible.
   crossChainFee,
+  signingPayloadEncoding,
+}
+
+/// SC signing payload 的线格式。
+///
+/// [json] 是 0.1.27 及更早版本使用的原始 JSON bytes；[zlibJsonV1] 使用 Dart SDK
+/// zlib level 6 压缩同一份 JSON bytes。冷端解压后仍从完整交易重建并计算签名摘要。
+enum ScSigningPayloadEncoding {
+  json,
+  zlibJsonV1,
 }
 
 class ScSignRequest extends RegistryItem {
+  static const int _zlibJsonV1WireValue = 1;
+
+  /// 解压后的 signing payload 上限。
+  ///
+  /// 4 MiB 可覆盖当前 1000-input 压力 fixture，同时限制恶意压缩载荷的内存放大。
+  static const int maxSigningPayloadBytes = 4 * 1024 * 1024;
+
   /// Request id follows the same UUID-bytes convention as other sign requests.
   /// It is generated lazily when omitted by the caller.
   Uint8List? uuid;
@@ -35,6 +54,9 @@ class ScSignRequest extends RegistryItem {
   /// The value of API response `signing_payload.data`.
   /// Cold side passes this directly to `ScUnsignedTransaction.fromJson`.
   final Map<String, dynamic> signingPayloadData;
+
+  /// [signingPayloadData] 在 UR 中使用的编码。
+  final ScSigningPayloadEncoding signingPayloadEncoding;
 
   /// Optional display metadata from the hot side; not used to build the SC tx.
   final String? fee;
@@ -53,6 +75,7 @@ class ScSignRequest extends RegistryItem {
     required this.address,
     required this.publicKey,
     required this.signingPayloadData,
+    this.signingPayloadEncoding = ScSigningPayloadEncoding.json,
     this.fee,
     this.outputs,
     this.origin,
@@ -68,6 +91,7 @@ class ScSignRequest extends RegistryItem {
 
   @override
   CborValue toCborValue() {
+    final signingPayloadBytes = RegistryItem.jsonBytes(signingPayloadData);
     final Map<CborValue, CborValue> map = {
       CborSmallInt(ScSignRequestKeys.uuid.index): cborBytes(
         getRequestId(),
@@ -77,8 +101,13 @@ class ScSignRequest extends RegistryItem {
       CborSmallInt(ScSignRequestKeys.path.index): CborString(path),
       CborSmallInt(ScSignRequestKeys.address.index): CborString(address),
       CborSmallInt(ScSignRequestKeys.publicKey.index): CborString(publicKey),
-      CborSmallInt(ScSignRequestKeys.signingPayloadData.index): cborBytes(RegistryItem.jsonBytes(signingPayloadData)),
+      CborSmallInt(ScSignRequestKeys.signingPayloadData.index): cborBytes(_encodeSigningPayload(signingPayloadBytes)),
     };
+
+    // Legacy JSON 不写 marker，保证默认构造的请求与 0.1.27 逐字节兼容。
+    if (signingPayloadEncoding == ScSigningPayloadEncoding.zlibJsonV1) {
+      map[CborSmallInt(ScSignRequestKeys.signingPayloadEncoding.index)] = CborSmallInt(_zlibJsonV1WireValue);
+    }
 
     if (origin != null) {
       map[CborSmallInt(ScSignRequestKeys.origin.index)] = CborString(origin!);
@@ -101,13 +130,15 @@ class ScSignRequest extends RegistryItem {
 
   @override
   RegistryItem decodeFromCbor(CborMap map) {
+    final signingPayloadEncoding = _readSigningPayloadEncoding(map);
     return ScSignRequest(
       uuid: RegistryItem.readBytes(map, ScSignRequestKeys.uuid.index),
       xfp: RegistryItem.readText(map, ScSignRequestKeys.xfp.index),
       path: RegistryItem.readText(map, ScSignRequestKeys.path.index),
       address: RegistryItem.readText(map, ScSignRequestKeys.address.index),
       publicKey: RegistryItem.readText(map, ScSignRequestKeys.publicKey.index),
-      signingPayloadData: RegistryItem.readJsonMap(map, ScSignRequestKeys.signingPayloadData.index),
+      signingPayloadData: _readSigningPayloadData(map, signingPayloadEncoding),
+      signingPayloadEncoding: signingPayloadEncoding,
       fee: RegistryItem.readOptionalText(map, ScSignRequestKeys.fee.index),
       outputs: RegistryItem.readOptionalJsonList(map, ScSignRequestKeys.outputs.index),
       origin: RegistryItem.readOptionalText(map, ScSignRequestKeys.origin.index),
@@ -143,6 +174,7 @@ class ScSignRequest extends RegistryItem {
     required String address,
     required String publicKey,
     required Map<String, dynamic> signingPayloadData,
+    ScSigningPayloadEncoding signingPayloadEncoding = ScSigningPayloadEncoding.json,
     String? fee,
     List<dynamic>? outputs,
     String? origin,
@@ -156,6 +188,7 @@ class ScSignRequest extends RegistryItem {
       address: address,
       publicKey: publicKey,
       signingPayloadData: signingPayloadData,
+      signingPayloadEncoding: signingPayloadEncoding,
       fee: fee,
       outputs: outputs,
       origin: origin,
@@ -163,4 +196,63 @@ class ScSignRequest extends RegistryItem {
       crossChainFee: crossChainFee,
     ).toUR();
   }
+
+  Uint8List _encodeSigningPayload(Uint8List jsonBytes) {
+    return switch (signingPayloadEncoding) {
+      ScSigningPayloadEncoding.json => jsonBytes,
+      ScSigningPayloadEncoding.zlibJsonV1 => Uint8List.fromList(ZLibCodec(level: 6).encode(jsonBytes)),
+    };
+  }
+
+  static ScSigningPayloadEncoding _readSigningPayloadEncoding(CborMap map) {
+    final key = ScSignRequestKeys.signingPayloadEncoding.index;
+    if (!RegistryItem.hasKey(map, key)) return ScSigningPayloadEncoding.json;
+
+    final wireValue = RegistryItem.readInt(map, key);
+    if (wireValue == _zlibJsonV1WireValue) return ScSigningPayloadEncoding.zlibJsonV1;
+    throw ArgumentError('Unsupported SC signing payload encoding: $wireValue');
+  }
+
+  static Map<String, dynamic> _readSigningPayloadData(CborMap map, ScSigningPayloadEncoding encoding) {
+    final bytes = RegistryItem.readBytes(map, ScSignRequestKeys.signingPayloadData.index);
+    if (encoding == ScSigningPayloadEncoding.json) {
+      return _jsonMapFromBytes(bytes);
+    }
+
+    final sink = _BoundedBytesSink(maxLength: maxSigningPayloadBytes);
+    final decoder = ZLibCodec().decoder.startChunkedConversion(sink);
+    decoder.add(bytes);
+    decoder.close();
+    return _jsonMapFromBytes(sink.bytes);
+  }
+
+  static Map<String, dynamic> _jsonMapFromBytes(Uint8List bytes) {
+    final value = jsonDecode(utf8.decode(bytes));
+    if (value is Map) return Map<String, dynamic>.from(value);
+    throw ArgumentError('SC signing payload must be a JSON map');
+  }
+}
+
+// Zlib decoder 每产出一个 chunk 就先检查累计长度，避免压缩炸弹完整落入内存。
+final class _BoundedBytesSink extends ByteConversionSink {
+  _BoundedBytesSink({required this.maxLength});
+
+  final int maxLength;
+  final BytesBuilder _builder = BytesBuilder(copy: false);
+  int _length = 0;
+
+  Uint8List get bytes => _builder.takeBytes();
+
+  @override
+  void add(List<int> chunk) {
+    final nextLength = _length + chunk.length;
+    if (nextLength > maxLength) {
+      throw ArgumentError('SC signing payload exceeds $maxLength decompressed bytes');
+    }
+    _builder.add(chunk);
+    _length = nextLength;
+  }
+
+  @override
+  void close() {}
 }

--- a/packages/bc_ur_dart/pubspec.yaml
+++ b/packages/bc_ur_dart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: bc_ur_dart
 description: A dart plugin for Uniform Resources(URs) decode/encode. URs are URI-encoded CBOR structures developed by Blockchain Commons.
-version: 0.1.27
+version: 0.1.28
 homepage: https://github.com/fxwalletOfficial/fx-wallet-packages/tree/main/packages/bc_ur_dart
 
 environment:

--- a/packages/bc_ur_dart/test/models/sc_sign_request_test.dart
+++ b/packages/bc_ur_dart/test/models/sc_sign_request_test.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:bc_ur_dart/bc_ur_dart.dart';
@@ -75,6 +77,118 @@ void main() {
       expect(request.crossChainFee, isNull);
     });
 
+    test('round trips deterministic zlib signing payload while preserving request fields', () {
+      final signingPayloadData = <String, dynamic>{
+        'siacoinInputs': List<Map<String, dynamic>>.generate(
+          4,
+          (index) => <String, dynamic>{
+            'parent': <String, dynamic>{
+              'id': 'input-$index',
+              'stateElement': <String, dynamic>{'leafIndex': index, 'merkleProof': List<String>.filled(20, 'proof-$index')},
+            },
+            'satisfiedPolicy': <String, dynamic>{'policy': 'pk', 'signatures': <String>[]},
+          },
+        ),
+        'siacoinOutputs': const <Map<String, dynamic>>[
+          <String, dynamic>{'value': '1000', 'address': 'receiver-address'},
+        ],
+      };
+
+      UR build() => ScSignRequest.buildUR(
+            requestId: '123e4567-e89b-12d3-a456-426614174000',
+            xfp: 'A1B2C3D4',
+            path: "m/44'/1991'/0'",
+            address: 'sender-address',
+            publicKey: 'ed25519-public-key',
+            signingPayloadData: signingPayloadData,
+            signingPayloadEncoding: ScSigningPayloadEncoding.zlibJsonV1,
+            chain: 'sc',
+          );
+
+      final first = build();
+      final second = build();
+      final request = ScSignRequest.fromUR(first);
+      final map = cbor.decode(first.payload) as CborMap;
+      final compressed = map[CborSmallInt(ScSignRequestKeys.signingPayloadData.index)]! as CborBytes;
+
+      expect(first.payload, second.payload, reason: '固定输入的 SC zlib 请求必须逐字节确定');
+      expect(request.signingPayloadEncoding, ScSigningPayloadEncoding.zlibJsonV1);
+      expect(request.signingPayloadData, signingPayloadData);
+      expect(ScSignRequest.fromCBOR(first.payload).signingPayloadData, signingPayloadData);
+      expect(compressed.bytes.length, lessThan(utf8.encode(jsonEncode(signingPayloadData)).length));
+      expect((map[CborSmallInt(ScSignRequestKeys.signingPayloadEncoding.index)]! as CborInt).toInt(), 1);
+    });
+
+    test('keeps legacy request bytes unchanged when compression is not selected', () {
+      UR build(ScSigningPayloadEncoding encoding) => ScSignRequest.buildUR(
+            requestId: '123e4567-e89b-12d3-a456-426614174000',
+            xfp: 'A1B2C3D4',
+            path: "m/44'/1991'/0'",
+            address: 'sender-address',
+            publicKey: 'ed25519-public-key',
+            signingPayloadData: const <String, dynamic>{'siacoinInputs': <dynamic>[]},
+            signingPayloadEncoding: encoding,
+          );
+
+      final defaultRequest = ScSignRequest.buildUR(
+        requestId: '123e4567-e89b-12d3-a456-426614174000',
+        xfp: 'A1B2C3D4',
+        path: "m/44'/1991'/0'",
+        address: 'sender-address',
+        publicKey: 'ed25519-public-key',
+        signingPayloadData: const <String, dynamic>{'siacoinInputs': <dynamic>[]},
+      );
+      final explicitLegacy = build(ScSigningPayloadEncoding.json);
+      final map = cbor.decode(defaultRequest.payload) as CborMap;
+
+      expect(defaultRequest.payload, explicitLegacy.payload);
+      expect(map.containsKey(CborSmallInt(ScSignRequestKeys.signingPayloadEncoding.index)), isFalse);
+      expect(ScSignRequest.fromUR(defaultRequest).signingPayloadEncoding, ScSigningPayloadEncoding.json);
+    });
+
+    test('rejects corrupted or unknown compressed signing payloads', () {
+      final valid = ScSignRequest.buildUR(
+        requestId: '123e4567-e89b-12d3-a456-426614174000',
+        xfp: 'A1B2C3D4',
+        path: "m/44'/1991'/0'",
+        address: 'sender-address',
+        publicKey: 'ed25519-public-key',
+        signingPayloadData: const <String, dynamic>{'siacoinInputs': <dynamic>[]},
+        signingPayloadEncoding: ScSigningPayloadEncoding.zlibJsonV1,
+      );
+      final damagedMap = cbor.decode(valid.payload) as CborMap;
+      final fieldKey = CborSmallInt(ScSignRequestKeys.signingPayloadData.index);
+      final damagedBytes = Uint8List.fromList((damagedMap[fieldKey]! as CborBytes).bytes)..[0] ^= 0xff;
+      damagedMap[fieldKey] = CborBytes(damagedBytes);
+
+      final unknownMap = cbor.decode(valid.payload) as CborMap;
+      unknownMap[CborSmallInt(ScSignRequestKeys.signingPayloadEncoding.index)] = const CborSmallInt(99);
+
+      expect(() => ScSignRequest.fromUR(_urFromMap(damagedMap)), throwsA(isA<InvalidCborURException>()));
+      expect(() => ScSignRequest.fromUR(_urFromMap(unknownMap)), throwsA(isA<InvalidCborURException>()));
+    });
+
+    test('rejects compressed signing payload beyond the decompressed size limit', () {
+      final oversized = Uint8List(ScSignRequest.maxSigningPayloadBytes + 1)..fillRange(0, ScSignRequest.maxSigningPayloadBytes + 1, 0x20);
+      final map = cbor.decode(
+        ScSignRequest.buildUR(
+          requestId: '123e4567-e89b-12d3-a456-426614174000',
+          xfp: 'A1B2C3D4',
+          path: "m/44'/1991'/0'",
+          address: 'sender-address',
+          publicKey: 'ed25519-public-key',
+          signingPayloadData: const <String, dynamic>{'siacoinInputs': <dynamic>[]},
+        ).payload,
+      ) as CborMap;
+      map[CborSmallInt(ScSignRequestKeys.signingPayloadData.index)] = CborBytes(ZLibCodec(level: 6).encode(oversized));
+      map[CborSmallInt(ScSignRequestKeys.signingPayloadEncoding.index)] = const CborSmallInt(1);
+
+      expect(
+        () => ScSignRequest.fromUR(_urFromMap(map)),
+        throwsA(isA<InvalidCborURException>().having((error) => error.message, 'message', contains('exceeds'))),
+      );
+    });
+
     test('round trips signature payload', () {
       final ur = ScSignature.buildUR(
         requestId: '123e4567-e89b-12d3-a456-426614174000',
@@ -141,4 +255,8 @@ void main() {
       expect(request.getRequestIdString(), isNotEmpty);
     });
   });
+}
+
+UR _urFromMap(CborMap map) {
+  return UR(type: RegistryType.SC_SIGN_REQUEST.type, payload: Uint8List.fromList(cbor.encode(map)));
 }


### PR DESCRIPTION
## 原因

SC V2 冷签请求会携带完整 `signing_payload.data`。其中每个 input 都包含 parent、state element 和 Merkle proof，输入数增加时二维码分片近似线性增长。App 侧保持单片 80 字符时，当前确定性 fixture 的请求分片为：

| Inputs | 旧 JSON 请求 | zlib 请求 |
| ---: | ---: | ---: |
| 1 | 31 | 19 |
| 34 | 775 | 339 |
| 100 | 2,261 | 977 |
| 1,000 | 22,534 | 9,682 |

本改动只提供 SC 专用、显式启用的请求编码能力，不改变签名算法、交易字段或通用 UR 分片规则。

## 实现

- 将 `bc_ur_dart` 版本更新到 `0.1.28`。
- 为 `ScSignRequest` 增加可选 `zlib-json-v1` 编码：
  - 对现有完整 `signingPayloadData` JSON bytes 使用 Dart SDK zlib level 6。
  - 在新增 CBOR integer key 12 写入格式值 1。
  - `ScSignRequest.fromUR()` 和 `fromCBOR()` 在模型边界透明解压后返回原始完整 Map。
- 默认仍使用原始 JSON；默认构造的 CBOR 不写格式字段，与 0.1.27 保持逐字节一致。
- 解压后的 payload 上限为 4 MiB，解码过程中按 chunk 检查，避免压缩载荷无界放大。

## 安全不变量

- 冷端收到的仍是完整交易数据，继续独立重建交易并计算 `InputSigHash`。
- 不接受热端提供的 digest，也不修改 Ed25519 签名逻辑。
- 损坏的 zlib、未知格式、非 JSON Map 和超过解压上限的载荷均失败关闭。
- 不影响 SC 签名响应、SCP 或其他链的 UR 模型。

## 兼容性

| 发送端 | 接收端 | 结果 |
| --- | --- | --- |
| 旧格式 | 新版 | 支持，按 legacy JSON 解码 |
| 新格式 | 新版 | 支持，透明解压 |
| 新格式 | 旧版 | 不支持；该格式必须由调用方显式启用并负责版本门禁 |
| 默认调用 | 任意旧版 | 保持旧格式 |

## 验证

- `dart test`：154 项通过。
- `dart analyze`：无问题。
- 覆盖确定性编码、UR/CBOR round-trip、旧格式字节兼容、字段保留、损坏载荷、未知格式和超限解压。

## 未覆盖风险

- 真实双设备扫码识别由消费该能力的 App PR 验证；本包不改变二维码单片长度。
